### PR TITLE
balance: Блок заморозки пиро аномалии при стабильности 50+

### DIFF
--- a/code/modules/anomalies/impulses/atmosferics.dm
+++ b/code/modules/anomalies/impulses/atmosferics.dm
@@ -55,6 +55,7 @@
 /datum/anomaly_impulse/freese
 	name = "Заморозка"
 	desc = "Аномалия выпускает водяной пар понижает температуру окружающей среды, что приводит к образованию льда на полу."
+	stability_high = 50
 	/// Minimum range of effect.
 	var/range_low = 0
 	/// Maximum range of effect.


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Импульс создания воды вокруг пиро аномалии и понижения температуры воздуха теперь отключается при стабильности от 50.
Позволяет использовать аномалию в качестве двигателя станции (через турбину). До этого все ломалось из-за понижения температуры.
Также при стабилизации аномалии, накопленная вокруг плазма больше не будет тушиться, что сделает стабилизацию пиро аномалий чуть более динамичной.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
В дискорде попросили. Думаю будет прикольно если пару раундов сделают двигатель на аномалии. 
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
