### PR TITLE
bugfix: Фикс клонирования пушек и патронов

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -11,6 +11,7 @@
 	)
 	icon = 'icons/obj/weapons/ammo.dmi'
 	icon_state = "s-casing"
+	origin_tech = "materials=3;combat=3"
 	flags = CONDUCT
 	slot_flags = ITEM_SLOT_BELT
 	throwforce = 1
@@ -161,6 +162,7 @@
 	)
 	icon_state = "357"
 	icon = 'icons/obj/weapons/ammo.dmi'
+	origin_tech = "materials=3;combat=3"
 	flags = CONDUCT
 	slot_flags = ITEM_SLOT_BELT
 	item_state = "syringe_kit"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -13,7 +13,7 @@
 	throw_speed = 3
 	throw_range = 5
 	force = 5
-	origin_tech = "combat=1"
+	origin_tech = "materials=3;combat=3"
 	needs_permit = TRUE
 	attack_verb = list("ударил")
 	pickup_sound = 'sound/items/handling/pickup/gun_pickup.ogg'


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

Больше нельзя клонировать никакие пушки, магазины, или патроны(если их техи не изменены индивидуально чтобы быть ниже 4)

## Причина создания ПР / Почему это хорошо для игры
Потому что клонировать пушки и патроны это кринж и плохо для игры. Это было добавлено без взгляда назад и расстановку техов всему что можно абузить, в итоге люди клонируют себе магазины дигло стечкинов и пулеметы. При том что сам механ клонирования не требует вообщем-то ничего и риска для игрока (помимо 50 урона) а странные объекты спавнятся бесконечно.
<img width="637" height="357" alt="image" src="https://github.com/user-attachments/assets/462df579-f174-45c3-8248-fcae0bbf34a7" />

<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
Потому что игроки не должны бесплатно и без усилий и без последствий получать крутой лут

## Тесты
Попытался склонировать рандомные патроны и пушки. Ничего не клонируется