### PR TITLE
bugfix: Исправление бага с заточкой колоды карт синдиката

### DIFF
--- a/code/modules/games/52card.dm
+++ b/code/modules/games/52card.dm
@@ -114,12 +114,16 @@
 	card_attack_verb = list("атаковал", "полоснул", "порезал")
 	card_resistance_flags = NONE
 	sharp = TRUE
+	var/sharpened = FALSE
 
 /obj/item/deck/cards/syndicate/sharpen_act(obj/item/whetstone/whetstone, mob/user)
+	if(sharpened)
+		return
 	name = "[whetstone.prefix] [name]"
 	card_force = clamp(card_force + whetstone.increment, 0, whetstone.max)
 	card_throwforce = clamp(card_throwforce + whetstone.increment, 0, whetstone.max)
 	set_sharpness(TRUE)
+	sharpened = TRUE
 	return TRUE
 
 

--- a/code/modules/games/52card.dm
+++ b/code/modules/games/52card.dm
@@ -114,16 +114,13 @@
 	card_attack_verb = list("атаковал", "полоснул", "порезал")
 	card_resistance_flags = NONE
 	sharp = TRUE
-	var/sharpened = FALSE
 
 /obj/item/deck/cards/syndicate/sharpen_act(obj/item/whetstone/whetstone, mob/user)
-	if(sharpened)
-		return
 	name = "[whetstone.prefix] [name]"
 	card_force = clamp(card_force + whetstone.increment, 0, whetstone.max)
 	card_throwforce = clamp(card_throwforce + whetstone.increment, 0, whetstone.max)
 	set_sharpness(TRUE)
-	sharpened = TRUE
+	item_flags |= NOSHARPENING
 	return TRUE
 
 


### PR DESCRIPTION
## Причина создания ПР

Баг с бесконечной заточкой колоды карт: `sharpened sharpened sharpened sharpened sharpened sharpened sharpened sharpened sharpened suspicious deck of cards`

## Исправление

Добавлено поле `sharpened` для отслеживания заточки колоды.