### PR TITLE
map: ремап каторги

### DIFF
--- a/_maps/map_files/Delta/Lavaland.dmm
+++ b/_maps/map_files/Delta/Lavaland.dmm
@@ -3440,9 +3440,6 @@
 "nQ" = (
 /obj/machinery/seed_extractor,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "green"
@@ -3583,13 +3580,6 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
-"pq" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "laborcamp_away";
-	name = "Labor Camp Airlock"
-	},
-/turf/simulated/floor/plasteel,
-/area/mine/laborcamp)
 "pt" = (
 /obj/structure/stone_tile/surrounding/cracked{
 	dir = 6
@@ -4365,6 +4355,7 @@
 /obj/item/seeds/lavaland/cactus,
 /obj/item/seeds/lavaland/cactus,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	icon_state = "green"
 	},
@@ -4504,6 +4495,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
+/obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "green"
@@ -4737,6 +4729,9 @@
 /obj/item/seeds/comfrey,
 /obj/item/seeds/comfrey,
 /obj/item/seeds/comfrey,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "green"
@@ -5106,7 +5101,6 @@
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /obj/item/plant_analyzer,
 /obj/item/seeds/lavaland/fireblossom,
-/obj/machinery/light/small,
 /obj/machinery/camera{
 	c_tag = "Labor Camp Breakroom";
 	dir = 1;
@@ -5365,6 +5359,9 @@
 /obj/item/reagent_containers/food/snacks/lavaland_food/fine_meal{
 	pixel_x = 4;
 	pixel_y = 14
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
@@ -5973,6 +5970,7 @@
 /obj/structure/table/wood,
 /obj/item/twohanded/fishing_rod/tribal,
 /obj/effect/mapping_helpers/no_lava,
+/obj/item/twohanded/fishing_rod/tribal,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Hg" = (
@@ -6006,6 +6004,7 @@
 /obj/machinery/biogenerator,
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/bag/plants,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "green"
@@ -7756,9 +7755,6 @@
 /obj/item/seeds/lavaland/inocybe,
 /obj/item/seeds/lavaland/inocybe,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "green"
@@ -13021,7 +13017,7 @@ aq
 gu
 aq
 aq
-pq
+hQ
 hQ
 aq
 ty
@@ -13535,7 +13531,7 @@ aq
 gu
 aq
 aq
-pq
+hQ
 hQ
 aq
 bZ
@@ -16581,7 +16577,7 @@ an
 an
 an
 an
-an
+nO
 nO
 nO
 nO
@@ -16838,8 +16834,8 @@ an
 an
 an
 an
-an
-an
+nO
+nO
 nO
 nO
 nO
@@ -17096,15 +17092,15 @@ an
 an
 an
 an
-an
 nO
 nO
 nO
 nO
 nO
 nO
-Dn
-an
+nO
+nO
+fw
 an
 an
 an
@@ -17354,14 +17350,14 @@ an
 an
 an
 an
+nO
+nO
+nO
+nO
+nO
+nO
+nO
 fw
-nO
-nO
-nO
-nO
-Cv
-fw
-an
 an
 an
 an
@@ -17611,14 +17607,14 @@ an
 an
 an
 an
-Hk
-fw
 nO
 nO
 nO
+nO
+nO
+nO
+Dn
 fw
-fw
-an
 an
 an
 an
@@ -17868,13 +17864,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+fw
+nO
+nO
+nO
+nO
+Cv
+fw
 an
 an
 an
@@ -18125,13 +18121,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+Hk
+fw
+nO
+nO
+nO
+fw
+fw
 an
 an
 an

--- a/_maps/map_files/Delta/Lavaland.dmm
+++ b/_maps/map_files/Delta/Lavaland.dmm
@@ -72,6 +72,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "ap" = (
@@ -157,9 +160,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
-"aD" = (
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/explored)
 "aE" = (
 /obj/item/radio/intercom/locked/prison{
 	pixel_y = 24
@@ -193,10 +193,8 @@
 	},
 /area/mine/living_quarters)
 "aJ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "aL" = (
@@ -357,13 +355,12 @@
 	},
 /area/mine/living_quarters)
 "bj" = (
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock{
+	name = "Labor Camp Storage"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "brown"
-	},
+/turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "bk" = (
 /turf/simulated/floor/plasteel,
@@ -394,6 +391,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "browncorner"
 	},
+/area/mine/laborcamp)
+"bo" = (
+/obj/structure/weightmachine/horizontalbar/high,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "bq" = (
 /obj/structure/table,
@@ -933,6 +935,15 @@
 	},
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"cX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "cY" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -1063,6 +1074,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
+"du" = (
+/obj/machinery/door/airlock{
+	name = "Labor Camp Storage"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "dv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -1150,6 +1167,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"dL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/kitchen_machine/tribal_oven,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "dM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -1176,6 +1198,16 @@
 	icon_state = "brown"
 	},
 /area/mine/production)
+"dQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "dR" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -2158,6 +2190,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -2292,6 +2325,15 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"iW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	brightness_range = 6;
+	dir = 4;
+	light_range = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "iX" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -2381,6 +2423,16 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"jA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "jE" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -3381,6 +3433,21 @@
 	icon_state = "barber"
 	},
 /area/mine/laborcamp)
+"nO" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
+"nQ" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "nX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3516,6 +3583,13 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"pq" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "laborcamp_away";
+	name = "Labor Camp Airlock"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "pt" = (
 /obj/structure/stone_tile/surrounding/cracked{
 	dir = 6
@@ -4053,6 +4127,15 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"tK" = (
+/obj/structure/table/wood,
+/obj/item/shovel/spade/wooden{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "tR" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -4068,6 +4151,13 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
+"tU" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "tZ" = (
@@ -4088,6 +4178,7 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
+/obj/item/bedsheet/mime,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken6";
 	tag = "icon-wood-broken6"
@@ -4259,13 +4350,23 @@
 /area/mine/maintenance)
 "vw" = (
 /obj/structure/table,
-/obj/item/storage/fancy/cigarettes/cigpack_random,
+/obj/item/storage/fancy/cigarettes/cigpack_uplift,
 /obj/item/lighter/random{
 	pixel_x = 2
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
+	},
+/area/mine/laborcamp)
+"vA" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/cactus,
+/obj/item/seeds/lavaland/cactus,
+/obj/item/seeds/lavaland/cactus,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "vC" = (
@@ -4291,14 +4392,14 @@
 /area/mine/necropolis)
 "vI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/item/trash/syndi_cakes,
 /obj/effect/decal/cleanable/cobweb2,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	initialize_directions = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -4387,6 +4488,27 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"wJ" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/porcini,
+/obj/item/seeds/lavaland/porcini,
+/obj/item/seeds/lavaland/porcini,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
+"wM" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "wR" = (
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
@@ -4550,6 +4672,16 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"xT" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "xX" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -4579,16 +4711,52 @@
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/necropolis)
+"yl" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "ym" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
 	},
+/area/mine/laborcamp)
+"yp" = (
+/obj/structure/weightmachine/horizontalbar,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "yq" = (
 /obj/structure/safe/floor,
@@ -4621,6 +4789,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"yv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/kitchen/knife,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "yw" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -4808,6 +4982,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
+"zA" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/weightmachine/horizontalbar,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "zB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
@@ -4915,6 +5094,28 @@
 /obj/structure/stone_tile/block,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/necropolis)
+"AF" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/shovel/spade/wooden,
+/obj/item/cultivator/wooden,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/plant_analyzer,
+/obj/item/seeds/lavaland/fireblossom,
+/obj/machinery/light/small,
+/obj/machinery/camera{
+	c_tag = "Labor Camp Breakroom";
+	dir = 1;
+	network = list("Labor Camp")
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "AG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -5077,6 +5278,14 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/mine/eva)
+"BW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "BX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -5117,6 +5326,11 @@
 "Ct" = (
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"Cv" = (
+/obj/structure/stone_tile/slab/cracked,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "Cy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -5145,6 +5359,15 @@
 	icon_state = "clockwork_floor"
 	},
 /area/mine/necropolis)
+"CK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/lavaland_food/fine_meal{
+	pixel_x = 4;
+	pixel_y = 14
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "CM" = (
 /obj/structure/stone_tile/slab,
 /obj/item/clockwork/fallen_armor,
@@ -5223,6 +5446,16 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"Dn" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "DM" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -5421,8 +5654,8 @@
 /area/lavaland/surface/outdoors/necropolis)
 "Fp" = (
 /obj/structure/bed,
-/obj/item/bedsheet/orange,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/bedsheet/patriot,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken7";
 	tag = "icon-wood-broken7"
@@ -5736,6 +5969,12 @@
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"Hd" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/fishing_rod/tribal,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Hg" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -5754,10 +5993,24 @@
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"Hk" = (
+/obj/structure/flora/ausbushes/fullgrass/hell,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Hl" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/plasteel,
 /area/mine/production)
+"Hs" = (
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Ht" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5867,6 +6120,16 @@
 /obj/machinery/vending/cola/free,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
+"Im" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/coaltree,
+/obj/item/seeds/lavaland/coaltree,
+/obj/item/seeds/lavaland/coaltree,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "In" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light{
@@ -5931,6 +6194,19 @@
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
+"IL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "IZ" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -6167,6 +6443,16 @@
 	icon_state = "clockwork_floor"
 	},
 /area/mine/necropolis)
+"Kv" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/ember,
+/obj/item/seeds/lavaland/ember,
+/obj/item/seeds/lavaland/ember,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Ky" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Garbage Lavaland Collector";
@@ -7222,6 +7508,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
+"To" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Tq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7453,6 +7750,20 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"Vl" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Vp" = (
 /obj/structure/stone_tile/block/cracked,
 /obj/structure/stone_tile/block{
@@ -7551,6 +7862,19 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"VS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "VU" = (
 /obj/structure/stone_tile/block/cracked,
 /obj/structure/stone_tile{
@@ -7585,6 +7909,12 @@
 	},
 /turf/simulated/mineral/random/volcanic,
 /area/lavaland/surface/outdoors)
+"Wi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "Wj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7603,6 +7933,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/production)
+"Wq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/monstermeat/goliath{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/monstermeat/goliath{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/monstermeat/goliath{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "Wr" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 4
@@ -7800,6 +8147,11 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"XX" = (
+/obj/structure/flora/firebush,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "XY" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -7851,6 +8203,26 @@
 	icon_state = "freezerfloor"
 	},
 /area/mine/living_quarters)
+"Yu" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
+"Yv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "YA" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding_tile,
@@ -7966,6 +8338,18 @@
 "Zf" = (
 /turf/simulated/wall/r_wall,
 /area/mine/living_quarters)
+"Zg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Labor Camp Storage"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "Zh" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -12637,7 +13021,7 @@ aq
 gu
 aq
 aq
-aq
+pq
 hQ
 aq
 ty
@@ -12875,12 +13259,12 @@ an
 an
 an
 an
-an
-ab
-ab
-aj
-aj
-aj
+qT
+ap
+ap
+ap
+ap
+qT
 Gp
 rj
 wh
@@ -12893,15 +13277,15 @@ aP
 aq
 aZ
 aq
-ao
 aq
+bk
 aJ
 aq
 sq
 QD
 sq
 aj
-aD
+ab
 aj
 ab
 ai
@@ -13132,13 +13516,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-aj
-aj
-qT
+tZ
+Hs
+IL
+cX
+Wi
+Wi
+bj
 vI
 ic
 ym
@@ -13150,8 +13534,8 @@ aQ
 aq
 gu
 aq
-bk
 aq
+pq
 hQ
 aq
 bZ
@@ -13389,11 +13773,11 @@ an
 an
 an
 an
-an
-an
-an
-an
 qT
+nQ
+jA
+vA
+aq
 qT
 aq
 qT
@@ -13407,7 +13791,7 @@ ap
 tZ
 ba
 aq
-bj
+ao
 HJ
 Cy
 aq
@@ -13646,10 +14030,10 @@ an
 an
 an
 an
-an
-an
-an
-an
+qT
+To
+jA
+Im
 qT
 NZ
 sF
@@ -13903,10 +14287,10 @@ an
 an
 an
 an
-an
-an
-an
-an
+qT
+yl
+BW
+AF
 qT
 qT
 GD
@@ -14160,10 +14544,10 @@ an
 an
 an
 an
-an
-an
-an
-an
+qT
+Vl
+Yv
+Kv
 qT
 Dd
 sF
@@ -14417,10 +14801,10 @@ an
 an
 an
 an
-an
-an
-an
-an
+qT
+wJ
+VS
+wM
 qT
 qT
 aq
@@ -14674,11 +15058,11 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
+qT
+qT
+Zg
+tZ
+qT
 aq
 Ss
 FO
@@ -14917,6 +15301,11 @@ an
 an
 an
 an
+XX
+fw
+fw
+fw
+fw
 an
 an
 an
@@ -14926,16 +15315,11 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+aq
+bo
+jA
+CK
+dL
 qT
 Xm
 HA
@@ -15171,20 +15555,15 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+fw
+fw
+fw
+fw
+fw
+tK
+fw
+fw
+fw
 an
 an
 an
@@ -15194,6 +15573,11 @@ an
 an
 an
 qT
+zA
+dQ
+tU
+JZ
+du
 tT
 WJ
 qw
@@ -15427,6 +15811,16 @@ an
 an
 an
 an
+fw
+fw
+nO
+nO
+Yu
+nO
+nO
+Hd
+fw
+fw
 an
 an
 an
@@ -15435,21 +15829,11 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+qT
+yp
+iW
+Wq
+yv
 aq
 oA
 Ts
@@ -15684,6 +16068,16 @@ an
 an
 an
 an
+fw
+xT
+nO
+nO
+nO
+nO
+nO
+nO
+fw
+fw
 an
 an
 an
@@ -15692,21 +16086,11 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+qT
+qT
+aq
+qT
+aq
 aq
 qT
 qT
@@ -15941,16 +16325,16 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+nO
+nO
+nO
+nO
+nO
+nO
+nO
+nO
+fw
+fw
 an
 an
 an
@@ -16198,15 +16582,15 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+nO
+nO
+nO
+nO
+nO
+nO
+nO
+nO
+fw
 an
 an
 an
@@ -16456,14 +16840,14 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
+nO
+nO
+nO
+nO
+nO
+nO
+nO
+Hk
 an
 an
 an
@@ -16713,13 +17097,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+nO
+nO
+nO
+nO
+nO
+nO
+Dn
 an
 an
 an
@@ -16970,13 +17354,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+fw
+nO
+nO
+nO
+nO
+Cv
+fw
 an
 an
 an
@@ -17227,13 +17611,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+Hk
+fw
+nO
+nO
+nO
+fw
+fw
 an
 an
 an
@@ -17264,7 +17648,7 @@ No
 No
 No
 No
-No
+aj
 aj
 aj
 aj
@@ -17519,9 +17903,9 @@ an
 aT
 aT
 aT
-an
 No
 No
+aj
 aj
 aj
 aj
@@ -17776,10 +18160,10 @@ an
 an
 an
 an
-an
 No
 No
-No
+aj
+aj
 aj
 aj
 aj
@@ -18033,11 +18417,11 @@ an
 an
 an
 an
-an
-an
-an
 No
 No
+No
+aj
+aj
 aj
 fw
 oX
@@ -18291,10 +18675,10 @@ an
 an
 an
 an
-an
-an
-an
 No
+No
+aj
+aj
 aj
 aj
 oX
@@ -18548,10 +18932,10 @@ an
 an
 an
 an
-an
-an
 No
 No
+aj
+aj
 aj
 aj
 fw
@@ -18805,10 +19189,10 @@ an
 an
 an
 an
-an
-an
 No
 No
+aj
+aj
 aj
 aj
 fw
@@ -19061,11 +19445,11 @@ an
 an
 an
 an
-an
-an
-an
 No
 No
+No
+aj
+aj
 aj
 aj
 fw
@@ -19318,10 +19702,10 @@ an
 an
 an
 an
-an
-an
 No
 No
+aj
+aj
 aj
 aj
 fw
@@ -19577,10 +19961,10 @@ an
 No
 No
 No
-No
 aj
 aj
-fw
+aj
+aj
 fw
 La
 La

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -190273,8 +190273,8 @@ coE
 acF
 uFL
 acF
-coE
 acF
+cIV
 uFL
 acF
 coE

--- a/_maps/map_files/celestation/Lavaland.dmm
+++ b/_maps/map_files/celestation/Lavaland.dmm
@@ -603,6 +603,17 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
+"bX" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "bY" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/simulated/floor/plasteel{
@@ -974,7 +985,6 @@
 	},
 /area/mine/living_quarters)
 "dP" = (
-/obj/item/trash/syndi_cakes,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -984,7 +994,7 @@
 	network = list("Labor Camp")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "dR" = (
@@ -1070,6 +1080,12 @@
 	icon_state = "brown"
 	},
 /area/mine/production)
+"ej" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/fishing_rod/tribal,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "ek" = (
 /obj/machinery/door/window/southright{
 	name = "Infirmary"
@@ -1541,6 +1557,16 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
+"gs" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "gt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -1612,8 +1638,15 @@
 /turf/simulated/floor/plasteel,
 /area/mine/lobby)
 "gK" = (
-/obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/plasteel/dark,
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/porcini,
+/obj/item/seeds/lavaland/porcini,
+/obj/item/seeds/lavaland/porcini,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
 /area/mine/laborcamp)
 "gM" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -1773,6 +1806,20 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel/freezer,
 /area/mine/living_quarters)
+"hH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/vending/cola/free,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/mine/laborcamp)
 "hI" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
@@ -2390,11 +2437,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	dir = 10;
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "lk" = (
@@ -2945,6 +2990,17 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"mY" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "na" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
@@ -3560,6 +3616,26 @@
 	},
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"sy" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/shovel/spade/wooden,
+/obj/item/cultivator/wooden,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/plant_analyzer,
+/obj/item/seeds/lavaland/fireblossom,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "sC" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -3981,6 +4057,13 @@
 	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
+"vN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "vO" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -4003,6 +4086,36 @@
 	icon_state = "darkred"
 	},
 /area/mine/laborcamp/security)
+"vV" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "vZ" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -4152,6 +4265,15 @@
 	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
+"xD" = (
+/obj/structure/table/wood,
+/obj/item/shovel/spade/wooden{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "xH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -4465,6 +4587,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/weightmachine/horizontalbar/high,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -4874,10 +4997,9 @@
 /area/mine/living_quarters)
 "CY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 9
 	},
-/turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
 "Dd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5037,7 +5159,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "EF" = (
@@ -5051,6 +5173,11 @@
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"EI" = (
+/obj/structure/stone_tile/slab/cracked,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "EJ" = (
 /obj/structure/lattice/catwalk/mapping,
 /obj/structure/cable{
@@ -5104,6 +5231,10 @@
 	icon_state = "clockwork_floor"
 	},
 /area/mine/necropolis)
+"ER" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "EV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5148,6 +5279,11 @@
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"Fp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/sustenance,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "Fx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -5324,6 +5460,16 @@
 	tag = "icon-wood-broken7"
 	},
 /area/mine/laborcamp)
