### PR TITLE
bugfix: kidan thief antaghud

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -28,7 +28,7 @@
 #define DIAG_PATH_HUD 		"23"//Bot path indicators
 #define GLAND_HUD 			"24"//Gland indicators for abductors
 #define THOUGHT_HUD			"25"//Telepathy bubbles
-#define KIDAN_PHEROMONES_HUD	"26"//Kidan pheromones hud
+#define KIDAN_PHEROMONES_HUD	"pheromone_hud" // Kidan pheromones hud
 
 //by default everything in the hud_list of an atom is an image
 //a value in hud_list with one of these will change that behavior


### PR DESCRIPTION
## Описание
конфликт antag_hud_type у thief и киданов (26 и 26), поэтому перевел худ феромонов на феромон_хад
пока что делаю так ток у киданов, другие худы лучше менять с полноценными тестами

## Причина создания ПР / Почему это хорошо для игры
баг, нету антагхуда у воров киданов при юзе феромонов

[2025-07-20 15:17:54.226] Runtime in code/modules/antagonists/_common/antag_datum.dm,265: undefined proc or verb /datum/atom_hud/kidan_pheromones/join hud().