### PR TITLE
add: Отключение наблюдения ИИ через нательные камеры.

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -340,7 +340,7 @@
 	alarm_on = FALSE
 	SSalarm.cancelAlarm("Camera", get_area(src), src)
 
-/obj/machinery/camera/proc/can_use()
+/obj/machinery/camera/proc/can_use(mob/user)
 	if(!status)
 		return 0
 	if(stat & EMPED)
@@ -438,6 +438,15 @@
 		cam["y"] = 0
 		cam["z"] = 0
 	return cam
+
+
+/obj/machinery/camera/proc/can_AI_see(mob/living/silicon/ai/ai)
+	if(!ai)
+		return TRUE
+
+	var/list/tempnetwork = network & ai.network
+	return tempnetwork.len > 0
+
 
 /obj/machinery/camera/get_remote_view_fullscreens(mob/user)
 	if(view_range == short_range) //unfocused

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -25,9 +25,10 @@
 	var/list/T = list()
 
 	for(var/obj/machinery/camera/C in L)
-		var/list/tempnetwork = C.network & src.network
-		if(tempnetwork.len)
-			T[text("[][]", C.c_tag, (C.can_use() ? null : " (Deactivated)"))] = C
+		if(!C.can_AI_see(src))
+			continue
+
+		T[text("[][]", C.c_tag, (C.can_use() ? null : " (Deactivated)"))] = C
 
 	track.cameras = T
 	return T

--- a/code/modules/mining/equipment/mining_medic.dm
+++ b/code/modules/mining/equipment/mining_medic.dm
@@ -2,6 +2,13 @@
 Almost every mining medic related stuff
 */
 
+/obj/machinery/camera/portable/no_ai
+
+
+/obj/machinery/camera/portable/no_ai/can_AI_see(ai)
+	return FALSE
+
+
 /obj/item/clothing/accessory/camera
 	name = "mining camera"
 	desc = "Небольшая нагрудная видеокамера, обладающая массивным датчиком, позволяющим считывать датчики костюма с основной станции. \
@@ -26,7 +33,7 @@ Almost every mining medic related stuff
 	/// Is our camera on
 	var/on = FALSE
 	/// Our portable camera
-	var/obj/machinery/camera/portable/camera
+	var/obj/machinery/camera/portable/no_ai/camera
 	/// Can we see camera from intertainment network?
 	var/news_feed = FALSE
 	/// Main feed network

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -68,7 +68,7 @@
 
 	for(var/z_level in lower_z to upper_z)
 		for(var/obj/machinery/camera/current_camera as anything in cameras["[z_level]"])
-			if(!current_camera || !current_camera.can_use())
+			if(!current_camera || !current_camera.can_use() || !current_camera.can_AI_see())
 				continue
 
 			var/turf/point = locate(src.x + (CHUNK_SIZE / 2), src.y + (CHUNK_SIZE / 2), z_level)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Отключение наблюдения ИИ через нательные камеры. Не отображаются в списке на телепортацию (если раньше отображались).
Не открывают "туман войны".
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР 
Зюзя попросил сделать. Он автор.
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Создал камеру в области невидимой для ИИ, включил, область осталась невидимой. В дебаге соответствующая камера была пропущена при обновлении "тумана".
Наблюдение через монитор сб и телик не поломалось.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
