### PR TITLE
add: Свет мониторов зависит от цвета

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -14,8 +14,8 @@
 	var/obj/structure/computerframe/frame = /obj/structure/computerframe
 	var/icon_keyboard = "generic_key"
 	var/icon_screen = "generic"
-	var/light_range_on = 1
-	var/light_power_on = 0.7
+	var/light_range_on = 2
+	var/light_power_on = 0.9
 	var/abductor = FALSE
 	/// Are we in the middle of a flicker event?
 	var/flickering = FALSE
@@ -126,6 +126,13 @@
 		. += "[icon_keyboard]"
 		underlays += emissive_appearance(icon, "[icon_keyboard]_lightmask", src)
 
+	if(!(stat & BROKEN))
+		// Get the average color of the computer screen so it can be used as a tinted glow
+		// Shamelessly stolen from /tg/'s /datum/component/customizable_reagent_holder.
+		var/icon/emissive_avg_screen_color = new(icon, icon_screen)
+		emissive_avg_screen_color.Scale(1, 1)
+		var/screen_emissive_color = copytext(emissive_avg_screen_color.GetPixel(1, 1), 1, 8) // remove opacity
+		set_light(light_range_on, light_power_on, screen_emissive_color)
 
 /obj/machinery/computer/power_change(forced = FALSE)
 	. = ..() //we don't check parent return due to this also being contigent on the BROKEN stat flag

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -126,20 +126,18 @@
 		. += "[icon_keyboard]"
 		underlays += emissive_appearance(icon, "[icon_keyboard]_lightmask", src)
 
-	if(!(stat & BROKEN))
-		// Get the average color of the computer screen so it can be used as a tinted glow
-		// Shamelessly stolen from /tg/'s /datum/component/customizable_reagent_holder.
-		var/icon/emissive_avg_screen_color = new(icon, icon_screen)
-		emissive_avg_screen_color.Scale(1, 1)
-		var/screen_emissive_color = copytext(emissive_avg_screen_color.GetPixel(1, 1), 1, 8) // remove opacity
-		set_light(light_range_on, light_power_on, screen_emissive_color)
 
 /obj/machinery/computer/power_change(forced = FALSE)
 	. = ..() //we don't check parent return due to this also being contigent on the BROKEN stat flag
 	if((stat & (BROKEN|NOPOWER)))
 		set_light_on(FALSE)
 	else
-		set_light(light_range_on, light_power_on, l_on = TRUE)
+		// Get the average color of the computer screen so it can be used as a tinted glow
+		// Shamelessly stolen from /tg/'s /datum/component/customizable_reagent_holder.
+		var/icon/emissive_avg_screen_color = new(icon, icon_screen)
+		emissive_avg_screen_color.Scale(1, 1)
+		var/screen_emissive_color = copytext(emissive_avg_screen_color.GetPixel(1, 1), 1, 8) // remove opacity
+		set_light(l_range = light_range_on, l_power = light_power_on, l_color = screen_emissive_color, l_on = TRUE)
 	if(.)
 		update_icon()
 


### PR DESCRIPTION
## Описание
- https://github.com/ParadiseSS13/Paradise/pull/27484

Цвет соответствует цвету экрана, свет теперь ярче и дальше.

## Причина создания ПР / Почему это хорошо для игры
Красиво.

## Демонстрация изменений
**До изменений:**
<img width="1127" height="332" alt="image" src="https://github.com/user-attachments/assets/521fc8a4-bc23-4ea2-975f-333abbd8ca8a" />


**После изменений:**
<img width="1134" height="470" alt="image" src="https://github.com/user-attachments/assets/0f18d1de-acae-4996-984f-4b69524aa9d9" />

## Тесты
Локалка.
