### PR TITLE
balance: Промахи для дальнобойного оружия

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -524,11 +524,13 @@
 		return !density || body_position == LYING_DOWN
 	// always hitting dense/standing mobs
 	if(density || body_position == STANDING_UP)
-		var/def_zone_hit_chance = projectile_def_zone_hit_chance(projectile.def_zone)
+		var/def_zone_hit_chance = projectile.calculate_hit_chance(src)
 		return !prob(def_zone_hit_chance)
 	// otherwise chance to hit is defined by the projectile var/hit_crawling_mobs_chance
 	if(projectile.hit_crawling_mobs_chance > 0 && projectile.hit_crawling_mobs_chance <= 100)
-		return !prob(projectile.hit_crawling_mobs_chance)
+		var/def_zone_hit_chance = projectile.calculate_hit_chance(src)
+		var/total_hit_chance = projectile.hit_crawling_mobs_chance * def_zone_hit_chance / 100
+		return !prob(total_hit_chance)
 	return TRUE
 
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -524,7 +524,8 @@
 		return !density || body_position == LYING_DOWN
 	// always hitting dense/standing mobs
 	if(density || body_position == STANDING_UP)
-		return FALSE
+		var/def_zone_hit_chance = projectile_def_zone_hit_chance(projectile.def_zone)
+		return !prob(def_zone_hit_chance)
 	// otherwise chance to hit is defined by the projectile var/hit_crawling_mobs_chance
 	if(projectile.hit_crawling_mobs_chance > 0 && projectile.hit_crawling_mobs_chance <= 100)
 		return !prob(projectile.hit_crawling_mobs_chance)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -527,8 +527,12 @@
 		return FALSE
 	return TRUE
 
-
-/proc/projectile_def_zone_hit_chance(def_zone)
+/obj/projectile/proc/calculate_hit_chance(mob/living/target)
+	if(forced_accuracy)
+		return 100
+	var/distance = get_dist(firer, target)
+	if(distance < 2) //point-back shot (diagonal dist is 1.414)
+		return 100
 	switch(def_zone)
 		if(BODY_ZONE_CHEST)
 			return 100

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -526,3 +526,15 @@
 	if(reflectability < desired_reflectability_level)
 		return FALSE
 	return TRUE
+
+
+/proc/projectile_def_zone_hit_chance(def_zone)
+	switch(def_zone)
+		if(BODY_ZONE_CHEST)
+			return 100
+		if(BODY_ZONE_HEAD)
+			return 75
+		if(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
+			return 50
+		else
+			return 50


### PR DESCRIPTION
## Описание

Промахи для дальнобойного оружия основанные на вероятности.

### Шансы
**Выстрелы со снайперки** - 100% шанс попадания в любую часть тела.
**Выстрелы в упор** - 100% шанс попадания в любую часть тела.
**Выстрел в туловище** - 100% шанс попадания.
**Выстрел в руку/ногу/кисть/стопу** - 50% шанс попасть
**Выстрел в голову** - 75% шанс попадания

## Причина создания ПР / Почему это хорошо для игры

https://discord.com/channels/617003227182792704/618952559607939072/1396380717537038507

## Тесты
Проверил на локалке, промахи работают, теперь лучше стрелять в голову или тело.

*на подходе пр с улучшением промахов на просчет точности в зависимости от оружия, дальности и части тела.*