+"GN" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "GP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
@@ -5534,6 +5680,20 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
+"HP" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Id" = (
 /obj/structure/lattice/catwalk/mapping,
 /obj/structure/transit_tube/crossing,
@@ -6189,10 +6349,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
+"NF" = (
+/obj/structure/flora/firebush,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "NG" = (
-/obj/machinery/vending/sustenance,
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/coaltree,
+/obj/item/seeds/lavaland/coaltree,
+/obj/item/seeds/lavaland/coaltree,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	dir = 6;
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "NJ" = (
@@ -6545,6 +6715,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
+"Sa" = (
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Sc" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -6760,12 +6939,15 @@
 	},
 /area/mine/laborcamp)
 "TG" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/cactus,
+/obj/item/seeds/lavaland/cactus,
+/obj/item/seeds/lavaland/cactus,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/cola/free,
-/obj/structure/sign/poster/contraband/clown{
-	pixel_x = 32
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
 	},
-/turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
 "TH" = (
 /turf/simulated/wall,
@@ -6832,13 +7014,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"UC" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "UE" = (
 /obj/structure/table,
-/obj/item/storage/fancy/cigarettes/cigpack_random,
 /obj/item/lighter/random{
 	pixel_x = 2
 	},
 /obj/machinery/light/small,
+/obj/item/storage/fancy/cigarettes/cigpack_uplift,
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
 	},
@@ -6912,6 +7104,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
+"Vh" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Vi" = (
 /obj/machinery/suit_storage_unit/lavaland,
 /obj/effect/decal/cleanable/dirt,
@@ -7264,6 +7466,11 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"XB" = (
+/obj/structure/flora/ausbushes/fullgrass/hell,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "XD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mineral/mint{
@@ -45832,11 +46039,11 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
+NF
+Vn
+Vn
+Vn
+Vn
 an
 an
 an
@@ -46086,15 +46293,15 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+Vn
+Vn
+Vn
+Vn
+Vn
+xD
+Vn
+Vn
+Vn
 an
 an
 an
@@ -46342,16 +46549,16 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+Vn
+Vn
+ER
+ER
+GN
+ER
+ER
+ej
+Vn
+Vn
 an
 an
 an
@@ -46599,16 +46806,16 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+Vn
+gs
+ER
+ER
+ER
+ER
+ER
+ER
+Vn
+Vn
 an
 an
 an
@@ -46856,16 +47063,16 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+ER
+ER
+ER
+ER
+ER
+ER
+ER
+ER
+Vn
+Vn
 an
 an
 an
@@ -47113,15 +47320,15 @@ ab
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+ER
+ER
+ER
+ER
+ER
+ER
+ER
+ER
+Vn
 an
 an
 an
@@ -47371,14 +47578,14 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
+ER
+ER
+ER
+ER
+ER
+ER
+ER
+XB
 an
 an
 an
@@ -47628,13 +47835,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+ER
+ER
+ER
+ER
+ER
+ER
+UC
 an
 an
 an
@@ -47885,13 +48092,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+Vn
+ER
+ER
+ER
+ER
+EI
+Vn
 an
 an
 an
@@ -48142,13 +48349,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+XB
+Vn
+ER
+ER
+ER
+Vn
+Vn
 an
 an
 an
@@ -55340,15 +55547,15 @@ Vn
 Vn
 aj
 aj
-aj
-aj
+ap
+ap
 aq
 qT
 qt
 aq
 qT
 qT
-zI
+hH
 JZ
 UE
 tZ
@@ -55597,10 +55804,10 @@ Vn
 Vn
 aj
 aj
-aj
-aj
-aj
 ap
+Sa
+vN
+HP
 gK
 lh
 na
@@ -55854,10 +56061,10 @@ Vn
 Vn
 aj
 aj
-aj
-aj
-aj
 ap
+bX
+JZ
+CY
 CY
 Et
 aq
@@ -56111,10 +56318,10 @@ Vn
 Vn
 aj
 aj
-aj
-aj
-aj
 ap
+mY
+JZ
+CY
 CY
 dP
 hK
@@ -56368,10 +56575,10 @@ Vn
 Vn
 aj
 aj
-aj
-aj
-aj
 ap
+vV
+Vh
+sy
 TG
 NG
 qT
@@ -56625,7 +56832,7 @@ Vn
 Vn
 aj
 aj
-aj
+qT
 qT
 qt
 aq
@@ -57404,7 +57611,7 @@ kE
 Il
 jp
 aq
-JZ
+Fp
 JZ
 JZ
 ZH

--- a/_maps/map_files/celestation/Lavaland.dmm
+++ b/_maps/map_files/celestation/Lavaland.dmm
@@ -26,6 +26,15 @@
 "ad" = (
 /turf/simulated/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors)
+"af" = (
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "ag" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -737,26 +746,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
-"cE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/shovel/spade/wooden,
-/obj/item/cultivator/wooden,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/plant_analyzer,
-/obj/item/seeds/lavaland/fireblossom,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
+"cC" = (
+/obj/structure/flora/ausbushes/fullgrass/hell,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "cG" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -994,13 +988,16 @@
 	},
 /area/mine/living_quarters)
 "dP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Labor Camp Breakroom";
 	dir = 1;
 	network = list("Labor Camp")
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "green"
@@ -2664,11 +2661,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
-"mg" = (
-/obj/structure/stone_tile/slab/cracked,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "mj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3097,16 +3089,6 @@
 	},
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/necropolis)
-"oi" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 10
-	},
-/obj/structure/stone_tile/slab/cracked{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "ok" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -3164,14 +3146,6 @@
 	icon_state = "dark"
 	},
 /area/mine/living_quarters)
-"pb" = (
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "pg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3226,6 +3200,20 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"pC" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "pE" = (
 /obj/machinery/camera{
 	c_tag = "Labor Camp Infirmary";
@@ -3359,6 +3347,10 @@
 	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
+"ql" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "qt" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall/rust,
@@ -3520,6 +3512,16 @@
 	icon_state = "brown"
 	},
 /area/mine/production)
+"rN" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "rP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -3530,6 +3532,14 @@
 	icon_state = "brown"
 	},
 /area/mine/production)
