### PR TITLE
add: Изменениие емагнутых слотмашин

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -18657,7 +18657,7 @@
 	},
 /area/atmos)
 "ciu" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "caution"
@@ -22639,7 +22639,7 @@
 	},
 /area/maintenance/turbine)
 "cCO" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
 "cCP" = (
@@ -23649,7 +23649,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/controlroom)
 "cGF" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/carpet/black,
@@ -48025,7 +48025,7 @@
 /turf/simulated/wall,
 /area/crew_quarters/kitchen)
 "fUv" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
 "fUO" = (
@@ -62910,7 +62910,7 @@
 /area/security/securearmory)
 "juy" = (
 /obj/machinery/light/small,
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
 "juL" = (
@@ -93247,7 +93247,7 @@
 	},
 /area/hallway/primary/central/sw)
 "qvt" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/magestavern.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/magestavern.dmm
@@ -437,7 +437,7 @@
 /turf/simulated/floor/wood,
 /area/ruin/unpowered)
 "tm" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/wood,
 /area/ruin/unpowered)
 "tr" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebotany.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebotany.dmm
@@ -1014,7 +1014,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacebotany/GardenMaint)
 "mV" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp_laboratory.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp_laboratory.dmm
@@ -3481,7 +3481,7 @@
 	},
 /area/ruin/ussp_xeno/entrance)
 "UO" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light_switch{
 	pixel_x = -19;

--- a/_maps/map_files/RandomZLevels/academy.dmm
+++ b/_maps/map_files/RandomZLevels/academy.dmm
@@ -6335,7 +6335,7 @@
 /turf/simulated/floor/carpet/black,
 /area/awaymission/academy/headmaster)
 "VZ" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "green"
@@ -6412,7 +6412,7 @@
 	},
 /area/awaymission/academy/classrooms)
 "WO" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "green"

--- a/_maps/map_files/RandomZLevels/evil_santa.dmm
+++ b/_maps/map_files/RandomZLevels/evil_santa.dmm
@@ -4288,7 +4288,7 @@
 	},
 /area/vision_change_area/awaymission/evil_santa/mine)
 "Kv" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/wood/fancy,
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "Kx" = (

--- a/_maps/map_files/celestation/celestation.dmm
+++ b/_maps/map_files/celestation/celestation.dmm
@@ -14350,7 +14350,7 @@
 	},
 /area/atmos)
 "bVa" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/wood/fancy/oak,
 /area/maintenance/gambling_den2)
 "bVc" = (
@@ -47511,7 +47511,7 @@
 	pixel_y = -32;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/wood/fancy/oak,
 /area/maintenance/gambling_den2)
 "hHP" = (
@@ -99096,7 +99096,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
 "rKY" = (
@@ -123066,7 +123066,7 @@
 	},
 /area/medical/morgue)
 "wot" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/machinery/camera{
 	c_tag = "Bar East";
 	dir = 8

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -15038,7 +15038,7 @@
 	},
 /area/atmos)
 "bVa" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/wood/fancy/oak,
 /area/maintenance/gambling_den2)
 "bVc" = (
@@ -40022,7 +40022,7 @@
 	pixel_y = -32;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/wood/fancy/oak,
 /area/maintenance/gambling_den2)
 "hHP" = (
@@ -75801,7 +75801,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "rKY" = (
@@ -91293,7 +91293,7 @@
 	},
 /area/hallway/primary/fore/west)
 "wot" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "woF" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -25179,7 +25179,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bFe" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "bFf" = (
