### PR TITLE
bugfix: Исправление бага с ускорителем масс

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1125,13 +1125,15 @@
 
 /atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = INFINITY, dodgeable = TRUE)
 	var/list/speed_mods = list()
-	SEND_SIGNAL(thrower, COMSIG_GET_THROW_SPEED_MODIFIERS, speed_mods)
+	if(istype(thrower))
+		SEND_SIGNAL(thrower, COMSIG_GET_THROW_SPEED_MODIFIERS, speed_mods)
 	for(var/mod in speed_mods)
 		speed *= mod
 
 	var/list/range_deltas = list()
 	if(range > 1)
-		SEND_SIGNAL(thrower, COMSIG_GET_THROW_RANGE_DELTAS, range_deltas)
+		if(istype(thrower))
+			SEND_SIGNAL(thrower, COMSIG_GET_THROW_RANGE_DELTAS, range_deltas)
 		for(var/delta in range_deltas)
 			range += delta
 


### PR DESCRIPTION

## Причина создания ПР / Почему это хорошо для игры

Проблема ввозникает потому что в проке /atom/movable/proc/throw_at передается thrower как mob, и при попытке отправки сигнала COMSIG_GET_THROW_SPEED_MODIFIERS возникает ошибка где то там.


## Исправление

Добавил проверки istype(thrower) перед отправкой сигналов связанных с мускулами.