+"rR" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "rV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -3616,6 +3626,11 @@
 	icon_state = "clockwork_floor"
 	},
 /area/mine/necropolis)
+"sD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/sustenance,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "sF" = (
 /obj/structure/transit_tube/diagonal/topleft,
 /obj/structure/lattice/catwalk/mapping,
@@ -3644,6 +3659,14 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"sO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 9
+	},
+/area/mine/laborcamp)
 "sP" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -3940,11 +3963,6 @@
 /obj/structure/lattice/catwalk/mapping,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/production)
-"uY" = (
-/obj/structure/flora/firebush,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "uZ" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -4093,25 +4111,15 @@
 	icon_state = "purplecorner"
 	},
 /area/mine/living_quarters)
-"ws" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/lavaland/inocybe,
-/obj/item/seeds/lavaland/inocybe,
-/obj/item/seeds/lavaland/inocybe,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+"wt" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
 	},
-/area/mine/laborcamp)
-"wu" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/fishing_rod/tribal,
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
 /area/lavaland/surface/outdoors)
 "wA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -4313,6 +4321,11 @@
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/necropolis)
+"yk" = (
+/obj/structure/flora/firebush,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "ym" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4353,15 +4366,6 @@
 /obj/structure/lattice/catwalk/mapping,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/storage)
-"yG" = (
-/obj/structure/table/wood,
-/obj/item/shovel/spade/wooden{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "yJ" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -4445,11 +4449,6 @@
 	icon_state = "brown"
 	},
 /area/mine/lobby)
-"zg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/sustenance,
-/turf/simulated/floor/plasteel,
-/area/mine/laborcamp)
 "zi" = (
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -4551,7 +4550,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/weightmachine/horizontalbar/high,
+/obj/machinery/vending/cola/free,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -4624,6 +4623,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/mine/lobby)
+"Ae" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Ai" = (
 /obj/structure/stone_tile/slab,
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient,
@@ -4806,6 +4816,20 @@
 	icon_state = "brown"
 	},
 /area/mine/production)
+"BC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/weightmachine/horizontalbar/high,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/mine/laborcamp)
 "BK" = (
 /obj/structure/ore_box,
 /obj/machinery/camera{
@@ -4832,16 +4856,6 @@
 	icon_state = "brown"
 	},
 /area/mine/lobby)
-"BU" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/slab/cracked{
-	dir = 5
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "BX" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -4921,6 +4935,16 @@
 	icon_state = "clockwork_floor"
 	},
 /area/mine/necropolis)
+"CF" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "CK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5007,29 +5031,6 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
-"Ds" = (
-/obj/machinery/biogenerator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
-"Dw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/vending/cola/free,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/mine/laborcamp)
 "Dy" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5095,6 +5096,36 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
+"Eb" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Ef" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -5149,10 +5180,10 @@
 "Et" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -5653,47 +5684,6 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
-"HT" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/lavaland/polypore,
-/obj/item/seeds/lavaland/polypore,
-/obj/item/seeds/lavaland/polypore,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
-"HW" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/seeds/reishi,
-/obj/item/seeds/reishi,
-/obj/item/seeds/reishi,
-/obj/item/seeds/wheat{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/seeds/wheat{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/seeds/wheat{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/seeds/aloe,
-/obj/item/seeds/aloe,
-/obj/item/seeds/aloe,
-/obj/item/seeds/comfrey,
-/obj/item/seeds/comfrey,
-/obj/item/seeds/comfrey,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "Id" = (
 /obj/structure/lattice/catwalk/mapping,
 /obj/structure/transit_tube/crossing,
@@ -6043,16 +6033,6 @@
 	icon_state = "clockwork_floor"
 	},
 /area/mine/necropolis)
-"KV" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "La" = (
 /turf/simulated/wall/r_wall,
 /area/mine/maintenance)
@@ -6336,6 +6316,16 @@
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/necropolis)
+"Nr" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "Nw" = (
 /obj/structure/stone_tile/slab/cracked,
 /obj/structure/fluff/drake_statue/falling{
@@ -6370,6 +6360,12 @@
 	icon_state = "green"
 	},
 /area/mine/laborcamp)
+"NI" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/fishing_rod/tribal,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "NJ" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -6465,6 +6461,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
+"Ow" = (
+/obj/structure/stone_tile/slab/cracked,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "OF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -6474,6 +6475,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
+"OK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9
+	},
+/area/mine/laborcamp)
 "OL" = (
 /obj/machinery/computer/prisoner{
 	dir = 4
@@ -6575,6 +6588,13 @@
 "Qo" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
+	},
+/area/mine/laborcamp)
+"Qp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "Qw" = (
@@ -6835,6 +6855,15 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"SI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9
+	},
+/area/mine/laborcamp)
 "SJ" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -6959,16 +6988,6 @@
 /obj/structure/stone_tile/cracked,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"TK" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 5
-	},
-/obj/structure/stone_tile/slab/cracked{
-	dir = 10
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "TO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -7031,11 +7050,6 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"UH" = (
-/obj/structure/flora/ausbushes/fullgrass/hell,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "UI" = (
 /obj/structure/stone_tile/surrounding_tile/burnt,
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -7433,6 +7447,15 @@
 	icon_state = "brown"
 	},
 /area/mine/production)
+"Xr" = (
+/obj/structure/table/wood,
+/obj/item/shovel/spade/wooden{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Xu" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -7450,6 +7473,29 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"Xv" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/shovel/spade/wooden,
+/obj/item/cultivator/wooden,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/plant_analyzer,
+/obj/item/seeds/lavaland/fireblossom,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Xw" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile/block{
@@ -7475,13 +7521,6 @@
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
-"XO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "XS" = (
 /obj/ash_walker_landmark,
 /turf/template_noop,
@@ -7759,10 +7798,6 @@
 	icon_state = "brown"
 	},
 /area/mine/lobby)
-"ZW" = (
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 Uo
@@ -46036,7 +46071,7 @@ an
 an
 an
 an
-uY
+yk
 Vn
 Vn
 Vn
@@ -46295,7 +46330,7 @@ Vn
 Vn
 Vn
 Vn
-yG
+Xr
 Vn
 Vn
 Vn
@@ -46548,12 +46583,12 @@ an
 an
 Vn
 Vn
-ZW
-ZW
-TK
-ZW
-ZW
-wu
+ql
+ql
+wt
+ql
+ql
+NI
 Vn
 Vn
 an
@@ -46804,13 +46839,13 @@ an
 an
 an
 Vn
-oi
-ZW
-ZW
-ZW
-ZW
-ZW
-ZW
+Nr
+ql
+ql
+ql
+ql
+ql
+ql
 Vn
 Vn
 an
@@ -47060,14 +47095,14 @@ an
 an
 an
 an
-ZW
-ZW
-ZW
-ZW
-ZW
-ZW
-ZW
-ZW
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
 Vn
 Vn
 an
@@ -47317,14 +47352,14 @@ ab
 an
 an
 an
-ZW
-ZW
-ZW
-ZW
-ZW
-ZW
-ZW
-ZW
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
 Vn
 an
 an
@@ -47575,14 +47610,14 @@ an
 an
 an
 an
-ZW
-ZW
-ZW
-ZW
-ZW
-ZW
-ZW
-UH
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+cC
 an
 an
 an
@@ -47832,13 +47867,13 @@ an
 an
 an
 an
-ZW
-ZW
-ZW
-ZW
-ZW
-ZW
-BU
+ql
+ql
+ql
+ql
+ql
+ql
+CF
 an
 an
 an
@@ -48090,11 +48125,11 @@ an
 an
 an
 Vn
-ZW
-ZW
-ZW
-ZW
-mg
+ql
+ql
+ql
+ql
+Ow
 Vn
 an
 an
@@ -48346,11 +48381,11 @@ an
 an
 an
 an
-UH
+cC
 Vn
-ZW
-ZW
-ZW
+ql
+ql
+ql
 Vn
 Vn
 an
@@ -55295,7 +55330,7 @@ Ts
 JQ
 oR
 aq
-zI
+BC
 bl
 ML
 aq
@@ -55552,7 +55587,7 @@ qt
 aq
 qT
 qT
-Dw
+zI
 JZ
 UE
 tZ
@@ -55802,9 +55837,9 @@ Vn
 aj
 aj
 ap
-Ds
-XO
-ws
+af
+Qp
+pC
 gK
 lh
 na
@@ -56059,9 +56094,9 @@ Vn
 aj
 aj
 ap
-pb
+rR
 JZ
-CY
+SI
 CY
 Et
 aq
@@ -56316,10 +56351,10 @@ Vn
 aj
 aj
 ap
-HT
+Ae
 JZ
-CY
-CY
+OK
+sO
 dP
 hK
 LG
@@ -56573,9 +56608,9 @@ Vn
 aj
 aj
 ap
-HW
-KV
-cE
+Eb
+rN
+Xv
 TG
 NG
 qT
@@ -57608,7 +57643,7 @@ kE
 Il
 jp
 aq
-zg
+sD
 JZ
 JZ
 ZH

--- a/_maps/map_files/celestation/Lavaland.dmm
+++ b/_maps/map_files/celestation/Lavaland.dmm
@@ -603,17 +603,6 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
-"bX" = (
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "bY" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/simulated/floor/plasteel{
@@ -748,6 +737,26 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
+"cE" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/shovel/spade/wooden,
+/obj/item/cultivator/wooden,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/plant_analyzer,
+/obj/item/seeds/lavaland/fireblossom,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "cG" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -1080,12 +1089,6 @@
 	icon_state = "brown"
 	},
 /area/mine/production)
-"ej" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/fishing_rod/tribal,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "ek" = (
 /obj/machinery/door/window/southright{
 	name = "Infirmary"
@@ -1557,16 +1560,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
-"gs" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 10
-	},
-/obj/structure/stone_tile/slab/cracked{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "gt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -1806,20 +1799,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel/freezer,
 /area/mine/living_quarters)
-"hH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/vending/cola/free,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/mine/laborcamp)
 "hI" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
@@ -2685,6 +2664,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
+"mg" = (
+/obj/structure/stone_tile/slab/cracked,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "mj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2990,17 +2974,6 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
-"mY" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/lavaland/polypore,
-/obj/item/seeds/lavaland/polypore,
-/obj/item/seeds/lavaland/polypore,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "na" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
@@ -3124,6 +3097,16 @@
 	},
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/necropolis)
+"oi" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "ok" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -3181,6 +3164,14 @@
 	icon_state = "dark"
 	},
 /area/mine/living_quarters)
+"pb" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "pg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3616,26 +3607,6 @@
 	},
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
-"sy" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/shovel/spade/wooden,
-/obj/item/cultivator/wooden,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/plant_analyzer,
-/obj/item/seeds/lavaland/fireblossom,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "sC" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -3969,6 +3940,11 @@
 /obj/structure/lattice/catwalk/mapping,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/production)
+"uY" = (
+/obj/structure/flora/firebush,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "uZ" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -4057,13 +4033,6 @@
 	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
-"vN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "vO" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -4086,36 +4055,6 @@
 	icon_state = "darkred"
 	},
 /area/mine/laborcamp/security)