@@ -57960,7 +57960,7 @@
 /turf/simulated/floor/glass,
 /area/maintenance/server)
 "eXx" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint)
 "eYH" = (
@@ -69797,7 +69797,7 @@
 	},
 /area/toxins/xenobiology)
 "mDw" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "mDU" = (

--- a/_maps/map_files/event/Station/coldcolony.dmm
+++ b/_maps/map_files/event/Station/coldcolony.dmm
@@ -4998,7 +4998,7 @@
 /turf/simulated/floor/plating,
 /area/coldcolony/malta/resid_serv/crew_quarters/fitness)
 "bPH" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plating,
 /area/coldcolony/malta/maintenance/bar)
 "bPY" = (
@@ -6707,7 +6707,7 @@
 /turf/simulated/floor/plating,
 /area/coldcolony/malta/maintenance/servicegen)
 "cwk" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/carpet,
 /area/coldcolony/malta/maintenance/casino)
 "cwm" = (
@@ -30707,7 +30707,7 @@
 /area/coldcolony/malta/bridge/vip)
 "lma" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plating,
 /area/coldcolony/malta/maintenance/casino)
 "lmc" = (
@@ -33572,7 +33572,7 @@
 /area/coldcolony/malta/research/shallway)
 "msd" = (
 /obj/machinery/light/small,
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/carpet,
 /area/coldcolony/malta/maintenance/casino)
 "msF" = (
@@ -34462,7 +34462,7 @@
 /turf/simulated/floor/wood/fancy/birch,
 /area/coldcolony/malta/bridge/checkpoint)
 "mKG" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/carpet,
 /area/coldcolony/malta/resid_serv/bar/atrium)
 "mLe" = (
@@ -54971,7 +54971,7 @@
 	},
 /area/coldcolony/malta/hallway/service/south)
 "ufD" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -59335,7 +59335,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plating,
 /area/coldcolony/malta/maintenance/casino)
 "vHz" = (

--- a/_maps/map_files/event/Station/delta_old.dmm
+++ b/_maps/map_files/event/Station/delta_old.dmm
@@ -4676,7 +4676,7 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aOs" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
 "aOu" = (
@@ -18178,7 +18178,7 @@
 	},
 /area/atmos)
 "ciu" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "caution"
@@ -35666,7 +35666,7 @@
 /turf/simulated/floor/wood,
 /area/blueshield)
 "dFm" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/atrium)
 "dFn" = (
@@ -35741,7 +35741,7 @@
 /obj/machinery/camera{
 	c_tag = "Theatre"
 	},
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar/atrium)
 "dFx" = (
@@ -35837,7 +35837,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dFW" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
@@ -37234,7 +37234,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
 "dLD" = (
@@ -86994,7 +86994,7 @@
 	},
 /area/hallway/primary/central/sw)
 "qvt" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},

--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -6893,7 +6893,7 @@
 	},
 /area/shuttle/administration)
 "djz" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -29497,7 +29497,7 @@
 	},
 /area/syndicate_mothership)
 "nKO" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/wood,
 /area/centcom/zone1)
 "nKV" = (
@@ -34768,7 +34768,7 @@
 	},
 /area/shuttle/trade/sol)
 "qkl" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -41049,7 +41049,7 @@
 	},
 /area/shuttle/escape)
 "sWF" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -48645,7 +48645,7 @@
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
 "wqc" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = 7

--- a/_maps/map_files/generic/z2_old.dmm
+++ b/_maps/map_files/generic/z2_old.dmm
@@ -8162,7 +8162,7 @@
 	},
 /area/centcom/zone1)
 "ghO" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/item/radio/intercom{
 	pixel_y = 30
 	},
@@ -15911,7 +15911,7 @@
 	},
 /area/syndicate_mothership)
 "lFi" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/indestructible{
 	icon_state = "grimy"
 	},

--- a/_maps/map_files/nova/nova.dmm
+++ b/_maps/map_files/nova/nova.dmm
@@ -31471,7 +31471,7 @@
 	},
 /area/security/warden)
 "eAR" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
@@ -86928,7 +86928,7 @@
 	},
 /area/maintenance/trading)
 "mRf" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
@@ -113277,7 +113277,7 @@
 	},
 /area/security/brigstaff)
 "qHF" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/siding/wood{
 	do_not_delete_me = 1
 	},
@@ -145077,7 +145077,7 @@
 "vls" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "vlt" = (
@@ -160246,7 +160246,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "xzt" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},

--- a/_maps/map_files/shuttles/admin_club.dmm
+++ b/_maps/map_files/shuttles/admin_club.dmm
@@ -165,7 +165,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "navybluealt"
@@ -311,7 +311,7 @@
 	},
 /area/shuttle/administration)
 "za" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "navybluealt"
@@ -425,7 +425,7 @@
 	},
 /area/shuttle/administration)
 "FQ" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "navybluealt"

