### PR TITLE
bugfix: Событие vent_clog больше не игнорит заваренные венты

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -20,7 +20,11 @@
 
 /datum/event/vent_clog/tick()
 	if(activeFor % interval == 0)
-		var/obj/vent = pick_n_take(vents)
+		var/obj/machinery/atmospherics/unary/vent_scrubber/vent = pick_n_take(vents)
+
+		if(!vent || vent.welded)
+			endWhen++
+			return
 
 		var/list/gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","psilocybin","lube",
 							"atrazine","banana","charcoal","space_drugs","methamphetamine","holywater","ethanol","hot_coco","facid",


### PR DESCRIPTION
## Описание
Событие vent_clog больше не игнорит заваренные венты.

## Причина создания ПР / Почему это хорошо для игры

## Демонстрация изменений

## Тесты