-"vV" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/seeds/reishi,
-/obj/item/seeds/reishi,
-/obj/item/seeds/reishi,
-/obj/item/seeds/wheat{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/seeds/wheat{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/seeds/wheat{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/seeds/aloe,
-/obj/item/seeds/aloe,
-/obj/item/seeds/aloe,
-/obj/item/seeds/comfrey,
-/obj/item/seeds/comfrey,
-/obj/item/seeds/comfrey,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "vZ" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -4154,6 +4093,26 @@
 	icon_state = "purplecorner"
 	},
 /area/mine/living_quarters)
+"ws" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
+"wu" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/fishing_rod/tribal,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "wA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -4265,15 +4224,6 @@
 	icon_state = "grimy"
 	},
 /area/mine/living_quarters)
-"xD" = (
-/obj/structure/table/wood,
-/obj/item/shovel/spade/wooden{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "xH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -4403,6 +4353,15 @@
 /obj/structure/lattice/catwalk/mapping,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/storage)
+"yG" = (
+/obj/structure/table/wood,
+/obj/item/shovel/spade/wooden{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "yJ" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -4486,6 +4445,11 @@
 	icon_state = "brown"
 	},
 /area/mine/lobby)
+"zg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/sustenance,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "zi" = (
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -4868,6 +4832,16 @@
 	icon_state = "brown"
 	},
 /area/mine/lobby)
+"BU" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "BX" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -5033,6 +5007,29 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"Ds" = (
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
+"Dw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/vending/cola/free,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/mine/laborcamp)
 "Dy" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5173,11 +5170,6 @@
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
-"EI" = (
-/obj/structure/stone_tile/slab/cracked,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "EJ" = (
 /obj/structure/lattice/catwalk/mapping,
 /obj/structure/cable{
@@ -5231,10 +5223,6 @@
 	icon_state = "clockwork_floor"
 	},
 /area/mine/necropolis)
-"ER" = (
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "EV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5279,11 +5267,6 @@
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
-"Fp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/sustenance,
-/turf/simulated/floor/plasteel,
-/area/mine/laborcamp)
 "Fx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -5460,16 +5443,6 @@
 	tag = "icon-wood-broken7"
 	},
 /area/mine/laborcamp)
-"GN" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 5
-	},
-/obj/structure/stone_tile/slab/cracked{
-	dir = 10
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "GP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
@@ -5680,17 +5653,44 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
-"HP" = (
+"HT" = (
 /obj/machinery/hydroponics/soil,
-/obj/item/seeds/lavaland/inocybe,
-/obj/item/seeds/lavaland/inocybe,
-/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
+"HW" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "green"
 	},
 /area/mine/laborcamp)
@@ -6043,6 +6043,16 @@
 	icon_state = "clockwork_floor"
 	},
 /area/mine/necropolis)
+"KV" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "La" = (
 /turf/simulated/wall/r_wall,
 /area/mine/maintenance)
@@ -6349,11 +6359,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
-"NF" = (
-/obj/structure/flora/firebush,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "NG" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/lavaland/coaltree,
@@ -6715,15 +6720,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
-"Sa" = (
-/obj/machinery/biogenerator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "Sc" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -6963,6 +6959,16 @@
 /obj/structure/stone_tile/cracked,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"TK" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "TO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -7014,16 +7020,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
-"UC" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/slab/cracked{
-	dir = 5
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "UE" = (
 /obj/structure/table,
 /obj/item/lighter/random{
@@ -7035,6 +7031,11 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"UH" = (
+/obj/structure/flora/ausbushes/fullgrass/hell,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "UI" = (
 /obj/structure/stone_tile/surrounding_tile/burnt,
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -7104,16 +7105,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
-"Vh" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "Vi" = (
 /obj/machinery/suit_storage_unit/lavaland,
 /obj/effect/decal/cleanable/dirt,
@@ -7466,11 +7457,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
-"XB" = (
-/obj/structure/flora/ausbushes/fullgrass/hell,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "XD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mineral/mint{
@@ -7489,6 +7475,13 @@
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"XO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "XS" = (
 /obj/ash_walker_landmark,
 /turf/template_noop,
@@ -7766,6 +7759,10 @@
 	icon_state = "brown"
 	},
 /area/mine/lobby)
+"ZW" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 Uo
@@ -46039,7 +46036,7 @@ an
 an
 an
 an
-NF
+uY
 Vn
 Vn
 Vn
@@ -46298,7 +46295,7 @@ Vn
 Vn
 Vn
 Vn
-xD
+yG
 Vn
 Vn
 Vn
@@ -46551,12 +46548,12 @@ an
 an
 Vn
 Vn
-ER
-ER
-GN
-ER
-ER
-ej
+ZW
+ZW
+TK
+ZW
+ZW
+wu
 Vn
 Vn
 an
@@ -46807,13 +46804,13 @@ an
 an
 an
 Vn
-gs
-ER
-ER
-ER
-ER
-ER
-ER
+oi
+ZW
+ZW
+ZW
+ZW
+ZW
+ZW
 Vn
 Vn
 an
@@ -47063,14 +47060,14 @@ an
 an
 an
 an
-ER
-ER
-ER
-ER
-ER
-ER
-ER
-ER
+ZW
+ZW
+ZW
+ZW
+ZW
+ZW
+ZW
+ZW
 Vn
 Vn
 an
@@ -47320,14 +47317,14 @@ ab
 an
 an
 an
-ER
-ER
-ER
-ER
-ER
-ER
-ER
-ER
+ZW
+ZW
+ZW
+ZW
+ZW
+ZW
+ZW
+ZW
 Vn
 an
 an
@@ -47578,14 +47575,14 @@ an
 an
 an
 an
-ER
-ER
-ER
-ER
-ER
-ER
-ER
-XB
+ZW
+ZW
+ZW
+ZW
+ZW
+ZW
+ZW
+UH
 an
 an
 an
@@ -47835,13 +47832,13 @@ an
 an
 an
 an
-ER
-ER
-ER
-ER
-ER
-ER
-UC
+ZW
+ZW
+ZW
+ZW
+ZW
+ZW
+BU
 an
 an
 an
@@ -48093,11 +48090,11 @@ an
 an
 an
 Vn
-ER
-ER
-ER
-ER
-EI
+ZW
+ZW
+ZW
+ZW
+mg
 Vn
 an
 an
@@ -48349,11 +48346,11 @@ an
 an
 an
 an
-XB
+UH
 Vn
-ER
-ER
-ER
+ZW
+ZW
+ZW
 Vn
 Vn
 an
@@ -55555,7 +55552,7 @@ qt
 aq
 qT
 qT
-hH
+Dw
 JZ
 UE
 tZ
@@ -55805,9 +55802,9 @@ Vn
 aj
 aj
 ap
-Sa
-vN
-HP
+Ds
+XO
+ws
 gK
 lh
 na
@@ -56062,7 +56059,7 @@ Vn
 aj
 aj
 ap
-bX
+pb
 JZ
 CY
 CY
@@ -56319,7 +56316,7 @@ Vn
 aj
 aj
 ap
-mY
+HT
 JZ
 CY
 CY
@@ -56576,9 +56573,9 @@ Vn
 aj
 aj
 ap
-vV
-Vh
-sy
+HW
+KV
+cE
 TG
 NG
 qT
@@ -57611,7 +57608,7 @@ kE
 Il
 jp
 aq
-Fp
+zg
 JZ
 JZ
 ZH

--- a/_maps/map_files/cerestation/Lavaland.dmm
+++ b/_maps/map_files/cerestation/Lavaland.dmm
@@ -548,6 +548,16 @@
 	icon_state = "barber"
 	},
 /area/mine/laborcamp)
+"bR" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "bS" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/cans/beer{
@@ -572,6 +582,15 @@
 	icon_state = "dark"
 	},
 /area/mine/living_quarters)
+"bU" = (
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "bV" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -750,6 +769,17 @@
 	icon_state = "brown"
 	},
 /area/mine/storage)
+"cM" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "cQ" = (
 /obj/structure/closet/secure_closet/personal/mining,
 /turf/simulated/floor/plasteel{
@@ -880,6 +910,15 @@
 "dq" = (
 /turf/simulated/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors/unexplored)
+"dw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9
+	},
+/area/mine/laborcamp)
 "dx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -950,13 +989,16 @@
 	},
 /area/mine/storage)
 "dP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Labor Camp Breakroom";
 	dir = 1;
 	network = list("Labor Camp")
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "green"
@@ -1287,17 +1329,6 @@
 	icon_state = "dark"
 	},
 /area/mine/laborcamp/security)
-"fr" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/lavaland/polypore,
-/obj/item/seeds/lavaland/polypore,
-/obj/item/seeds/lavaland/polypore,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "fs" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -1904,26 +1935,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
-"iG" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/shovel/spade/wooden,
-/obj/item/cultivator/wooden,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/plant_analyzer,
-/obj/item/seeds/lavaland/fireblossom,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "iH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2196,6 +2207,16 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"km" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "kn" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -2383,6 +2404,12 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"lf" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/fishing_rod/tribal,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "lg" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -2622,16 +2649,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
-"me" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 5
-	},
-/obj/structure/stone_tile/slab/cracked{
-	dir = 10
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "mj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2668,36 +2685,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"mq" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/seeds/reishi,
-/obj/item/seeds/reishi,
-/obj/item/seeds/reishi,
-/obj/item/seeds/wheat{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/seeds/wheat{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/seeds/wheat{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/seeds/aloe,
-/obj/item/seeds/aloe,
-/obj/item/seeds/aloe,
-/obj/item/seeds/comfrey,
-/obj/item/seeds/comfrey,
-/obj/item/seeds/comfrey,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "mr" = (
 /obj/structure/stone_tile/surrounding,
 /obj/structure/closet/crate/necropolis/tendril,
@@ -3355,6 +3342,10 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"qC" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "qD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3373,6 +3364,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"qG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9
+	},
+/area/mine/laborcamp)
 "qH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -3526,16 +3529,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"rW" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/slab/cracked{
-	dir = 5
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "rY" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/mapping_helpers/no_lava,
@@ -3760,6 +3753,11 @@
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"tH" = (
+/obj/structure/flora/firebush,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "tR" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -3780,12 +3778,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
-"tW" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/fishing_rod/tribal,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "tZ" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
@@ -4087,6 +4079,29 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
+"wE" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/shovel/spade/wooden,
+/obj/item/cultivator/wooden,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/plant_analyzer,
+/obj/item/seeds/lavaland/fireblossom,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "wR" = (
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
@@ -4094,6 +4109,16 @@
 /obj/structure/stone_tile,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"wU" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "wY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4172,10 +4197,6 @@
 	},
 /obj/structure/lattice/catwalk/mapping,
 /turf/simulated/floor/lava/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"xx" = (
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
 /area/lavaland/surface/outdoors)
 "xH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4305,15 +4326,23 @@
 	icon_state = "brown"
 	},
 /area/mine/storage)
-"yt" = (
-/obj/structure/table/wood,
-/obj/item/shovel/spade/wooden{
-	pixel_x = 6;
-	pixel_y = 1
+"yI" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "yJ" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -4511,7 +4540,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/vending/cola/free,
+/obj/structure/weightmachine/horizontalbar/high,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -4587,16 +4616,6 @@
 	icon_state = "dark"
 	},
 /area/mine/laborcamp/security)
-"As" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 10
-	},
-/obj/structure/stone_tile/slab/cracked{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "Av" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel{
@@ -4645,23 +4664,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/lobby)
-"AH" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/lavaland/inocybe,
-/obj/item/seeds/lavaland/inocybe,
-/obj/item/seeds/lavaland/inocybe,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "AM" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -4939,6 +4941,8 @@
 /area/mine/living_quarters)
 "CY" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 9
 	},