--- a/_maps/map_files/templates/piratbase.dmm
+++ b/_maps/map_files/templates/piratbase.dmm
@@ -1173,7 +1173,7 @@
 	},
 /area/ruin/space/pirate_base/kitchen)
 "dc" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/pirate_base/entertainment)
 "dd" = (
@@ -5588,7 +5588,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/pirate_base/prison_solar)
 "pv" = (
-/obj/machinery/slot_machine,
+/obj/machinery/computer/slot_machine,
 /obj/structure/sign/poster/contraband/have_a_puff{
 	pixel_x = -32
 	},

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -703,7 +703,10 @@
 				return
 
 			to_chat(user, span_notice("You connect the monitor."))
-			new circuit.build_path(get_turf(src), src)
+			if(circuit.build_path)
+				new circuit.build_path(get_turf(src), src)
+			else
+				to_chat(user, span_warning("You connect the monitor, but it doesn't work. Maybe the circuit is broken?"))
 
 
 /obj/structure/computerframe/wirecutter_act(mob/living/user, obj/item/I)

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -242,6 +242,11 @@
 	build_path = /obj/machinery/computer/arcade/orion_trail
 	origin_tech = "programming=1"
 
+/obj/item/circuitboard/arcade/slotmachine
+	board_name = "Slotmachine"
+	build_path = /obj/machinery/computer/slot_machine
+	origin_tech = "programming=1"
+
 /obj/item/circuitboard/solar_control
 	board_name = "Solar Control"
 	build_path = /obj/machinery/power/solar_control

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -34,10 +34,10 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 		return credits * EMAGGED_SLOT_MACHINE_PRIZE_MOD
 	return credits
 
-/datum/slotmachine_prize/proc/apply_effect(obj/machinery/slot_machine/slotmachine, mob/user, prize_credits)
+/datum/slotmachine_prize/proc/apply_effect(obj/machinery/computer/slot_machine/slotmachine, mob/user, prize_credits)
 	//Do nothing by default
 
-/datum/slotmachine_prize/proc/apply_emagged_effect(obj/machinery/slot_machine/slotmachine, mob/user)
+/datum/slotmachine_prize/proc/apply_emagged_effect(obj/machinery/computer/slot_machine/slotmachine, mob/user)
 	if(!length(available_prizes))
 		to_chat(user, "Кажется ваш приз затерялся в блюспейс аномалии!")
 		return
@@ -50,7 +50,7 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 	resultlvl = "orange"
 	custom_result = "Неудача!"
 
-/datum/slotmachine_prize/lose/apply_emagged_effect(obj/machinery/slot_machine/slotmachine, mob/user)
+/datum/slotmachine_prize/lose/apply_emagged_effect(obj/machinery/computer/slot_machine/slotmachine, mob/user)
 	if(!isliving(user))
 		return
 	var/mob/living/target = user
@@ -94,7 +94,7 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 	say_phrase = "Победитель!"
 	sound = 'sound/goonstation/misc/bell.ogg'
 
-/datum/slotmachine_prize/medium/apply_emagged_effect(obj/machinery/slot_machine/slotmachine, mob/user)
+/datum/slotmachine_prize/medium/apply_emagged_effect(obj/machinery/computer/slot_machine/slotmachine, mob/user)
 	slotmachine.give_custom_prize(user, /obj/item/storage/box/random_syndi)
 
 
@@ -122,15 +122,15 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 	say_phrase = "ДЖЕКПОТ!"
 	sound = 'sound/goonstation/misc/airraid_loop.ogg'
 
-/datum/slotmachine_prize/jackpot/apply_effect(obj/machinery/slot_machine/slotmachine, mob/user, prize_credits)
+/datum/slotmachine_prize/jackpot/apply_effect(obj/machinery/computer/slot_machine/slotmachine, mob/user, prize_credits)
 	GLOB.minor_announcement.announce("Поздравляем [user.name] с выигрышем джекпота в [prize_credits] кредитов!", "Обладатель джекпота!")
 
-/datum/slotmachine_prize/jackpot/apply_emagged_effect(obj/machinery/slot_machine/slotmachine, mob/user)
+/datum/slotmachine_prize/jackpot/apply_emagged_effect(obj/machinery/computer/slot_machine/slotmachine, mob/user)
 	slotmachine.give_custom_prize(user, /obj/item/radio/uplink)
 
 
 
-/obj/machinery/slot_machine
+/obj/machinery/computer/slot_machine
 	name = "slot machine"
 	desc = "Gambling for the antisocial."
 	icon = 'icons/obj/economy.dmi'
@@ -143,11 +143,11 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 	var/result = null
 	var/resultlvl = null
 
-/obj/machinery/slot_machine/attack_hand(mob/user as mob)
+/obj/machinery/computer/slot_machine/attack_hand(mob/user as mob)
 	add_fingerprint(user)
 	ui_interact(user)
 
-/obj/machinery/slot_machine/emag_act(mob/user)
+/obj/machinery/computer/slot_machine/emag_act(mob/user)
 	. = ..()
 	if(emagged)
 		return
@@ -155,17 +155,17 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 	to_chat(user, span_warning("Smells like something burnt"))
 	emagged = TRUE
 
-/obj/machinery/slot_machine/update_icon_state()
+/obj/machinery/computer/slot_machine/update_icon_state()
 	icon_state = "slots-[working ? "on" : "off"]"
 
 
-/obj/machinery/slot_machine/ui_interact(mob/user, datum/tgui/ui = null)
+/obj/machinery/computer/slot_machine/ui_interact(mob/user, datum/tgui/ui = null)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "SlotMachine", name)
 		ui.open()
 
-/obj/machinery/slot_machine/ui_data(mob/user)
+/obj/machinery/computer/slot_machine/ui_data(mob/user)
 	var/list/data = list()
 	// Get account
 	account = get_card_account(user)
@@ -178,7 +178,7 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 	data["resultlvl"] = resultlvl
 	return data
 
-/obj/machinery/slot_machine/ui_act(action, params)
+/obj/machinery/computer/slot_machine/ui_act(action, params)
 	if(..())
 		return
 	add_fingerprint(usr)
@@ -196,18 +196,18 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 		playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 		addtimer(CALLBACK(src, PROC_REF(spin_slots), usr), 25)
 
-/obj/machinery/slot_machine/proc/get_prize_coefficient()
+/obj/machinery/computer/slot_machine/proc/get_prize_coefficient()
 	if(emagged)
 		return EMAGGED_SLOT_MACHINE_PRIZE_MOD
 	return 1
 
-/obj/machinery/slot_machine/proc/apply_emagged_lose_effect(mob/user)
+/obj/machinery/computer/slot_machine/proc/apply_emagged_lose_effect(mob/user)
 	if(!isliving(user))
 		return
 	var/mob/living/target = user
 	target.adjust_slot_machine_lose_effect()
 
-/obj/machinery/slot_machine/proc/spin_slots(mob/user)
+/obj/machinery/computer/slot_machine/proc/spin_slots(mob/user)
 	if(!istype(user))
 		return
 	var/prize = detect_result()
@@ -216,7 +216,7 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 	update_icon(UPDATE_ICON_STATE)
 	SStgui.update_uis(src) // Push a UI update
 
-/obj/machinery/slot_machine/proc/apply_spin_result(mob/user, datum/slotmachine_prize/prizedatum)
+/obj/machinery/computer/slot_machine/proc/apply_spin_result(mob/user, datum/slotmachine_prize/prizedatum)
 	if(!prizedatum || !istype(prizedatum))
 		do_sparks(1, TRUE, src)
 		atom_say("Ошибка!")
@@ -235,7 +235,7 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 	if(emagged)
 		prizedatum.apply_emagged_effect(src, user)
 
-/obj/machinery/slot_machine/proc/detect_result()
+/obj/machinery/computer/slot_machine/proc/detect_result()
 	// Convert prize chance to weigth logic
 	var/total = 0
 	for(var/prize_id in GLOB.slotmachine_prizes)
@@ -251,50 +251,50 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 	// if any other cases
 	return GLOB.slotmachine_prizes["lose"]
 
-/obj/machinery/slot_machine/verb/test_lose()
+/obj/machinery/computer/slot_machine/verb/test_lose()
 	set name = "Проверить lose"
 	set category = STATPANEL_OBJECT
 	apply_spin_result(usr, "lose")
 
-/obj/machinery/slot_machine/verb/test_minimal()
+/obj/machinery/computer/slot_machine/verb/test_minimal()
 	set name = "Проверить minimal"
 	set category = STATPANEL_OBJECT
 	apply_spin_result(usr, "minimal")
 