@@ -4991,11 +4995,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
-"DK" = (
-/obj/structure/flora/ausbushes/fullgrass/hell,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "DM" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -5100,10 +5099,10 @@
 "Et" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -5225,6 +5224,11 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
+"FF" = (
+/obj/structure/flora/ausbushes/fullgrass/hell,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "FH" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -5288,6 +5292,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"FX" = (
+/obj/structure/table/wood,
+/obj/item/shovel/spade/wooden{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Gg" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/block/cracked{
@@ -5310,6 +5323,36 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
+"Gm" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Gp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5515,14 +5558,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine/laborcamp)
-"Hs" = (
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
 /area/mine/laborcamp)
 "Hz" = (
 /obj/structure/stone_tile/block/burnt{
@@ -5919,6 +5954,11 @@
 	icon_state = "clockwork_floor"
 	},
 /area/mine/necropolis)
+"KW" = (
+/obj/structure/stone_tile/slab/cracked,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "La" = (
 /turf/simulated/wall/r_wall,
 /area/mine/maintenance)
@@ -6365,15 +6405,6 @@
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
-"OG" = (
-/obj/machinery/biogenerator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "OL" = (
 /obj/machinery/computer/prisoner{
 	dir = 4
@@ -6388,13 +6419,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"OQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "OR" = (
 /obj/item/stack/ore/bananium,
 /turf/simulated/mineral/random/volcanic,
@@ -6524,11 +6548,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"QM" = (
-/obj/structure/flora/firebush,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "QO" = (
 /obj/effect/rune{
 	color = "#DAA520";
@@ -6549,11 +6568,6 @@
 	icon_state = "clockwork_floor"
 	},
 /area/mine/necropolis)
-"QQ" = (
-/obj/structure/stone_tile/slab/cracked,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "QT" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -6606,6 +6620,20 @@
 "RD" = (
 /turf/simulated/wall/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"RF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/vending/cola/free,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/mine/laborcamp)
 "RM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -6642,6 +6670,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
+"RZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Sc" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -6790,6 +6825,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/lobby)
+"SZ" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Tb" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -6842,6 +6885,12 @@
 	icon_state = "darkred"
 	},
 /area/mine/laborcamp)
+"Tl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9
+	},
+/area/mine/laborcamp)
 "Tn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -6856,30 +6905,6 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "brown"
-	},
-/area/mine/laborcamp)
-"Tu" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
-"Tv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/weightmachine/horizontalbar/high,
-/turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
@@ -7056,6 +7081,16 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"Vl" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "Vn" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -46195,7 +46230,7 @@ an
 an
 an
 an
-QM
+tH
 Vn
 Vn
 Vn
@@ -46454,7 +46489,7 @@ Vn
 Vn
 Vn
 Vn
-yt
+FX
 Vn
 Vn
 Vn
@@ -46707,12 +46742,12 @@ an
 an
 Vn
 Vn
-xx
-xx
-me
-xx
-xx
-tW
+qC
+qC
+wU
+qC
+qC
+lf
 Vn
 Vn
 an
@@ -46963,13 +46998,13 @@ an
 an
 an
 Vn
-As
-xx
-xx
-xx
-xx
-xx
-xx
+Vl
+qC
+qC
+qC
+qC
+qC
+qC
 Vn
 Vn
 an
@@ -47219,14 +47254,14 @@ an
 an
 an
 an
-xx
-xx
-xx
-xx
-xx
-xx
-xx
-xx
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
 Vn
 Vn
 an
@@ -47476,14 +47511,14 @@ an
 an
 an
 an
-xx
-xx
-xx
-xx
-xx
-xx
-xx
-xx
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
 Vn
 an
 an
@@ -47734,14 +47769,14 @@ an
 an
 an
 an
-xx
-xx
-xx
-xx
-xx
-xx
-xx
-DK
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+FF
 an
 an
 an
@@ -47991,13 +48026,13 @@ an
 an
 an
 an
-xx
-xx
-xx
-xx
-xx
-xx
-rW
+qC
+qC
+qC
+qC
+qC
+qC
+bR
 an
 an
 an
@@ -48249,11 +48284,11 @@ an
 an
 an
 Vn
-xx
-xx
-xx
-xx
-QQ
+qC
+qC
+qC
+qC
+KW
 Vn
 an
 an
@@ -48505,11 +48540,11 @@ an
 an
 an
 an
-DK
+FF
 Vn
-xx
-xx
-xx
+qC
+qC
+qC
 Vn
 Vn
 an
@@ -55967,7 +56002,7 @@ Ts
 JQ
 oR
 aq
-Tv
+zI
 bl
 ML
 aq
@@ -56224,7 +56259,7 @@ qt
 aq
 qT
 qT
-zI
+RF
 JZ
 UE
 tZ
@@ -56474,9 +56509,9 @@ Vn
 aj
 aj
 ap
-OG
-OQ
-AH
+bU
+RZ
+yI
 gK
 lh
 na
@@ -56731,10 +56766,10 @@ Vn
 aj
 aj
 ap
-Hs
+SZ
 JZ
-CY
-CY
+dw
+Tl
 Et
 aq
 VO
@@ -56988,9 +57023,9 @@ Vn
 aj
 aj
 ap
-fr
+cM
 JZ
-CY
+qG
 CY
 dP
 hK
@@ -57245,9 +57280,9 @@ aj
 aj
 aj
 ap
-mq
-Tu
-iG
+Gm
+km
+wE
 TG
 NG
 qT

--- a/_maps/map_files/cerestation/Lavaland.dmm
+++ b/_maps/map_files/cerestation/Lavaland.dmm
@@ -363,6 +363,17 @@
 	icon_state = "browncorner"
 	},
 /area/mine/laborcamp)
+"bm" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "bn" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -880,6 +891,17 @@
 "dq" = (
 /turf/simulated/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors/unexplored)
+"dt" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "dx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -950,7 +972,6 @@
 	},
 /area/mine/storage)
 "dP" = (
-/obj/item/trash/syndi_cakes,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -960,7 +981,7 @@
 	network = list("Labor Camp")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "dR" = (
@@ -987,6 +1008,21 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
+"dZ" = (
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
+"eb" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/fishing_rod/tribal,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "ec" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -1177,6 +1213,36 @@
 	icon_state = "brown"
 	},
 /area/mine/production)
+"eW" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "eX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
@@ -1588,8 +1654,15 @@
 /turf/simulated/floor/plasteel,
 /area/mine/lobby)
 "gK" = (
-/obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/plasteel/dark,
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/porcini,
+/obj/item/seeds/lavaland/porcini,
+/obj/item/seeds/lavaland/porcini,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
 /area/mine/laborcamp)
 "gM" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -2362,11 +2435,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	dir = 10;
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "lk" = (
@@ -2926,6 +2997,10 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"nm" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "nn" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 4
@@ -2940,6 +3015,13 @@
 	icon_state = "brown"
 	},
 /area/mine/production)
+"nG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "nK" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/cracked{
@@ -3025,6 +3107,15 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
+"oq" = (
+/obj/structure/table/wood,
+/obj/item/shovel/spade/wooden{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "ox" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -3268,6 +3359,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/storage)
+"qq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/weightmachine/horizontalbar/high,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/mine/laborcamp)
 "qt" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall/rust,
@@ -3675,6 +3780,16 @@
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"tF" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "tR" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -3839,6 +3954,16 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"va" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "vk" = (
 /obj/structure/toilet{
 	dir = 8
@@ -3849,6 +3974,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/freezer,
 /area/mine/living_quarters)
+"vo" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "vs" = (
 /obj/structure/closet/secure_closet/personal/mining,
 /obj/structure/cable{
@@ -4407,6 +4542,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/vending/cola/free,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -4683,7 +4819,7 @@
 /area/mine/storage)
 "BX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/cigbutt,
+/obj/machinery/vending/sustenance,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "brown"
@@ -4807,10 +4943,9 @@
 /area/mine/living_quarters)
 "CY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 9
 	},
-/turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
 "Dd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4971,7 +5106,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "EF" = (
@@ -5512,6 +5647,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
+"Iy" = (
+/obj/structure/flora/firebush,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Iz" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -6109,9 +6249,14 @@
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
 "NG" = (
-/obj/machinery/vending/sustenance,
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/coaltree,
+/obj/item/seeds/lavaland/coaltree,
+/obj/item/seeds/lavaland/coaltree,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	dir = 6;
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "NJ" = (
@@ -6134,6 +6279,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
+"NS" = (
+/obj/structure/stone_tile/slab/cracked,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "NV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6458,6 +6608,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
+"RT" = (
+/obj/structure/flora/ausbushes/fullgrass/hell,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "RU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -6503,6 +6658,20 @@
 "Sj" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/mine/production)
+"Sn" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Ss" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -6685,12 +6854,15 @@
 	},
 /area/mine/laborcamp)
 "TG" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/cactus,
+/obj/item/seeds/lavaland/cactus,
+/obj/item/seeds/lavaland/cactus,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/cola/free,
-/obj/structure/sign/poster/contraband/clown{
-	pixel_x = 32
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
 	},
-/turf/simulated/floor/plasteel/dark,
 /area/mine/laborcamp)
 "TH" = (
 /turf/simulated/wall,
@@ -6764,10 +6936,10 @@
 /area/mine/production)
 "UE" = (
 /obj/structure/table,
-/obj/item/storage/fancy/cigarettes/cigpack_random,
 /obj/item/lighter/random{
 	pixel_x = 2
 	},
+/obj/item/storage/fancy/cigarettes/cigpack_uplift,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
@@ -7275,6 +7447,16 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"YE" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "YF" = (
 /obj/structure/window/reinforced/clockwork{
 	dir = 8;
@@ -7338,6 +7520,26 @@
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "browncorner"
+	},
+/area/mine/laborcamp)
+"YW" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/shovel/spade/wooden,
+/obj/item/cultivator/wooden,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/plant_analyzer,
+/obj/item/seeds/lavaland/fireblossom,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "YX" = (
@@ -45993,11 +46195,11 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
+Iy
+Vn
+Vn
+Vn
+Vn
 an
 an
 an
@@ -46247,15 +46449,15 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+Vn
+Vn
+Vn
+Vn
+Vn
+oq
+Vn
+Vn
+Vn
 an
 an
 an
@@ -46503,16 +46705,16 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+Vn
+Vn
+nm
+nm
+va
+nm
+nm
+eb
+Vn
+Vn
 an
 an
 an
@@ -46760,16 +46962,16 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+Vn
+vo
+nm
+nm
+nm
+nm
+nm
+nm
+Vn
+Vn
 an
 an
 an
@@ -47017,16 +47219,16 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+Vn
+Vn
 an
 an
 an
@@ -47274,15 +47476,15 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+Vn
 an
 an
 an
@@ -47532,14 +47734,14 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+RT
 an
 an
 an
@@ -47789,13 +47991,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+nm
+nm
+nm
+nm
+nm
+nm
+YE
 an
 an
 an
@@ -48046,13 +48248,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+Vn
+nm
+nm
+nm
+nm
+NS
+Vn
 an
 an
 an
@@ -48303,13 +48505,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+RT
+Vn
+nm
+nm
+nm
+Vn
+Vn
 an
 an
 an
@@ -55765,7 +55967,7 @@ Ts
 JQ
 oR
 aq
-zI
+qq
 bl
 ML
 aq
@@ -56014,8 +56216,8 @@ Vn
 Vn
 aj
 aj
-aj
-aj
+ap
+ap
 aq
 qT
 qt
@@ -56271,10 +56473,10 @@ Vn
 Vn
 aj
 aj
-aj
-aj
-aj
 ap
+dZ
+nG
+Sn
 gK
 lh
 na
@@ -56528,10 +56730,10 @@ Vn
 Vn
 aj
 aj
-aj
-aj
-aj
 ap
+bm
+JZ
+CY
 CY
 Et
 aq
@@ -56785,10 +56987,10 @@ Vn
 Vn
 aj
 aj
-aj
-aj
-aj
 ap
+dt
+JZ
+CY
 CY
 dP
 hK
@@ -57042,10 +57244,10 @@ Vn
 aj
 aj
 aj
-aj
-aj
-aj
 ap
+eW
+tF
+YW
 TG
 NG
 qT
@@ -57299,7 +57501,7 @@ Vn
 aj
 aj
 aj
-aj
+qT
 qT
 qt
 aq

--- a/_maps/map_files/cerestation/Lavaland.dmm
+++ b/_maps/map_files/cerestation/Lavaland.dmm
@@ -363,17 +363,6 @@
 	icon_state = "browncorner"
 	},
 /area/mine/laborcamp)
-"bm" = (
-/obj/machinery/seed_extractor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "bn" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -891,17 +880,6 @@
 "dq" = (
 /turf/simulated/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors/unexplored)
-"dt" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/lavaland/polypore,
-/obj/item/seeds/lavaland/polypore,
-/obj/item/seeds/lavaland/polypore,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "dx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1008,21 +986,6 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
-"dZ" = (
-/obj/machinery/biogenerator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
-"eb" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/fishing_rod/tribal,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "ec" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -1213,36 +1176,6 @@
 	icon_state = "brown"
 	},
 /area/mine/production)
-"eW" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/seeds/reishi,
-/obj/item/seeds/reishi,
-/obj/item/seeds/reishi,
-/obj/item/seeds/wheat{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/seeds/wheat{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/seeds/wheat{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/seeds/aloe,
-/obj/item/seeds/aloe,
-/obj/item/seeds/aloe,
-/obj/item/seeds/comfrey,
-/obj/item/seeds/comfrey,
-/obj/item/seeds/comfrey,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "eX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
@@ -1354,6 +1287,17 @@
 	icon_state = "dark"
 	},
 /area/mine/laborcamp/security)
+"fr" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "fs" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -1960,6 +1904,26 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
+"iG" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/shovel/spade/wooden,
+/obj/item/cultivator/wooden,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/plant_analyzer,
+/obj/item/seeds/lavaland/fireblossom,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "iH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2658,6 +2622,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
+"me" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "mj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2694,6 +2668,36 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"mq" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "mr" = (
 /obj/structure/stone_tile/surrounding,
 /obj/structure/closet/crate/necropolis/tendril,
@@ -2997,10 +3001,6 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
-"nm" = (
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "nn" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 4
@@ -3015,13 +3015,6 @@
 	icon_state = "brown"
 	},
 /area/mine/production)
-"nG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "nK" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/cracked{
@@ -3107,15 +3100,6 @@
 	icon_state = "bar"
 	},
 /area/mine/living_quarters)
-"oq" = (
-/obj/structure/table/wood,
-/obj/item/shovel/spade/wooden{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "ox" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -3359,20 +3343,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/storage)
-"qq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/weightmachine/horizontalbar/high,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/mine/laborcamp)
 "qt" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall/rust,
@@ -3556,6 +3526,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"rW" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "rY" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/mapping_helpers/no_lava,
@@ -3780,16 +3760,6 @@
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
-"tF" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "tR" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -3810,6 +3780,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"tW" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/fishing_rod/tribal,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "tZ" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
@@ -3954,16 +3930,6 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
-"va" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 5
-	},
-/obj/structure/stone_tile/slab/cracked{
-	dir = 10
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "vk" = (
 /obj/structure/toilet{
 	dir = 8
@@ -3974,16 +3940,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/freezer,
 /area/mine/living_quarters)
-"vo" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 10
-	},
-/obj/structure/stone_tile/slab/cracked{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "vs" = (
 /obj/structure/closet/secure_closet/personal/mining,
 /obj/structure/cable{
@@ -4217,6 +4173,10 @@
 /obj/structure/lattice/catwalk/mapping,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"xx" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "xH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -4345,6 +4305,15 @@
 	icon_state = "brown"
 	},
 /area/mine/storage)
+"yt" = (
+/obj/structure/table/wood,
+/obj/item/shovel/spade/wooden{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "yJ" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -4618,6 +4587,16 @@
 	icon_state = "dark"
 	},
 /area/mine/laborcamp/security)
+"As" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "Av" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel{
@@ -4666,6 +4645,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/lobby)
+"AH" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "AM" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -4995,6 +4991,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
+"DK" = (
+/obj/structure/flora/ausbushes/fullgrass/hell,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "DM" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -5515,6 +5516,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
+"Hs" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Hz" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 1
@@ -5647,11 +5656,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
-"Iy" = (
-/obj/structure/flora/firebush,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "Iz" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -6279,11 +6283,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
-"NS" = (
-/obj/structure/stone_tile/slab/cracked,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "NV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6366,6 +6365,15 @@
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
+"OG" = (
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "OL" = (
 /obj/machinery/computer/prisoner{
 	dir = 4
@@ -6380,6 +6388,13 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"OQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "OR" = (
 /obj/item/stack/ore/bananium,
 /turf/simulated/mineral/random/volcanic,
@@ -6509,6 +6524,11 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"QM" = (
+/obj/structure/flora/firebush,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "QO" = (
 /obj/effect/rune{
 	color = "#DAA520";
@@ -6529,6 +6549,11 @@
 	icon_state = "clockwork_floor"
 	},
 /area/mine/necropolis)
+"QQ" = (
+/obj/structure/stone_tile/slab/cracked,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "QT" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -6608,11 +6633,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine/maintenance)
-"RT" = (
-/obj/structure/flora/ausbushes/fullgrass/hell,
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "RU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -6658,20 +6678,6 @@
 "Sj" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/mine/production)
-"Sn" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/lavaland/inocybe,
-/obj/item/seeds/lavaland/inocybe,
-/obj/item/seeds/lavaland/inocybe,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
-	},
-/area/mine/laborcamp)
 "Ss" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -6850,6 +6856,30 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
+	icon_state = "brown"
+	},
+/area/mine/laborcamp)
+"Tu" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
+"Tv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/weightmachine/horizontalbar/high,
+/turf/simulated/floor/plasteel{
+	dir = 1;
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
@@ -7447,16 +7477,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
-"YE" = (
-/obj/structure/stone_tile/slab/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/slab/cracked{
-	dir = 5
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/lava/lava_land_surface/lava_only,
-/area/lavaland/surface/outdoors)
 "YF" = (
 /obj/structure/window/reinforced/clockwork{
 	dir = 8;
@@ -7520,26 +7540,6 @@
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "browncorner"
-	},
-/area/mine/laborcamp)
-"YW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/shovel/spade/wooden,
-/obj/item/cultivator/wooden,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/plant_analyzer,
-/obj/item/seeds/lavaland/fireblossom,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "YX" = (
@@ -46195,7 +46195,7 @@ an
 an
 an
 an
-Iy
+QM
 Vn
 Vn
 Vn
@@ -46454,7 +46454,7 @@ Vn
 Vn
 Vn
 Vn
-oq
+yt
 Vn
 Vn
 Vn
@@ -46707,12 +46707,12 @@ an
 an
 Vn
 Vn
-nm
-nm
-va
-nm
-nm
-eb
+xx
+xx
+me
+xx
+xx
+tW
 Vn
 Vn
 an
@@ -46963,13 +46963,13 @@ an
 an
 an
 Vn
-vo
-nm
-nm
-nm
-nm
-nm
-nm
+As
+xx
+xx
+xx
+xx
+xx
+xx
 Vn
 Vn
 an
@@ -47219,14 +47219,14 @@ an
 an
 an
 an
-nm
-nm
-nm
-nm
-nm
-nm
-nm
-nm
+xx
+xx
+xx
+xx
+xx
+xx
+xx
+xx
 Vn
 Vn
 an
@@ -47476,14 +47476,14 @@ an
 an
 an
 an
-nm
-nm
-nm
-nm
-nm
-nm
-nm
-nm
+xx
+xx
+xx
+xx
+xx
+xx
+xx
+xx
 Vn
 an
 an
@@ -47734,14 +47734,14 @@ an
 an
 an
 an
-nm
-nm
-nm
-nm
-nm
-nm
-nm
-RT
+xx
+xx
+xx
+xx
+xx
+xx
+xx
+DK
 an
 an
 an
@@ -47991,13 +47991,13 @@ an
 an
 an
 an
-nm
-nm
-nm
-nm
-nm
-nm
-YE
+xx
+xx
+xx
+xx
+xx
+xx
+rW
 an
 an
 an
@@ -48249,11 +48249,11 @@ an
 an
 an
 Vn
-nm
-nm
-nm
-nm
-NS
+xx
+xx
+xx
+xx
+QQ
 Vn
 an
 an
@@ -48505,11 +48505,11 @@ an
 an
 an
 an
-RT
+DK
 Vn
-nm
-nm
-nm
+xx
+xx
+xx
 Vn
 Vn
 an
@@ -55967,7 +55967,7 @@ Ts
 JQ
 oR
 aq
-qq
+Tv
 bl
 ML
 aq
@@ -56474,9 +56474,9 @@ Vn
 aj
 aj
 ap
-dZ
-nG
-Sn
+OG
+OQ
+AH
 gK
 lh
 na
@@ -56731,7 +56731,7 @@ Vn
 aj
 aj
 ap
-bm
+Hs
 JZ
 CY
 CY
@@ -56988,7 +56988,7 @@ Vn
 aj
 aj
 ap
-dt
+fr
 JZ
 CY
 CY
@@ -57245,9 +57245,9 @@ aj
 aj
 aj
 ap
-eW
-tF
-YW
+mq
+Tu
+iG
 TG
 NG
 qT

--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -31523,9 +31523,12 @@
 /turf/simulated/floor/wood,
 /area/centcom/zone2)
 "oHK" = (
-/obj/machinery/mineral/labor_claim_console{
-	machinedir = 1;
-	pixel_x = 30
+/obj/machinery/flasher{
+	id = "gulagshuttleflasher";
+	pixel_x = 25
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/siberia)
@@ -32570,15 +32573,8 @@
 	},
 /area/syndicate_mothership/control)
 "peG" = (
-/obj/machinery/flasher{
-	id = "gulagshuttleflasher";
-	pixel_x = 25
-	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/chair/comfy/shuttle{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/siberia)
@@ -37244,6 +37240,10 @@
 	icon_state = "dark"
 	},
 /area/centcom/jail)
+"rjK" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/floor/shuttle,
+/area/shuttle/siberia)
 "rkx" = (
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plasteel{
@@ -41399,10 +41399,8 @@
 	},
 /area/shuttle/ninja)
 "tbX" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/simulated/floor/shuttle,
+/obj/machinery/mineral/labor_claim_console,
+/turf/simulated/wall/shuttle/onlyselfsmooth,
 /area/shuttle/siberia)
 "tcs" = (
 /turf/simulated/floor/wood{
@@ -79856,7 +79854,7 @@ oJI
 sKg
 lDH
 sKg
-sKg
+tbX
 sXM
 prf
 oJI
@@ -80114,7 +80112,7 @@ lBl
 lOB
 svC
 tbv
-tbX
+tbv
 tbv
 qgA
 sgG
@@ -80370,9 +80368,9 @@ mMn
 nVS
 maj
 sKg
-tbv
+rjK
 kAJ
-tbv
+peG
 qgA
 sgG
 mVX
@@ -80628,7 +80626,7 @@ ogO
 oiv
 ovE
 oHK
-peG
+tbv
 tbv
 qgA
 sgG
@@ -80884,8 +80882,8 @@ oJI
 sKg
 okx
 sKg
-oJI
 sKg
+prf
 dhK
 oJI
 oJI

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -69,10 +69,8 @@
 /turf/simulated/mineral/random/labormineral/volcanic,
 /area/lavaland/surface/outdoors)
 "ao" = (
-/obj/machinery/computer/shuttle/labor/one_way{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "ap" = (
@@ -223,9 +221,7 @@
 	},
 /area/mine/eva)
 "aJ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "aK" = (
@@ -438,6 +434,10 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
+/obj/machinery/computer/shuttle/labor/one_way{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"
@@ -3010,6 +3010,17 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"hK" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "hL" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -3076,6 +3087,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -3183,6 +3195,12 @@
 /obj/structure/stone_tile/block/cracked,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"iE" = (
+/obj/machinery/door/airlock{
+	name = "Labor Camp Storage"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "iJ" = (
 /obj/structure/stone_tile/surrounding,
 /obj/structure/stone_tile/center/cracked,
@@ -3383,6 +3401,18 @@
 	},
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"jJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Labor Camp Storage"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "jL" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/surrounding_tile{
@@ -3607,6 +3637,15 @@
 /obj/structure/stone_tile/slab/cracked,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"lc" = (
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "le" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -3873,6 +3912,12 @@
 /obj/structure/stone_tile/cracked,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"mm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/kitchen/knife,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "mn" = (
 /obj/structure/stone_tile/block/cracked,
 /obj/structure/stone_tile/block{
@@ -4304,6 +4349,23 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"pm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/monstermeat/goliath{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/monstermeat/goliath{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/monstermeat/goliath{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "pn" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -4410,6 +4472,11 @@
 	dir = 1;
 	icon_state = "brown"
 	},
+/area/mine/laborcamp)
+"qx" = (
+/obj/structure/weightmachine/horizontalbar,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "qA" = (
 /obj/machinery/camera{
@@ -4533,6 +4600,16 @@
 	icon_state = "darkyellow"
 	},
 /area/mine/living_quarters)
+"rN" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/cactus,
+/obj/item/seeds/lavaland/cactus,
+/obj/item/seeds/lavaland/cactus,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "rS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4580,6 +4657,11 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"sk" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/weightmachine/horizontalbar,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "sv" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -4591,6 +4673,14 @@
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"sy" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "sE" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -4691,6 +4781,19 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp)
+"tA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "tC" = (
 /obj/machinery/camera{
 	c_tag = "Labor Camp Airlock";
@@ -4789,6 +4892,11 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
+"uP" = (
+/obj/structure/weightmachine/horizontalbar/high,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "uU" = (
 /obj/structure/stone_tile/slab/cracked,
 /obj/item/clockwork/clockgolem_remains,
@@ -4818,13 +4926,31 @@
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"vn" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "vq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"vu" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "vw" = (
 /obj/structure/table,
-/obj/item/storage/fancy/cigarettes/cigpack_random,
+/obj/item/storage/fancy/cigarettes/cigpack_uplift,
 /obj/item/lighter/random{
 	pixel_x = 2
 	},
@@ -4856,20 +4982,25 @@
 /area/lavaland/surface/outdoors)
 "vI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/item/trash/syndi_cakes,
 /obj/effect/decal/cleanable/cobweb2,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	initialize_directions = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
 	},
 /area/mine/laborcamp)
+"vO" = (
+/obj/structure/flora/firebush,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "vZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5093,10 +5224,10 @@
 /area/lavaland/surface/outdoors/necropolis)
 "ym" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -5346,6 +5477,19 @@
 /obj/structure/stone_tile,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Bi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Bq" = (
 /obj/structure/ore_box,
 /obj/item/gps/ruin{
@@ -5398,6 +5542,16 @@
 /obj/structure/stone_tile/slab,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"BP" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "BT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5410,6 +5564,37 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"Ch" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Ct" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -5442,6 +5627,16 @@
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
+	},
+/area/mine/laborcamp)
+"CW" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "Dd" = (
@@ -5754,6 +5949,12 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"GZ" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/fishing_rod/tribal,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Hc" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -5830,6 +6031,16 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"HS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "HU" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -5863,6 +6074,16 @@
 /obj/structure/bookcase,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"Ik" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "Il" = (
 /obj/machinery/vending/cola/free,
 /turf/simulated/floor/plasteel/dark,
@@ -5977,6 +6198,13 @@
 /obj/structure/stone_tile/block,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"Jj" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "laborcamp_away";
+	name = "Labor Camp Airlock"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "Jl" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -6094,6 +6322,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
+"KL" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "KO" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -6124,6 +6356,16 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"Ln" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/ember,
+/obj/item/seeds/lavaland/ember,
+/obj/item/seeds/lavaland/ember,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Lw" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 4
@@ -6156,6 +6398,11 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"LJ" = (
+/obj/structure/flora/ausbushes/fullgrass/hell,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "LK" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 1
@@ -6288,6 +6535,15 @@
 	icon_state = "clockwork_floor"
 	},
 /area/lavaland/surface/outdoors/necropolis)
+"MX" = (
+/obj/structure/table/wood,
+/obj/item/shovel/spade/wooden{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "MZ" = (
 /obj/item/stack/ore/gold,
 /obj/effect/mapping_helpers/no_lava,
@@ -6359,6 +6615,15 @@
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
+"NA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/lavaland_food/fine_meal{
+	pixel_x = 4;
+	pixel_y = 14
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "ND" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6394,6 +6659,11 @@
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"NJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/kitchen_machine/tribal_oven,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "NT" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -6526,6 +6796,16 @@
 	icon_state = "clockwork_floor"
 	},
 /area/lavaland/surface/outdoors/necropolis)
+"Ph" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "Pm" = (
 /turf/simulated/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors/necropolis)
@@ -6573,6 +6853,12 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/mine/living_quarters)
+"Ql" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "Qu" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/window/reinforced/clockwork{
@@ -6677,6 +6963,28 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"Rm" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/shovel/spade/wooden,
+/obj/item/cultivator/wooden,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/plant_analyzer,
+/obj/item/seeds/lavaland/fireblossom,
+/obj/machinery/light/small,
+/obj/machinery/camera{
+	c_tag = "Labor Camp Breakroom";
+	dir = 1;
+	network = list("Labor Camp")
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Rp" = (
 /obj/machinery/optable,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -6733,6 +7041,16 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"Sp" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/coaltree,
+/obj/item/seeds/lavaland/coaltree,
+/obj/item/seeds/lavaland/coaltree,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Ss" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -6914,6 +7232,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/production)
+"Uy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "UC" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -6925,6 +7252,11 @@
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"UD" = (
+/obj/structure/stone_tile/slab/cracked,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "UH" = (
 /obj/structure/stone_tile/slab,
 /obj/item/clockwork/clockgolem_remains,
@@ -6953,6 +7285,23 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"Va" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	brightness_range = 6;
+	dir = 4;
+	light_range = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
+"Vm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock{
+	name = "Labor Camp Storage"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "Vt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -7168,6 +7517,40 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
+"Xt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
+"Xw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
+"Xz" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "XC" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -7265,6 +7648,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
+"Zl" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/porcini,
+/obj/item/seeds/lavaland/porcini,
+/obj/item/seeds/lavaland/porcini,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "green"
+	},
 /area/mine/laborcamp)
 "Zt" = (
 /obj/structure/stone_tile/block,
@@ -11893,7 +12287,7 @@ aq
 gu
 aq
 aq
-aq
+Jj
 hQ
 aq
 ty
@@ -12131,12 +12525,12 @@ an
 an
 an
 an
-an
-ab
-ab
-aj
-aj
-aj
+qT
+ap
+ap
+ap
+ap
+qT
 Gp
 rj
 wh
@@ -12149,8 +12543,8 @@ aP
 aq
 aZ
 aq
-ao
 aq
+bk
 aJ
 aq
 aq
@@ -12388,13 +12782,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-aj
-aj
-qT
+tZ
+lc
+tA
+Uy
+Ql
+ao
+Vm
 vI
 ic
 ym
@@ -12406,8 +12800,8 @@ aQ
 aq
 gu
 aq
-bk
 aq
+Jj
 hQ
 aq
 bZ
@@ -12645,11 +13039,11 @@ an
 an
 an
 an
-an
-an
-an
-an
 qT
+vu
+Xw
+rN
+aq
 qT
 aq
 qT
@@ -12902,10 +13296,10 @@ an
 an
 an
 an
-an
-an
-an
-an
+qT
+hK
+Xw
+Sp
 qT
 NZ
 sF
@@ -13159,10 +13553,10 @@ an
 an
 an
 an
-an
-an
-an
-an
+qT
+Ch
+sy
+Rm
 qT
 qT
 GD
@@ -13416,10 +13810,10 @@ an
 an
 an
 an
-an
-an
-an
-an
+qT
+Xz
+Xt
+Ln
 qT
 Dd
 sF
@@ -13673,10 +14067,10 @@ an
 an
 an
 an
-an
-an
-an
-an
+qT
+Zl
+Bi
+CW
 qT
 qT
 aq
@@ -13930,11 +14324,11 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
+qT
+qT
+jJ
+tZ
+qT
 aq
 Ss
 FO
@@ -14187,11 +14581,11 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
+aq
+uP
+Xw
+NA
+NJ
 qT
 jB
 HA
@@ -14432,16 +14826,11 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+vO
+hl
+hl
+hl
+hl
 an
 an
 an
@@ -14450,6 +14839,11 @@ an
 an
 an
 qT
+sk
+HS
+vn
+JZ
+iE
 tT
 WJ
 qw
@@ -14686,26 +15080,26 @@ an
 an
 an
 an
+hl
+hl
+hl
+hl
+hl
+MX
+hl
+hl
+hl
 an
 an
 an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+qT
+qx
+Va
+pm
+mm
 aq
 oA
 Ts
@@ -14942,27 +15336,27 @@ an
 an
 an
 an
+hl
+hl
+KL
+KL
+BP
+KL
+KL
+GZ
+hl
+hl
 an
 an
 an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+qT
+qT
+aq
+qT
+aq
 aq
 qT
 qT
@@ -15199,16 +15593,16 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+hl
+Ph
+KL
+KL
+KL
+KL
+KL
+KL
+hl
+hl
 an
 an
 an
@@ -15456,16 +15850,16 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+KL
+KL
+KL
+KL
+KL
+KL
+KL
+KL
+hl
+hl
 an
 an
 an
@@ -15713,15 +16107,15 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
-an
+KL
+KL
+KL
+KL
+KL
+KL
+KL
+KL
+hl
 an
 an
 an
@@ -15971,14 +16365,14 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
-an
+KL
+KL
+KL
+KL
+KL
+KL
+KL
+LJ
 an
 an
 an
@@ -16228,13 +16622,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+KL
+KL
+KL
+KL
+KL
+KL
+Ik
 an
 an
 an
@@ -16485,13 +16879,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+hl
+KL
+KL
+KL
+KL
+UD
+hl
 an
 an
 an
@@ -16742,13 +17136,13 @@ an
 an
 an
 an
-an
-an
-an
-an
-an
-an
-an
+LJ
+hl
+KL
+KL
+KL
+hl
+hl
 an
 an
 an

--- a/_maps/map_files/nova/Lavaland.dmm
+++ b/_maps/map_files/nova/Lavaland.dmm
@@ -180,6 +180,11 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"bs" = (
+/obj/structure/flora/ausbushes/fullgrass/hell,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "bx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -333,6 +338,16 @@
 /obj/structure/stone_tile/block/cracked,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/necropolis)
+"dq" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "ds" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -376,6 +391,12 @@
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
+"dB" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/fishing_rod/tribal,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "dG" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -716,14 +737,14 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
 "fV" = (
-/obj/machinery/flasher{
-	id = "labor";
-	pixel_x = -28
-	},
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/porcini,
+/obj/item/seeds/lavaland/porcini,
+/obj/item/seeds/lavaland/porcini,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "brown"
+	dir = 5;
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "fW" = (
@@ -806,6 +827,11 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/cafeteria)
+"go" = (
+/obj/structure/weightmachine/horizontalbar/high,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "gp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -831,16 +857,6 @@
 	},
 /area/mine/laborcamp)
 "gw" = (
-/obj/structure/rack,
-/obj/item/storage/bag/ore,
-/obj/item/flashlight/lantern,
-/obj/item/pickaxe/safety,
-/obj/item/mining_scanner,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/beanie/orange,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/suit/storage/hazardvest,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 2
 	},
@@ -1146,6 +1162,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/cafeteria)
+"ih" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "ik" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1238,11 +1264,14 @@
 	},
 /area/mine/laborcamp/security)
 "iA" = (
-/obj/machinery/computer/shuttle/labor/one_way{
-	dir = 4
-	},
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/item/seeds/lavaland/polypore,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "Dark"
+	dir = 1;
+	icon_state = "green"
 	},
 /area/mine/laborcamp)
 "iB" = (
@@ -1292,6 +1321,17 @@
 /obj/structure/stone_tile/center/cracked,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/necropolis)
+"iS" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "iU" = (
 /obj/structure/stone_tile/block/cracked,
 /obj/structure/stone_tile/block/cracked{
@@ -1334,6 +1374,11 @@
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
+"jm" = (
+/obj/structure/stone_tile/slab/cracked,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "jq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -1346,6 +1391,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/mine/cafeteria)
+"js" = (
+/obj/structure/flora/firebush,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "jE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1569,6 +1619,16 @@
 	},
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/necropolis)
+"kx" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "ky" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -1790,6 +1850,16 @@
 	icon_state = "darkred"
 	},
 /area/mine/laborcamp/security)
+"lQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "lW" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -1819,7 +1889,6 @@
 /area/lavaland/surface/outdoors/necropolis)
 "mc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/cola/free,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -2048,15 +2117,8 @@
 /turf/simulated/floor/wood,
 /area/mine/cafeteria)
 "nX" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes/cigpack_random,
-/obj/item/lighter/random{
-	pixel_x = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -2256,13 +2318,9 @@
 	},
 /area/mine/lobby)
 "pj" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "brownfull"
 	},
@@ -2422,6 +2480,14 @@
 /obj/item/twohanded/ratvarian_spear,
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"pY" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "qb" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/machinery/camera{
@@ -2454,6 +2520,20 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"qu" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/item/seeds/lavaland/inocybe,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "qv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -2554,6 +2634,15 @@
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/cafeteria)
+"rb" = (
+/obj/structure/table/wood,
+/obj/item/shovel/spade/wooden{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "rc" = (
 /obj/structure/stone_tile/slab,
 /obj/item/storage/toolbox/brass,
@@ -2667,6 +2756,11 @@
 	icon_state = "brown"
 	},
 /area/mine/storage)
+"sd" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/weightmachine/horizontalbar,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "se" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = 26
@@ -3359,6 +3453,15 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"vY" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/cactus,
+/obj/item/seeds/lavaland/cactus,
+/obj/item/seeds/lavaland/cactus,
+/turf/simulated/floor/plasteel{
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "vZ" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -3558,6 +3661,15 @@
 /obj/structure/stone_tile/block/burnt,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/necropolis)
+"xx" = (
+/obj/machinery/biogenerator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "xB" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
@@ -3592,6 +3704,19 @@
 	tag = "icon-wood-broken6"
 	},
 /area/mine/laborcamp)
+"xH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "xM" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light/small{
@@ -3599,6 +3724,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/lobby)
+"xU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Labor Camp Storage"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "xV" = (
 /turf/simulated/floor/plasteel,
 /area/mine/storage)
@@ -3966,6 +4103,14 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"Ag" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Ah" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4174,6 +4319,16 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"Bf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "Bi" = (
 /obj/structure/toilet{
 	dir = 4
@@ -4457,6 +4612,13 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"CF" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "laborcamp_away";
+	name = "Labor Camp Airlock"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "CH" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -4551,6 +4713,10 @@
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
+"CV" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "CW" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -4940,6 +5106,21 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"FR" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/ember,
+/obj/item/seeds/lavaland/ember,
+/obj/item/seeds/lavaland/ember,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Labor Camp Breakroom";
+	dir = 1;
+	network = list("Labor Camp")
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "FT" = (
 /turf/simulated/wall,
 /area/mine/eva)
@@ -5046,6 +5227,17 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"Gu" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/lavaland/coaltree,
+/obj/item/seeds/lavaland/coaltree,
+/obj/item/seeds/lavaland/coaltree,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "GA" = (
 /turf/simulated/wall/indestructible/boss{
 	opacity = 0
@@ -5240,6 +5432,12 @@
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/mine/necropolis)
+"HN" = (
+/obj/machinery/door/airlock{
+	name = "Labor Camp Storage"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "HO" = (
 /obj/item/stack/ore/glass/basalt,
 /obj/effect/mapping_helpers/no_lava,
@@ -5315,6 +5513,13 @@
 /obj/structure/chair/brass,
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
+"Iy" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "IE" = (
 /turf/simulated/floor/plasteel,
 /area/mine/lobby)
@@ -5345,6 +5550,14 @@
 	icon_state = "brown"
 	},
 /area/mine/lobby)
+"Jd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock{
+	name = "Labor Camp Storage"
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "Jg" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -5432,11 +5645,38 @@
 	icon_state = "dark"
 	},
 /area/mine/lobby)
+"JK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "JN" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "browncorner"
 	},
 /area/mine/living_quarters)
+"JP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/monstermeat/goliath{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/monstermeat/goliath{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/monstermeat/goliath{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "JS" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -5528,6 +5768,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/cafeteria)
+"Ks" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/lava/lava_land_surface/lava_only,
+/area/lavaland/surface/outdoors)
 "Ku" = (
 /obj/machinery/vending/boozeomat,
 /turf/simulated/floor/wood,
@@ -5683,6 +5933,7 @@
 /obj/item/cigbutt{
 	pixel_y = 9
 	},
+/obj/machinery/vending/cola/free,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -5977,6 +6228,7 @@
 "MH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/vending/sustenance,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "MI" = (
@@ -6120,6 +6372,44 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/mine/cafeteria)
+"NJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
+"NM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/reishi,
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/wheat{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/aloe,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/obj/item/seeds/comfrey,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "NQ" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding,
@@ -7115,6 +7405,23 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"TZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/shovel/spade/wooden,
+/obj/item/cultivator/wooden,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/plant_analyzer,
+/obj/item/seeds/lavaland/fireblossom,
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "green"
+	},
+/area/mine/laborcamp)
 "Ua" = (
 /obj/machinery/door/airlock{
 	name = "Labor Camp Bathroom"
@@ -7207,6 +7514,15 @@
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"UF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	brightness_range = 6;
+	dir = 4;
+	light_range = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "UG" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
@@ -7400,7 +7716,10 @@
 /area/mine/storage)
 "VG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/sustenance,
+/obj/structure/table,
+/obj/item/lighter/random{
+	pixel_x = 2
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"
@@ -7658,6 +7977,15 @@
 	icon_state = "brown"
 	},
 /area/mine/lobby)
+"XA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/lavaland_food/fine_meal{
+	pixel_x = 4;
+	pixel_y = 14
+	},
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "XD" = (
 /obj/effect/rune{
 	color = "#DAA520";
@@ -7683,6 +8011,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/mine/cafeteria)
+"XK" = (
+/obj/structure/weightmachine/horizontalbar,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "XL" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -7824,13 +8157,18 @@
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors/necropolis)
 "YO" = (
+/obj/machinery/computer/shuttle/labor/one_way{
+	dir = 4
+	},
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/flasher{
+	id = "labor";
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "brown"
+	icon_state = "Dark"
 	},
 /area/mine/laborcamp)
 "YQ" = (
@@ -12427,8 +12765,8 @@ iu
 iu
 kn
 iu
-DH
-iu
+XT
+CF
 Kg
 iu
 bB
@@ -12684,9 +13022,9 @@ Ii
 iu
 jG
 XT
-hr
-iu
+XT
 ah
+yS
 XT
 bB
 oA
@@ -12927,10 +13265,10 @@ ta
 Cg
 Cg
 Ne
-Ne
-Ne
-Ne
-Ne
+XT
+hr
+hr
+hr
 iu
 gg
 Xf
@@ -12941,8 +13279,8 @@ GY
 iu
 kn
 iu
-iA
 XT
+CF
 Kg
 iu
 dI
@@ -13184,10 +13522,10 @@ ta
 ta
 ta
 ta
-Ne
-Ne
-Ne
-Ne
+Rn
+xx
+NJ
+Gu
 iu
 iu
 Ua
@@ -13199,7 +13537,7 @@ Rn
 lm
 iu
 YO
-fV
+ve
 yS
 nZ
 dI
@@ -13441,10 +13779,10 @@ ta
 ta
 ta
 ta
-Ne
-Ne
-Ne
-Ne
+XT
+iS
+yS
+vY
 hr
 VG
 Zp
@@ -13698,11 +14036,11 @@ ta
 ta
 ta
 ta
-Ne
-Ne
-Ne
-Ne
-hr
+XT
+iA
+lQ
+Ag
+Jd
 nX
 pj
 Bu
@@ -13955,10 +14293,10 @@ ta
 ta
 ta
 ta
-Ne
-Ne
-Ne
-Ne
+XT
+NM
+pY
+TZ
 hr
 mc
 Zp
@@ -14212,10 +14550,10 @@ ta
 ta
 ta
 ta
-Cg
-Ne
-Ne
-Ne
+XT
+qu
+JK
+FR
 iu
 iu
 hB
@@ -14469,10 +14807,10 @@ ta
 ta
 ta
 ta
-Cg
-Ne
-Ne
-Ne
+XT
+fV
+xH
+ih
 iu
 ZS
 kg
@@ -14726,10 +15064,10 @@ ta
 ta
 ta
 ta
-ta
-Ne
-Ne
-Ne
+XT
+XT
+xU
+Rn
 hr
 LW
 Pj
@@ -14983,10 +15321,10 @@ ta
 ta
 ta
 ta
-ta
-Cg
-Ne
-Ne
+iu
+go
+qM
+XA
 hr
 yc
 Pj
@@ -15240,11 +15578,11 @@ ta
 ta
 ta
 ta
-ta
-Cg
-Ne
-Ne
-hr
+XT
+sd
+Bf
+Iy
+HN
 gw
 Ab
 tv
@@ -15497,10 +15835,10 @@ ta
 ta
 ta
 ta
-ta
-Cg
-Ne
-Ne
+XT
+XK
+UF
+JP
 iu
 iH
 Va
@@ -15754,10 +16092,10 @@ ta
 ta
 ta
 ta
-ta
-Cg
-Cg
-Ne
+XT
+XT
+iu
+XT
 iu
 iu
 zJ
@@ -15997,11 +16335,11 @@ ta
 ta
 ta
 ta
-ta
-ta
-ta
-ta
-ta
+js
+bB
+bB
+bB
+bB
 ta
 ta
 ta
@@ -16251,15 +16589,15 @@ ta
 ta
 ta
 ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
+bB
+bB
+bB
+bB
+bB
+rb
+bB
+bB
+bB
 ta
 ta
 ta
@@ -16507,16 +16845,16 @@ ta
 ta
 ta
 ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
+bB
+bB
+CV
+CV
+Ks
+CV
+CV
+dB
+bB
+bB
 ta
 ta
 ta
@@ -16764,16 +17102,16 @@ ta
 ta
 ta
 ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
+bB
+kx
+CV
+CV
+CV
+CV
+CV
+CV
+bB
+bB
 ta
 ta
 ta
@@ -17021,16 +17359,16 @@ ta
 ta
 ta
 ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
+CV
+CV
+CV
+CV
+CV
+CV
+CV
+CV
+bB
+bB
 ta
 ta
 ta
@@ -17278,15 +17616,15 @@ ta
 ta
 ta
 ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
+CV
+CV
+CV
+CV
+CV
+CV
+CV
+CV
+bB
 ta
 ta
 ta
@@ -17536,14 +17874,14 @@ ta
 ta
 ta
 ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
+CV
+CV
+CV
+CV
+CV
+CV
+CV
+bs
 ta
 ta
 ta
@@ -17793,13 +18131,13 @@ ta
 ta
 ta
 ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
+CV
+CV
+CV
+CV
+CV
+CV
+dq
 ta
 ta
 ta
@@ -18050,13 +18388,13 @@ ta
 ta
 ta
 ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
+bB
+CV
+CV
+CV
+CV
+jm
+bB
 ta
 ta
 ta
@@ -18307,13 +18645,13 @@ ta
 ta
 ta
 ta
-ta
-ta
-ta
-ta
-ta
-ta
-ta
+bs
+bB
+CV
+CV
+CV
+bB
+bB
 ta
 ta
 ta


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

ЧУТКА ремапнуты все каторги на всех мапах. В них добавлена ботаника и биогенератор, что бы вампиры могли тусоватся там вместо пермы.
На всех мапах так же появилось лавогое озеро с удочкой. Тунички и столовка.
У дельты усложнен побег с каторги путем расширения реки.
Так же видо изменен шатл для уменьшения килбокса в 1 тайл

## Причина создания ПР / Почему это хорошо для игры

в процессе

## Демонстрация изменений

<img width="694" height="732" alt="image" src="https://github.com/user-attachments/assets/3e2aa5ee-78a8-452f-827a-c5c074c844e7" />
<img width="900" height="843" alt="image" src="https://github.com/user-attachments/assets/3e4602fc-bf17-48bc-bf75-bf3b6de1b015" />
<img width="849" height="843" alt="image" src="https://github.com/user-attachments/assets/41708f15-e8e1-436f-bbd8-7cdddd27badf" />
<img width="762" height="795" alt="image" src="https://github.com/user-attachments/assets/d51e8f47-99ff-4eb7-839b-9053d9fc1304" />