-/obj/machinery/slot_machine/verb/test_small()
+/obj/machinery/computer/slot_machine/verb/test_small()
 	set name = "Проверить small"
 	set category = STATPANEL_OBJECT
 	apply_spin_result(usr, "small")
 
-/obj/machinery/slot_machine/verb/test_medium()
+/obj/machinery/computer/slot_machine/verb/test_medium()
 	set name = "Проверить medium"
 	set category = STATPANEL_OBJECT
 	apply_spin_result(usr, "medium")
 
-/obj/machinery/slot_machine/verb/test_big()
+/obj/machinery/computer/slot_machine/verb/test_big()
 	set name = "Проверить big"
 	set category = STATPANEL_OBJECT
 	apply_spin_result(usr, "big")
 
-/obj/machinery/slot_machine/verb/test_jackpot()
+/obj/machinery/computer/slot_machine/verb/test_jackpot()
 	set name = "Проверить jackpot"
 	set category = STATPANEL_OBJECT
 	apply_spin_result(usr, "jackpot")
 
-/obj/machinery/slot_machine/proc/win_money(amt, sound='sound/machines/ping.ogg')
+/obj/machinery/computer/slot_machine/proc/win_money(amt, sound='sound/machines/ping.ogg')
 	if(sound)
 		playsound(loc, sound, 55, 1)
 	if(!account)
 		return
 	account.credit(amt, "Slot Winnings", "Slot Machine", account.owner_name)
 
-/obj/machinery/slot_machine/proc/give_custom_prize(mob/user, obj/item/prize)
+/obj/machinery/computer/slot_machine/proc/give_custom_prize(mob/user, obj/item/prize)
 	var/item = new prize(get_turf(src)) // Create item on slot machine turf
 	var/mob/living/carbon/human/carbon_user = user
 	if(istype(carbon_user)) // If living carbon - put in hands
 		carbon_user.put_in_any_hand_if_possible(item)
 
-/obj/machinery/slot_machine/wrench_act(mob/user, obj/item/I)
+/obj/machinery/computer/slot_machine/wrench_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -146,6 +146,7 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 	icon_state = "slots-off"
 	anchored = TRUE
 	density = TRUE
+	circuit = /obj/item/circuitboard/arcade/slotmachine
 	var/plays = 0
 	var/working = 0
 	var/datum/money_account/account = null
@@ -162,6 +163,8 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 		return
 	do_sparks(3, TRUE, src)
 	to_chat(user, span_warning("Smells like something burnt"))
+	circuit = /obj/item/circuitboard/broken
+	frame.circuit = new circuit(frame)
 	emagged = TRUE
 
 /obj/machinery/computer/slot_machine/update_icon_state()
@@ -308,3 +311,6 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 	if(!I.tool_use_check(user, 0))
 		return
 	default_unfasten_wrench(user, I)
+
+/obj/machinery/computer/slot_machine/screwdriver_act(mob/user, obj/item/I)
+	. = TRUE

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -54,7 +54,16 @@ GLOBAL_LIST_EMPTY(slotmachine_prizes)
 	if(!isliving(user))
 		return
 	var/mob/living/target = user
-	target.adjust_slot_machine_lose_effect()
+	var/gibbed = target.adjust_slot_machine_lose_effect()
+	if(!gibbed)
+		return
+	var/location = slotmachine.loc
+	do_sparks(3, TRUE, slotmachine)
+	qdel(slotmachine)
+	new /obj/item/stack/sheet/metal(location, 5)
+	new /obj/item/shard(location)
+	new /obj/item/shard(location)
+	explosion(location, 0, 0, 1, cause = "Emagged slotmachine self-destroy")
 
 
 /datum/slotmachine_prize/minimal

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -986,11 +986,12 @@
 		updatehealth()
 	. -= amount //if there's leftover healing, remove it from what we return
 
-/// Emagged slotmachine default lose effect
+/// Emagged slotmachine default lose effect, return TRUE to destroy slotmachine
 /mob/living/proc/adjust_slot_machine_lose_effect()
 	if (prob(EMAGGED_SLOT_MACHINE_GIB_CHANCE))
 		to_chat(src, span_warningbig("Критическая неудача!<br>Неизвестная сила разрывает ваше тело изнутри."))
 		src.gib()
-		return
+		return TRUE
 	to_chat(src, span_warning("Неудача! Вы ощущаете слабость, потянув за рычаг, надеюсь оно того стоило."))
 	src.adjustCloneLoss(5)
+	return FALSE

--- a/code/modules/mob/living/silicon/ai/ai_defense.dm
+++ b/code/modules/mob/living/silicon/ai/ai_defense.dm
@@ -11,6 +11,7 @@
 	if (prob(EMAGGED_SLOT_MACHINE_GIB_CHANCE))
 		to_chat(src, span_warningbig("Критическая неудача!<br>Неизвестная сила заставляет вас отключиться."))
 		src.death() // AI gib cause no body ghost error
-		return
+		return TRUE
 	to_chat(src, span_warning("Неудача! [src.name] получает видимые повреждения."))
 	src.adjustBruteLoss(rand(15, 20))
+	return FALSE

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -73,15 +73,16 @@
 	if (prob(EMAGGED_SLOT_MACHINE_GIB_CHANCE))
 		to_chat(src, span_warningbig("Критическая неудача!<br>Неизвестная сила разрушает ваш корпус."))
 		src.gib()
-		return
+		return TRUE
 	if (prob(EMAGGED_SLOT_MACHINE_ROBOT_BREAK_COMPONENT_CHANCE))
 		to_chat(src, span_warning("Неудача! Из корпуса [src.name] вылетают искры."))
 		do_sparks(3, TRUE, src)
 		src.destroy_random_component()
-		return
+		return FALSE
 	to_chat(src, span_warning("Неудача! [src.name] получает видимые повреждения."))
 	do_sparks(3, TRUE, src)
 	src.adjustBruteLoss(rand(15, 20))
+	return FALSE
 
 
 /mob/living/silicon/robot/proc/get_damaged_components(get_brute, get_burn, get_borked = FALSE, get_missing = FALSE)

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -484,7 +484,7 @@
 
 /datum/design/slotmachine
 	name = "Machine Board (Slotmachine Arcade)"
-	desc = "Allows for the construction of circuit boards used to build a new Slotmachine."
+	desc = "Позволяет изготавливать схемы, используемые для сборки новой слот-машины."
 	id = "arcadeslotmachine"
 	req_tech = list("programming" = 1)
 	build_type = IMPRINTER

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -486,7 +486,7 @@
 	name = "Machine Board (Slotmachine Arcade)"
 	desc = "Позволяет изготавливать схемы, используемые для сборки новой слот-машины."
 	id = "arcadeslotmachine"
-	req_tech = list("programming" = 1)
+	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/arcade/slotmachine

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -482,6 +482,16 @@
 	build_path = /obj/item/circuitboard/deepfryer
 	category = list("Misc. Machinery")
 
+/datum/design/slotmachine
+	name = "Machine Board (Slotmachine Arcade)"
+	desc = "Allows for the construction of circuit boards used to build a new Slotmachine."
+	id = "arcadeslotmachine"
+	req_tech = list("programming" = 1)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000)
+	build_path = /obj/item/circuitboard/arcade/slotmachine
+	category = list("Misc. Machinery")
+
 /datum/design/orion_trail
 	name = "Machine Board (Orion Trail Arcade Machine)"
 	desc = "Allows for the construction of circuit boards used to build a new Orion Trail machine."


### PR DESCRIPTION
## Описание

Исправление емагнутой слотмашины:
1. Сломашина теперь является компьютером и может быть собрана из платы
2. Плата печатается как и платы остальных аркадных игр
3. При пересборке слотмашины эффект емага исчезает
4. При выпадении гиба куклы - происходит самоуичтожение слотмашины (очень слабый взрыв и искры).

## Причина создания ПР / Почему это хорошо для игры

<img width="1070" height="102" alt="image" src="https://github.com/user-attachments/assets/e71d520f-cd99-49b8-9365-0cf2cd26648a" />

<img width="760" height="90" alt="image" src="https://github.com/user-attachments/assets/7a3ba98d-d5cb-4d6f-ae73-b60ffd47a3ac" />

<img width="522" height="83" alt="image" src="https://github.com/user-attachments/assets/088c2ae9-302b-41f5-a278-e6d2a32fca5c" />

Ветка обсуждения:
https://discord.com/channels/617003227182792704/1397068086661611562


## Тесты

Проверил на локалке, проблем не увидел.
