### PR TITLE
add: ТГ статус бар

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -292,7 +292,7 @@ CREATE TABLE `player` (
   `ghost_darkness_level` tinyint(1) UNSIGNED NOT NULL DEFAULT '255',
   `toggles_3` int(11) DEFAULT NULL,
   `screentip_mode` tinyint(1) DEFAULT '8',
-  `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#ffcc00',
+  `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#deefff',
   PRIMARY KEY (`id`),
   UNIQUE KEY `ckey` (`ckey`),
   KEY `lastseen` (`lastseen`),

--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -292,7 +292,7 @@ CREATE TABLE `player` (
   `ghost_darkness_level` tinyint(1) UNSIGNED NOT NULL DEFAULT '255',
   `toggles_3` int(11) DEFAULT NULL,
   `screentip_mode` tinyint(1) DEFAULT '8',
-  `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#ffd391',
+  `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#ffcc00',
   PRIMARY KEY (`id`),
   UNIQUE KEY `ckey` (`ckey`),
   KEY `lastseen` (`lastseen`),

--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -291,6 +291,8 @@ CREATE TABLE `player` (
   `viewrange` VARCHAR(5) NOT NULL DEFAULT '17x15' COLLATE 'utf8mb4_general_ci',
   `ghost_darkness_level` tinyint(1) UNSIGNED NOT NULL DEFAULT '255',
   `toggles_3` int(11) DEFAULT NULL,
+  `screentip_mode` tinyint(1) DEFAULT '8',
+  `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#ffd391',
   PRIMARY KEY (`id`),
   UNIQUE KEY `ckey` (`ckey`),
   KEY `lastseen` (`lastseen`),

--- a/SQL/updates/35-36.sql
+++ b/SQL/updates/35-36.sql
@@ -1,0 +1,4 @@
+# Updates DB from 28 to 29 -S34N_W
+# Adds support for screentips
+ALTER TABLE `player` ADD COLUMN `screentip_mode` tinyint(1) DEFAULT '8';
+ALTER TABLE `player` ADD COLUMN `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#ffd391'

--- a/SQL/updates/35-36.sql
+++ b/SQL/updates/35-36.sql
@@ -1,4 +1,4 @@
 # Updates DB from 35 to 36
 # Adds support for screentips
 ALTER TABLE `player` ADD COLUMN `screentip_mode` tinyint(1) DEFAULT '8';
-ALTER TABLE `player` ADD COLUMN `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#deefff'
+ALTER TABLE `player` ADD COLUMN `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#deefff';

--- a/SQL/updates/35-36.sql
+++ b/SQL/updates/35-36.sql
@@ -1,4 +1,4 @@
 # Updates DB from 35 to 36
 # Adds support for screentips
 ALTER TABLE `player` ADD COLUMN `screentip_mode` tinyint(1) DEFAULT '8';
-ALTER TABLE `player` ADD COLUMN `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#ffd391'
+ALTER TABLE `player` ADD COLUMN `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#ffcc00'

--- a/SQL/updates/35-36.sql
+++ b/SQL/updates/35-36.sql
@@ -1,4 +1,4 @@
 # Updates DB from 35 to 36
 # Adds support for screentips
 ALTER TABLE `player` ADD COLUMN `screentip_mode` tinyint(1) DEFAULT '8';
-ALTER TABLE `player` ADD COLUMN `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#ffcc00'
+ALTER TABLE `player` ADD COLUMN `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#deefff'

--- a/SQL/updates/35-36.sql
+++ b/SQL/updates/35-36.sql
@@ -1,4 +1,4 @@
-# Updates DB from 28 to 29 -S34N_W
+# Updates DB from 35 to 36
 # Adds support for screentips
 ALTER TABLE `player` ADD COLUMN `screentip_mode` tinyint(1) DEFAULT '8';
 ALTER TABLE `player` ADD COLUMN `screentip_color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '#ffd391'

--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -102,3 +102,12 @@
 
 //Blobbernauts
 #define ui_blobbernaut_overmind_health "EAST-1:28,CENTER+0:19"
+
+/// Takes a string or num view, and converts it to pixel width/height in a list(pixel_width, pixel_height)
+/proc/view_to_pixels(view)
+	if(!view)
+		return list(0, 0)
+	var/list/view_info = getviewsize(view)
+	view_info[1] *= world.icon_size
+	view_info[2] *= world.icon_size
+	return view_info

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -361,7 +361,7 @@
 #define EXPLOSION_BLOCK_PROC -1
 
 // The SQL version required by this version of the code
-#define SQL_VERSION 35
+#define SQL_VERSION 36
 
 // Vending machine stuff
 #define CAT_NORMAL 1
@@ -524,3 +524,14 @@
 #define ANALYZER_HISTORY_SIZE 30
 #define ANALYZER_HISTORY_MODE_KPA "kpa"
 #define ANALYZER_HISTORY_MODE_MOL "mol"
+
+/// Get the client from the var
+/proc/client_from_var(I)
+	if(ismob(I))
+		var/mob/A = I
+		return A.client
+	if(isclient(I))
+		return I
+	if(istype(I, /datum/mind))
+		var/datum/mind/B = I
+		return B.current.client

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -58,7 +58,8 @@
 #define SKIP_ATTACK_MESSAGE (1<<16)
 /// Checks whether the item was upgraded with a speed potion
 #define SPEEDPOTION_APPLIED (1<<17)
-
+/// Whether or not this atom shows screentips when hovered over
+#define NO_SCREENTIPS (1<<18)
 
 // Flags for the clothing_flags var on /obj/item/clothing
 

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -52,7 +52,7 @@
 #define PREFTOGGLE_2_AFKWATCH						(1<<5) // 32
 #define PREFTOGGLE_2_RUNECHAT						(1<<6) // 64
 #define PREFTOGGLE_2_DEATHMESSAGE					(1<<7) // 128
-#define PREFTOGGLE_2_HIDE_ITEM_TOOLTIPS  			(1<<8) // 256
+//#define PREFTOGGLE_2_EMPTY						(1<<8) // 256
 #define PREFTOGGLE_2_SEE_ITEM_OUTLINES				(1<<9) // 512
 // Yes I know this being an "enable to disable" is misleading, but it avoids having to tweak all existing pref entries
 #define PREFTOGGLE_2_REVERB_DISABLE					(1<<10) // 1024
@@ -87,6 +87,7 @@
 #define PREFTOGGLE_3_UI_SCALE         			(1<<1) // 2
 #define PREFTOGGLE_3_FACING_TO_MOUSE			(1<<2) // 4
 #define PREFTOGGLE_3_PAIN_BLURB	 				(1<<3) // 8
+#define PREFTOGGLE_3_HIDE_ITEM_TOOLTIPS			(1<<4) // 16
 
 #define TOGGLES_3_TOTAL                       	15 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
 

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -52,7 +52,7 @@
 #define PREFTOGGLE_2_AFKWATCH						(1<<5) // 32
 #define PREFTOGGLE_2_RUNECHAT						(1<<6) // 64
 #define PREFTOGGLE_2_DEATHMESSAGE					(1<<7) // 128
-//#define PREFTOGGLE_2_EMPTY						(1<<8) // 256
+//#define PREFTOGGLE_2_EMOTE_BUBBLE					(1<<8) // 256 tgui say(maybe temporary)
 #define PREFTOGGLE_2_SEE_ITEM_OUTLINES				(1<<9) // 512
 // Yes I know this being an "enable to disable" is misleading, but it avoids having to tweak all existing pref entries
 #define PREFTOGGLE_2_REVERB_DISABLE					(1<<10) // 1024
@@ -87,7 +87,6 @@
 #define PREFTOGGLE_3_UI_SCALE         			(1<<1) // 2
 #define PREFTOGGLE_3_FACING_TO_MOUSE			(1<<2) // 4
 #define PREFTOGGLE_3_PAIN_BLURB	 				(1<<3) // 8
-#define PREFTOGGLE_3_HIDE_ITEM_TOOLTIPS			(1<<4) // 16
 
 #define TOGGLES_3_TOTAL                       	15 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
 

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -52,7 +52,7 @@
 #define PREFTOGGLE_2_AFKWATCH						(1<<5) // 32
 #define PREFTOGGLE_2_RUNECHAT						(1<<6) // 64
 #define PREFTOGGLE_2_DEATHMESSAGE					(1<<7) // 128
-// #define PREFTOGGLE_2_EMOTE_BUBBLE					(1<<8) // 256 tgui say(maybe temporary)
+#define PREFTOGGLE_2_HIDE_ITEM_TOOLTIPS  			(1<<8) // 256
 #define PREFTOGGLE_2_SEE_ITEM_OUTLINES				(1<<9) // 512
 // Yes I know this being an "enable to disable" is misleading, but it avoids having to tweak all existing pref entries
 #define PREFTOGGLE_2_REVERB_DISABLE					(1<<10) // 1024

--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -9,10 +9,12 @@
 
 #define INVISIBILITY_LIGHTING 20
 
+// Normal cult runes
+#define INVISIBILITY_RUNES 25
 #define SEE_INVISIBLE_LIVING 25
 
 // Hidden cult runes
-#define INVISIBILITY_HIDDEN_RUNES  30
+#define INVISIBILITY_HIDDEN_RUNES 30
 #define SEE_INVISIBLE_HIDDEN_RUNES 30
 
 #define SEE_INVISIBLE_LEVEL_ONE 35	//Used by some stuff in code. It's really poorly organized.

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -448,8 +448,14 @@
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	screen_loc = "CENTER"
 
+/atom/movable/screen/click_catcher/MouseEntered(location, control, params)
+	return
+
+/atom/movable/screen/click_catcher/MouseExited(location, control, params)
+	return
+
 #define MAX_SAFE_BYOND_ICON_SCALE_TILES (MAX_SAFE_BYOND_ICON_SCALE_PX / world.icon_size)
-#define MAX_SAFE_BYOND_ICON_SCALE_PX (33 * 32)			//Not using world.icon_size on purpose.
+#define MAX_SAFE_BYOND_ICON_SCALE_PX (33 * 32) //Not using world.icon_size on purpose.
 
 /atom/movable/screen/click_catcher/proc/UpdateGreed(view_size_x = 15, view_size_y = 15)
 	var/icon/newicon = icon('icons/mob/screen_gen.dmi', "catcher")

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -196,6 +196,7 @@
 
 
 /atom/movable/screen/movable/action_button/MouseEntered(location, control, params)
+	. = ..()
 	if(!QDELETED(src))
 		if(!linked_keybind)
 			openToolTip(usr, src, params, title = name, content = desc, theme = actiontooltipstyle)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -116,6 +116,7 @@
 
 /atom/movable/screen/alert/MouseExited()
 	closeToolTip(usr)
+	return ..()
 
 /atom/movable/screen/alert/proc/do_timeout(mob/M, category)
 	if(!M || !M.alerts)

--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -2,6 +2,7 @@
 	icon = 'icons/hud/blob.dmi'
 
 /atom/movable/screen/blob/MouseEntered(location,control,params)
+	. = ..()
 	openToolTip(usr,src,params,title = name,content = desc, theme = "blob")
 
 /atom/movable/screen/blob/MouseExited()
@@ -36,7 +37,7 @@
 	if(hud && hud.mymob && isovermind(hud.mymob))
 		name = initial(name)
 		desc = initial(desc)
-	..()
+	return ..()
 
 /atom/movable/screen/blob/JumpToCore/Click()
 	if(isovermind(usr))
@@ -131,7 +132,7 @@
 		var/cost = (B.free_strain_rerolls)? "FREE" : BLOB_POWER_REROLL_COST
 		name = "[initial(name)] ([cost])"
 		desc = "Позволяет вам выбрать новый штамм из [BLOB_POWER_REROLL_CHOICES] случайных вариантов за [cost] ресурсов."
-	..()
+	return ..()
 
 /atom/movable/screen/blob/ReadaptStrain/Click()
 	if(isovermind(usr))

--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -7,6 +7,7 @@
 
 /atom/movable/screen/blob/MouseExited()
 	closeToolTip(usr)
+	return ..()
 
 /atom/movable/screen/blob/BlobHelp
 	icon_state = "ui_help"

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -2,6 +2,7 @@
 	icon = 'icons/mob/screen_ghost.dmi'
 
 /atom/movable/screen/ghost/MouseEntered()
+	. = ..()
 	flick(icon_state + "_anim", src)
 
 /atom/movable/screen/ghost/jumptomob

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -50,7 +50,7 @@
 	///Assoc list of controller groups, associated with key string group name with value of the plane master controller ref
 	var/list/atom/movable/plane_master_controller/plane_master_controllers = list()
 	///UI for screentips that appear when you mouse over things
-	var/obj/screen/screentip/screentip_text
+	var/atom/movable/screen/screentip/screentip_text
 
 	/// Think of multiz as a stack of z levels. Each index in that stack has its own group of plane masters
 	/// This variable is the plane offset our mob/client is currently "on"

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -49,6 +49,8 @@
 	var/list/datum/plane_master_group/master_groups = list()
 	///Assoc list of controller groups, associated with key string group name with value of the plane master controller ref
 	var/list/atom/movable/plane_master_controller/plane_master_controllers = list()
+	///UI for screentips that appear when you mouse over things
+	var/obj/screen/screentip/screentip_text
 
 	/// Think of multiz as a stack of z levels. Each index in that stack has its own group of plane masters
 	/// This variable is the plane offset our mob/client is currently "on"
@@ -73,6 +75,9 @@
 	for(var/mytype in subtypesof(/atom/movable/plane_master_controller))
 		var/atom/movable/plane_master_controller/controller_instance = new mytype(src)
 		plane_master_controllers[controller_instance.name] = controller_instance
+
+	screentip_text = new(null, src)
+	static_inventory += screentip_text
 
 	RegisterSignal(SSmapping, COMSIG_PLANE_OFFSET_INCREASE, PROC_REF(on_plane_increase))
 	RegisterSignal(mymob, COMSIG_MOB_LOGIN, PROC_REF(client_refresh))
@@ -188,6 +193,7 @@
 	QDEL_LIST_ASSOC_VAL(plane_master_controllers)
 
 	mymob = null
+	QDEL_NULL(screentip_text)
 	return ..()
 
 /datum/hud/proc/on_plane_increase(datum/source, old_max_offset, new_max_offset)

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -58,7 +58,7 @@
 	var/atom/movable/screen/movable/M = new()
 	M.name = "Movable UI Object"
 	M.icon_state = "block"
-	M.maptext = "Movable"
+	M.maptext = MAPTEXT("Movable")
 	M.maptext_width = 64
 
 	var/screen_l = tgui_input_text(usr, "Where on the screen? (Formatted as 'X,Y' e.g: '1,1' for bottom left)", "Spawn Movable UI Object")
@@ -76,7 +76,7 @@
 	var/atom/movable/screen/movable/snap/S = new()
 	S.name = "Snap UI Object"
 	S.icon_state = "block"
-	S.maptext = "Snap"
+	S.maptext = MAPTEXT("Snap")
 	S.maptext_width = 64
 
 	var/screen_l = tgui_input_text(usr, "Where on the screen? (Formatted as 'X,Y' e.g: '1,1' for bottom left)", "Spawn Snap UI Object")

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -17,6 +17,7 @@
 	VAR_PRIVATE/datum/hud/hud = null
 	appearance_flags = NO_CLIENT_COLOR
 	interaction_flags_click = BYPASS_ADJACENCY
+	flags = NO_SCREENTIPS
 	/**
 	 * Map name assigned to this object.
 	 * Automatically set by /client/proc/add_obj_to_map.
@@ -335,6 +336,7 @@
 
 
 /atom/movable/screen/zone_sel/MouseEntered(location, control, params)
+	. = ..()
 	MouseMove(location, control, params)
 
 
@@ -493,7 +495,7 @@
 	var/image/object_overlay
 
 /atom/movable/screen/inventory/MouseEntered(location, control, params)
-	..()
+	. = ..()
 	add_overlays()
 
 /atom/movable/screen/inventory/MouseExited(location, control, params)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -370,6 +370,7 @@
 	if(!isobserver(usr) && hovering)
 		cut_overlay(hover_overlays_cache[hovering])
 		hovering = null
+	return ..()
 
 
 /atom/movable/screen/zone_sel/proc/get_zone_at(icon_x, icon_y)

--- a/code/_onclick/hud/screentip.dm
+++ b/code/_onclick/hud/screentip.dm
@@ -1,0 +1,21 @@
+/atom/movable/screen/screentip
+	icon = null
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	screen_loc = "TOP,LEFT"
+	maptext_height = 480
+	maptext_width = 480
+	maptext_y = -50
+	maptext = ""
+
+/atom/movable/screen/screentip/Initialize(mapload, _hud)
+	. = ..()
+	hud = _hud
+	update_view()
+
+/atom/movable/screen/screentip/proc/update_view(datum/source)
+	SIGNAL_HANDLER
+	if(!hud?.mymob?.client) //Might not have been initialized by now
+		return
+	var/list/view_size = getviewsize(hud.mymob.client.view)
+	var/view = "[view_size[1]]x[view_size[2]]"
+	maptext_width = view_to_pixels(view)[1]

--- a/code/_onclick/hud/screentip.dm
+++ b/code/_onclick/hud/screentip.dm
@@ -4,7 +4,7 @@
 	screen_loc = "TOP,LEFT"
 	maptext_height = 480
 	maptext_width = 480
-	maptext_y = -50
+	maptext_y = -40
 	maptext = ""
 
 /atom/movable/screen/screentip/Initialize(mapload, _hud)

--- a/code/controllers/subsystem/debugview.dm
+++ b/code/controllers/subsystem/debugview.dm
@@ -47,7 +47,7 @@ SUBSYSTEM_DEF(debugview)
 	// And update the clients
 	for(var/client/C as anything in processing)
 		C.debug_text_overlay.maptext_y = mty
-		C.debug_text_overlay.maptext = "<span class='maptext' style='background-color: #272727;'>[out_text]</span>"
+		C.debug_text_overlay.maptext = MAPTEXT("<span style='background-color: #272727;'>[out_text]</span>")
 
 
 /datum/controller/subsystem/debugview/proc/start_processing(client/C)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1796,9 +1796,22 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	if(ai_controller)
 		ai_controller = new ai_controller(src)
 
-//Update the screentip to reflect what we're hoverin over
+/// Update the screentip to reflect what we're hovering over
 /atom/MouseEntered(location, control, params)
 	SSmouse_entered.hovers[usr.client] = src
+
+	var/datum/hud/active_hud = usr.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
+	var/screentip_mode = usr.client.prefs.screentip_mode
+	if(screentip_mode == 0 || (flags & NO_SCREENTIPS))
+		active_hud.screentip_text.maptext = ""
+		return
+
+	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
+	active_hud.screentip_text.maptext = MAPTEXT("<span style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[capitalize(src.declent_ru(NOMINATIVE))]</span>")
+
+// This is normal, I assure you. Paradise optimization.
+/atom/MouseExited(location, control, params)
+	usr.hud_used.screentip_text.maptext = ""
 
 /// Fired whenever this atom is the most recent to be hovered over in the tick.
 /// Preferred over MouseEntered if you do not need information such as the position of the mouse.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1539,15 +1539,3 @@
 	forceMove(holder_obj.loc)
 	qdel(holder_obj)
 
-/// Update the screentip to reflect what we're hovering over
-/atom/movable/MouseEntered(location, control, params)
-	var/datum/hud/active_hud = usr.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
-	var/screentip_mode = usr.client.prefs.screentip_mode
-	if(screentip_mode == 0 || (flags & NO_SCREENTIPS))
-		active_hud.screentip_text.maptext = ""
-		return
-	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
-	active_hud.screentip_text.maptext = MAPTEXT("<span style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[capitalize(src.declent_ru(NOMINATIVE))]</span>")
-
-/atom/movable/MouseExited(location, control, params)
-	usr.hud_used.screentip_text.maptext = ""

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1538,3 +1538,16 @@
 	REMOVE_TRAIT(src, TRAIT_UNDENSE, FULTON_TRAIT)
 	forceMove(holder_obj.loc)
 	qdel(holder_obj)
+
+/// Update the screentip to reflect what we're hovering over
+/atom/movable/MouseEntered(location, control, params)
+	if(invisibility > usr.see_invisible)
+		return
+	var/datum/hud/active_hud = usr.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
+	var/screentip_mode = usr.client.prefs.screentip_mode
+	if(screentip_mode == 0 || (flags & NO_SCREENTIPS))
+		active_hud.screentip_text.maptext = ""
+		return
+	// We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
+	active_hud.screentip_text.maptext = "<span class='maptext' style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[name]</span>"
+	usr.client.moused_over = UID()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1541,13 +1541,13 @@
 
 /// Update the screentip to reflect what we're hovering over
 /atom/movable/MouseEntered(location, control, params)
-	if(invisibility > usr.see_invisible)
-		return
 	var/datum/hud/active_hud = usr.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
 	var/screentip_mode = usr.client.prefs.screentip_mode
 	if(screentip_mode == 0 || (flags & NO_SCREENTIPS))
 		active_hud.screentip_text.maptext = ""
 		return
-	// We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
-	active_hud.screentip_text.maptext = "<span class='maptext' style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[name]</span>"
-	usr.client.moused_over = UID()
+	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
+	active_hud.screentip_text.maptext = MAPTEXT("<span style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[name]</span>")
+
+/atom/movable/MouseExited(location, control, params)
+	usr.hud_used.screentip_text.maptext = ""

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1547,7 +1547,7 @@
 		active_hud.screentip_text.maptext = ""
 		return
 	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
-	active_hud.screentip_text.maptext = MAPTEXT("<span style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[name]</span>")
+	active_hud.screentip_text.maptext = MAPTEXT("<span style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[capitalize(src.declent_ru(NOMINATIVE))]</span>")
 
 /atom/movable/MouseExited(location, control, params)
 	usr.hud_used.screentip_text.maptext = ""

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -27,6 +27,7 @@ To draw a rune, use a ritual dagger.
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // So that runes aren't so hard to click
 	var/visibility = 0
 	var/view_range = 7
+	invisibility = INVISIBILITY_RUNES
 	layer = SIGIL_LAYER
 	color = COLOR_BLOOD_BASE
 

--- a/code/game/objects/effects/temporary_visuals/cult.dm
+++ b/code/game/objects/effects/temporary_visuals/cult.dm
@@ -44,6 +44,7 @@
 	icon_state = "space"
 	duration = 600
 	layer = ABOVE_OBJ_LAYER
+	invisibility = INVISIBILITY_RUNES
 	var/from_lava = FALSE
 
 
@@ -63,6 +64,7 @@
 /obj/effect/temp_visual/cult/rune_spawn
 	icon_state = "runeouter"
 	alpha = 0
+	invisibility = INVISIBILITY_RUNES
 	var/turnedness = 179 //179 turns counterclockwise, 181 turns clockwise
 
 /obj/effect/temp_visual/cult/rune_spawn/Initialize(mapload, set_duration, set_color)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -88,13 +88,13 @@
 
 		if(dist < dev)
 			T.color = "red"
-			T.maptext = "Dev"
+			T.maptext = MAPTEXT("Dev")
 		else if(dist < heavy)
 			T.color = "yellow"
-			T.maptext = "Heavy"
+			T.maptext = MAPTEXT("Heavy")
 		else if(dist < light)
 			T.color = "blue"
-			T.maptext = "Light"
+			T.maptext = MAPTEXT("Light")
 		else
 			continue
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1053,6 +1053,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	deltimer(tip_timer) //delete any in-progress timer if the mouse is moved off the item before it finishes
 	closeToolTip(usr)
 	remove_outline()
+	return ..()
 
 
 /obj/item/MouseDrop_T(atom/dropping, mob/user, params)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1032,6 +1032,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 
 
 /obj/item/MouseEntered(location, control, params)
+	. = ..()
 	if(item_flags & (IN_INVENTORY|IN_STORAGE))
 		var/mob/living/user = usr
 		if(user.client.prefs.toggles2 & PREFTOGGLE_2_DESC_TIPS)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -40,6 +40,8 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	var/keep_dir = TRUE //When false, resets dir to default on changeturf()
 	smoothing_groups = SMOOTH_GROUP_FLOOR
 
+	flags = NO_SCREENTIPS
+
 	footstep = FOOTSTEP_FLOOR
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -606,6 +606,18 @@
 
 	add_overlay(dent_decals)
 
+/turf/simulated/wall/MouseEntered(location, control, params)
+	var/datum/hud/active_hud = usr.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
+	var/screentip_mode = usr.client.prefs.screentip_mode
+	if(screentip_mode == 0 || (flags & NO_SCREENTIPS))
+		active_hud.screentip_text.maptext = ""
+		return
+	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
+	active_hud.screentip_text.maptext = MAPTEXT("<span style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[name]</span>")
+
+/turf/simulated/wall/MouseExited(location, control, params)
+	usr.hud_used.screentip_text.maptext = ""
+
 #undef MAX_DENT_DECALS
 
 /turf/simulated/wall/flamer_fire_act(damage)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -606,18 +606,6 @@
 
 	add_overlay(dent_decals)
 
-/turf/simulated/wall/MouseEntered(location, control, params)
-	var/datum/hud/active_hud = usr.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
-	var/screentip_mode = usr.client.prefs.screentip_mode
-	if(screentip_mode == 0 || (flags & NO_SCREENTIPS))
-		active_hud.screentip_text.maptext = ""
-		return
-	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
-	active_hud.screentip_text.maptext = MAPTEXT("<span style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[capitalize(src.declent_ru(NOMINATIVE))]</span>")
-
-/turf/simulated/wall/MouseExited(location, control, params)
-	usr.hud_used.screentip_text.maptext = ""
-
 #undef MAX_DENT_DECALS
 
 /turf/simulated/wall/flamer_fire_act(damage)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -613,7 +613,7 @@
 		active_hud.screentip_text.maptext = ""
 		return
 	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
-	active_hud.screentip_text.maptext = MAPTEXT("<span style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[name]</span>")
+	active_hud.screentip_text.maptext = MAPTEXT("<span style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[capitalize(src.declent_ru(NOMINATIVE))]</span>")
 
 /turf/simulated/wall/MouseExited(location, control, params)
 	usr.hud_used.screentip_text.maptext = ""

--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -174,6 +174,7 @@
 	plane = SPLASHSCREEN_PLANE
 	layer = SPLASHSCREEN_LAYER
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	flags = NO_SCREENTIPS
 	/// Pixel shifts below are needed to centrally position the black icon within the start area at compile-time. This icon used as a background for title screens with smaller resolutions than required.
 	pixel_x = -288
 	pixel_y = -224

--- a/code/game/turfs/space/openspace.dm
+++ b/code/game/turfs/space/openspace.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/turf/space.dmi'
 	icon_state = "openspace" //transparent
 	baseturf = /turf/space/openspace
-	//mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pathing_pass_method = TURF_PATHING_PASS_PROC
 	var/can_cover_up = TRUE
 	var/can_build_on = TRUE

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -7,6 +7,8 @@
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = HEAT_CAPACITY_VACUUM
 
+	flags = NO_SCREENTIPS
+
 	plane = PLANE_SPACE
 	layer = SPACE_LAYER
 	light_power = 0.25

--- a/code/modules/antagonists/changeling/changeling_datum.dm
+++ b/code/modules/antagonists/changeling/changeling_datum.dm
@@ -1,3 +1,6 @@
+/// Helper to format the text that gets thrown onto the chem hud element.
+#define FORMAT_CHEM_CHARGES_TEXT(charges) MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#dd66dd'>[round(charges)]</font></div>")
+
 /// Time before changeling can revive himself.
 #define LING_FAKEDEATH_TIME					60 SECONDS
 /// The lowest value of genetic_damage [/datum/antagonist/changeling/process()] can take it to while dead.
@@ -254,7 +257,7 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	var/mob/living/carbon/human/h_owner = owner.current
 	if(h_owner.hud_used?.lingchemdisplay)
 		h_owner.hud_used.lingchemdisplay.invisibility = 0
-		h_owner.hud_used.lingchemdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font face='Small Fonts' color='#dd66dd'>[round(chem_charges)]</font></div>"
+		h_owner.hud_used.lingchemdisplay.maptext = FORMAT_CHEM_CHARGES_TEXT(chem_charges)
 
 	if(h_owner.stat == DEAD)
 		chem_charges = clamp(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown, chem_storage * 0.5)
@@ -651,3 +654,5 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 
 	return mind_holder.mind.has_antag_datum(/datum/antagonist/changeling)
 
+
+#undef FORMAT_CHEM_CHARGES_TEXT

--- a/code/modules/antagonists/vampire/vampire_datum.dm
+++ b/code/modules/antagonists/vampire/vampire_datum.dm
@@ -1,3 +1,6 @@
+/// Helper to format the text that gets thrown onto the chem hud element.
+#define FORMAT_BLOODUSABLE_TEXT(bloodusable) MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font face='Small Fonts' color='#ce0202'>[bloodusable]</font></div>")
+
 /datum/antagonist/vampire
 	name = "Vampire"
 	antag_hud_type = ANTAG_HUD_VAMPIRE
@@ -597,7 +600,7 @@
 		hud.vampire_blood_display.screen_loc = "WEST:6,CENTER-1:15"
 		hud.static_inventory += hud.vampire_blood_display
 		hud.show_hud(hud.hud_version)
-	hud.vampire_blood_display.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font face='Small Fonts' color='#ce0202'>[bloodusable]</font></div>"
+	hud.vampire_blood_display.maptext = FORMAT_BLOODUSABLE_TEXT(bloodusable)
 
 
 /datum/antagonist/vampire/proc/handle_vampire_cloak()
@@ -729,3 +732,6 @@
 	var/mob/living/user = ..()
 	user.faction -= ROLE_VAMPIRE
 	return user
+
+
+#undef FORMAT_BLOODUSABLE_TEXT

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -244,9 +244,14 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 	var/list/loadout_gear = list()
 	var/list/tgui_loadout_gear = list()
 	var/list/choosen_gears = list()
-	// Parallax
+	/// Parallax
 	var/parallax = PARALLAX_HIGH
 	var/multiz_detail = MULTIZ_DETAIL_DEFAULT
+
+	/// Screentip Mode, in pixels. 8 is small, 15 is mega big, 0 is off.
+	var/screentip_mode = 8
+	/// Color of screentips at top of screen
+	var/screentip_color = "#ffd391"
 
 	var/discord_id = null
 	var/discord_name = null
@@ -604,6 +609,8 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 			dat += "</td><td width='405px' height='300px' valign='top'>"
 			dat += "<h2>Настройки интерфейса</h2>"
 			dat += "<b>Настройки пользовательского интерфейса:</b><br>"
+			dat += "<b>Всплывающая подсказка:</b> <a href='byond://?_src_=prefs;preference=screentip_mode'>[(screentip_mode == 0) ? "Выключить" : "[screentip_mode]px"]</a><br>"
+			dat += "<b>Цвет всплывающей подсказки:</b> <span style='border: 1px solid #161616; background-color: [screentip_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='byond://?_src_=prefs;preference=screentip_color'><b>Изменить</b></a><br>"
 			dat += " – <b>Прозрачность:</b> <a href='byond://?_src_=prefs;preference=UIalpha'><b>[UI_style_alpha]</b></a><br>"
 			dat += " – <b>Цвет:</b> <a href='byond://?_src_=prefs;preference=UIcolor'><b>[UI_style_color]</b></a> <span style='border: 1px solid #161616; background-color: [UI_style_color];'>&nbsp;&nbsp;&nbsp;</span><br>"
 			dat += " – <b>Стиль интерфейса:</b> <a href='byond://?_src_=prefs;preference=ui'><b>[ui_theme_to_russian(UI_style)]</b></a><br>"
@@ -2424,6 +2431,18 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 
 				if("tgui_strip_menu")
 					toggles2 ^= PREFTOGGLE_2_BIG_STRIP_MENU
+
+				if("screentip_mode")
+					var/desired_screentip_mode = tgui_input_number(user, "Выберите размер всплывающей подсказки. Чтобы отключить всплывающие подсказки, установите значение 0. (Рекомендуемое значение от 8 до 15)", "Размер всплывающей подсказки", screentip_mode, 20, 0)
+					if(isnull(desired_screentip_mode))
+						return
+					screentip_mode = desired_screentip_mode
+
+				if("screentip_color")
+					var/screentip_color_new = tgui_input_color(user, "Выберите цвет всплывающей подсказки", "Игровые настройки", screentip_color)
+					if(isnull(screentip_color_new))
+						return
+					screentip_color = screentip_color_new
 
 				if("vote_popup")
 					toggles2 ^= PREFTOGGLE_2_DISABLE_VOTE_POPUPS

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -251,7 +251,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 	/// Screentip Mode, in pixels. 8 is small, 15 is mega big, 0 is off.
 	var/screentip_mode = 8
 	/// Color of screentips at top of screen
-	var/screentip_color = "#ffcc00"
+	var/screentip_color = "#deefff"
 
 	var/discord_id = null
 	var/discord_name = null

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -251,7 +251,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 	/// Screentip Mode, in pixels. 8 is small, 15 is mega big, 0 is off.
 	var/screentip_mode = 8
 	/// Color of screentips at top of screen
-	var/screentip_color = "#ffd391"
+	var/screentip_color = "#ffcc00"
 
 	var/discord_id = null
 	var/discord_name = null

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -82,7 +82,7 @@
 	parallax = sanitize_integer(parallax, 0, 16, initial(parallax))
 	discord_id = sanitize_text(discord_id, initial(discord_id))
 	discord_name = sanitize_text(discord_name, initial(discord_name))
-	screentip_mode = sanitize_text(screentip_mode, initial(screentip_mode))
+	screentip_mode = sanitize_integer(screentip_mode, 0, 20, initial(screentip_mode))
 	screentip_color = sanitize_hexcolor(screentip_color, initial(screentip_color))
 	return TRUE
 

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -22,9 +22,9 @@
 					keybindings,
 					viewrange,
 					ghost_darkness_level,
+					toggles_3,
 					screentip_mode,
-					screentip_color,
-					toggles_3
+					screentip_color
 					FROM [format_table_name("player")]
 					WHERE ckey=:ckey"}, list(
 						"ckey" = C.ckey
@@ -58,9 +58,9 @@
 		keybindings = init_keybindings(raw = query.item[19])
 		viewrange = query.item[20]
 		ghost_darkness_level = query.item[21]
-		screentip_mode = query.item[22]
-		screentip_color = query.item[23]
-		toggles3 = text2num(query.item[24])
+		toggles3 = text2num(query.item[22])
+		screentip_mode = query.item[23]
+		screentip_color = query.item[24]
 
 	qdel(query)
 
@@ -118,9 +118,9 @@
 					keybindings=:keybindings,
 					viewrange=:viewrange,
 					ghost_darkness_level=:ghost_darkness_level,
+					toggles_3=:toggles3,
 					screentip_mode=:screentip_mode,
-					screentip_color=:screentip_color,
-					toggles_3=:toggles3
+					screentip_color=:screentip_color
 					WHERE ckey=:ckey"}, list(
 						// OH GOD THE PARAMETERS
 						"ooccolour" = ooccolor,
@@ -141,10 +141,10 @@
 						"keybindings" = json_encode(keybindings_overrides),
 						"viewrange" = viewrange,
 						"ghost_darkness_level" = ghost_darkness_level,
-						"screentip_mode" = screentip_mode,
-						"screentip_color" = screentip_color,
 						"ckey" = C.ckey,
 						"toggles3" = num2text(toggles3, CEILING(log(10, (TOGGLES_3_TOTAL)), 1)),
+						"screentip_mode" = screentip_mode,
+						"screentip_color" = screentip_color
 					)
 					)
 

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -22,6 +22,8 @@
 					keybindings,
 					viewrange,
 					ghost_darkness_level,
+					screentip_mode,
+					screentip_color,
 					toggles_3
 					FROM [format_table_name("player")]
 					WHERE ckey=:ckey"}, list(
@@ -56,28 +58,32 @@
 		keybindings = init_keybindings(raw = query.item[19])
 		viewrange = query.item[20]
 		ghost_darkness_level = query.item[21]
-		toggles3 = text2num(query.item[22])
+		screentip_mode = query.item[22]
+		screentip_color = query.item[23]
+		toggles3 = text2num(query.item[24])
 
 	qdel(query)
 
 	//Sanitize
-	ooccolor		= sanitize_hexcolor(ooccolor, initial(ooccolor))
-	UI_style		= sanitize_inlist(UI_style, list(UI_THEME_WHITE, UI_THEME_MIDNIGHT, UI_THEME_PLASMAFIRE, UI_THEME_RETRO, UI_THEME_SLIMECORE, UI_THEME_OPERATIVE), initial(UI_style))
-	default_slot	= sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
-	toggles			= sanitize_integer(toggles, 0, TOGGLES_TOTAL, initial(toggles))
-	toggles2		= sanitize_integer(toggles2, 0, TOGGLES_2_TOTAL, initial(toggles2))
-	toggles3		= sanitize_integer(toggles3, 0, TOGGLES_3_TOTAL, initial(toggles3))
-	sound			= sanitize_integer(sound, 0, 65535, initial(sound))
-	UI_style_color	= sanitize_hexcolor(UI_style_color, initial(UI_style_color))
-	UI_style_alpha	= sanitize_integer(UI_style_alpha, 0, 255, initial(UI_style_alpha))
-	lastchangelog	= sanitize_text(lastchangelog, initial(lastchangelog))
+	ooccolor = sanitize_hexcolor(ooccolor, initial(ooccolor))
+	UI_style = sanitize_inlist(UI_style, list(UI_THEME_WHITE, UI_THEME_MIDNIGHT, UI_THEME_PLASMAFIRE, UI_THEME_RETRO, UI_THEME_SLIMECORE, UI_THEME_OPERATIVE), initial(UI_style))
+	default_slot = sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
+	toggles = sanitize_integer(toggles, 0, TOGGLES_TOTAL, initial(toggles))
+	toggles2 = sanitize_integer(toggles2, 0, TOGGLES_2_TOTAL, initial(toggles2))
+	toggles3 = sanitize_integer(toggles3, 0, TOGGLES_3_TOTAL, initial(toggles3))
+	sound = sanitize_integer(sound, 0, 65535, initial(sound))
+	UI_style_color = sanitize_hexcolor(UI_style_color, initial(UI_style_color))
+	UI_style_alpha = sanitize_integer(UI_style_alpha, 0, 255, initial(UI_style_alpha))
+	lastchangelog = sanitize_text(lastchangelog, initial(lastchangelog))
 	exp	= sanitize_text(exp, initial(exp))
 	clientfps = sanitize_integer(clientfps, -1, 1000, initial(clientfps))
 	atklog = sanitize_integer(atklog, 0, 100, initial(atklog))
 	fuid = sanitize_integer(fuid, 0, 10000000, initial(fuid))
 	parallax = sanitize_integer(parallax, 0, 16, initial(parallax))
-	discord_id			= sanitize_text(discord_id, initial(discord_id))
-	discord_name		= sanitize_text(discord_name, initial(discord_name))
+	discord_id = sanitize_text(discord_id, initial(discord_id))
+	discord_name = sanitize_text(discord_name, initial(discord_name))
+	screentip_mode = sanitize_text(screentip_mode, initial(screentip_mode))
+	screentip_color = sanitize_hexcolor(screentip_color, initial(screentip_color))
 	return TRUE
 
 /datum/preferences/proc/save_preferences(client/C)
@@ -112,6 +118,8 @@
 					keybindings=:keybindings,
 					viewrange=:viewrange,
 					ghost_darkness_level=:ghost_darkness_level,
+					screentip_mode=:screentip_mode,
+					screentip_color=:screentip_color,
 					toggles_3=:toggles3
 					WHERE ckey=:ckey"}, list(
 						// OH GOD THE PARAMETERS
@@ -133,6 +141,8 @@
 						"keybindings" = json_encode(keybindings_overrides),
 						"viewrange" = viewrange,
 						"ghost_darkness_level" = ghost_darkness_level,
+						"screentip_mode" = screentip_mode,
+						"screentip_color" = screentip_color,
 						"ckey" = C.ckey,
 						"toggles3" = num2text(toggles3, CEILING(log(10, (TOGGLES_3_TOTAL)), 1)),
 					)

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -316,16 +316,6 @@
 	disable_message = "Теперь вы не будете видеть уведомления в призрак-чате, если игрок в мире погибнет."
 	blackbox_message = "Toggle Death Notifications"
 
-/datum/preference_toggle/toggle_item_tooltips
-	name = "Всплывающие подсказки"
-	description = "Переключает отображение текстовых подсказок в верхней части экрана, когда вы наводите курсор на объект."
-	preftoggle_bitflag = PREFTOGGLE_3_HIDE_ITEM_TOOLTIPS
-	preftoggle_toggle = PREFTOGGLE_TOGGLE3
-	preftoggle_category = PREFTOGGLE_CATEGORY_LIVING
-	enable_message = "Вы больше не видите всплывающие подсказки."
-	disable_message = "Теперь вы видите всплывающие подсказки."
-	blackbox_message = "Toggle item tooltips"
-
 /datum/preference_toggle/toggle_reverb
 	name = "Ревербация звуков"
 	description = "Включает ревербацию определённых звуков."

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -319,8 +319,8 @@
 /datum/preference_toggle/toggle_item_tooltips
 	name = "Всплывающие подсказки"
 	description = "Переключает отображение текстовых подсказок в верхней части экрана, когда вы наводите курсор на объект."
-	preftoggle_bitflag = PREFTOGGLE_2_HIDE_ITEM_TOOLTIPS
-	preftoggle_toggle = PREFTOGGLE_TOGGLE2
+	preftoggle_bitflag = PREFTOGGLE_3_HIDE_ITEM_TOOLTIPS
+	preftoggle_toggle = PREFTOGGLE_TOGGLE3
 	preftoggle_category = PREFTOGGLE_CATEGORY_LIVING
 	enable_message = "Вы больше не видите всплывающие подсказки."
 	disable_message = "Теперь вы видите всплывающие подсказки."

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -179,13 +179,13 @@
 
 
 /datum/preference_toggle/toggle_end_of_round_sound
-	name = "Toggle Mute End of Round Sound"
-	description = "Toggles muting the end of round sound"
+	name = "Отключение звука в конце раунда"
+	description = "Отключение звука в конце раунда."
 	preftoggle_bitflag = SOUND_MUTE_END_OF_ROUND
 	preftoggle_toggle = PREFTOGGLE_SOUND
 	preftoggle_category = PREFTOGGLE_CATEGORY_GENERAL
-	enable_message = "You have muted the end of round sound."
-	disable_message = "You have unmuted the end of round sound."
+	enable_message = "Вы отключили звук в конце раунда."
+	disable_message = "Вы включили звук в конце раунда."
 	blackbox_message = "Toggle End of Round Sound"
 
 /datum/preference_toggle/toggle_ooc
@@ -315,6 +315,16 @@
 	enable_message = "Теперь вы будете видеть уведомления в призрак-чате, если игрок в мире погибнет."
 	disable_message = "Теперь вы не будете видеть уведомления в призрак-чате, если игрок в мире погибнет."
 	blackbox_message = "Toggle Death Notifications"
+
+/datum/preference_toggle/toggle_item_tooltips
+	name = "Всплывающие подсказки"
+	description = "Переключает отображение текстовых подсказок в верхней части экрана, когда вы наводите курсор на объект."
+	preftoggle_bitflag = PREFTOGGLE_2_HIDE_ITEM_TOOLTIPS
+	preftoggle_toggle = PREFTOGGLE_TOGGLE2
+	preftoggle_category = PREFTOGGLE_CATEGORY_LIVING
+	enable_message = "Вы больше не видите всплывающие подсказки."
+	disable_message = "Теперь вы видите всплывающие подсказки."
+	blackbox_message = "Toggle item tooltips"
 
 /datum/preference_toggle/toggle_reverb
 	name = "Ревербация звуков"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -372,6 +372,7 @@
 	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(run_examinate), A))
 
 /mob/proc/run_examinate(atom/target)
+	// TODO: TG Double Examine
 	var/list/result = target.examine(src)
 	SEND_SIGNAL(src, COMSIG_MOB_RUN_EXAMINATE, target, result)
 

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -258,7 +258,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 		// I assume it's faster to color,tag and OR the turf in, rather
 		// then checking if its there
 		T.color = RANDOM_COLOUR
-		T.maptext = "[T.x],[T.y],[T.z]"
+		T.maptext = MAPTEXT("[T.x],[T.y],[T.z]")
 		tagged |= T
 
 /obj/item/gps/visible_debug/proc/clear()

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -101,7 +101,7 @@ Notes:
 //Includes sanity.checks
 /proc/openToolTip(mob/user = null, atom/movable/tip_src = null, params = null, title = "", content = "", theme = "")
 	if(istype(user))
-		if(user.client && user.client.tooltips)
+		if(user.client && user.client.tooltips && (user.client.prefs.toggles2 & PREFTOGGLE_2_DESC_TIPS))
 			if(!theme && user.client.prefs && user.client.prefs.UI_style)
 				theme = lowertext(user.client.prefs.UI_style)
 			if(!theme)

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -106,6 +106,9 @@ Notes:
 				theme = lowertext(user.client.prefs.UI_style)
 			if(!theme)
 				theme = "default"
+			// Strip macros from item names
+			title = replacetext(title, "\proper", "")
+			title = replacetext(title, "\improper", "")
 			user.client.tooltips.show(tip_src, params, title, content, theme)
 
 

--- a/config/example/dbconfig.txt
+++ b/config/example/dbconfig.txt
@@ -9,7 +9,7 @@
 ## This value must be set to the version of the paradise schema in use.
 ## If this value does not match, the SQL database will not be loaded and an error will be generated.
 ## Roundstart will be delayed.
-DB_VERSION 35
+DB_VERSION 36
 
 ## Server the MySQL database can be found at.
 # Examples: localhost, 200.135.5.43, www.mysqldb.com, etc.

--- a/paradise.dme
+++ b/paradise.dme
@@ -317,6 +317,7 @@
 #include "code\_onclick\hud\radial.dm"
 #include "code\_onclick\hud\robot.dm"
 #include "code\_onclick\hud\screen_objects.dm"
+#include "code\_onclick\hud\screentip.dm"
 #include "code\_onclick\hud\slime.dm"
 #include "code\_onclick\hud\swarmer.dm"
 #include "code\_onclick\hud\parallax\parallax.dm"

--- a/tools/ci/dbconfig.txt
+++ b/tools/ci/dbconfig.txt
@@ -2,7 +2,7 @@
 # Dont use it ingame
 # Remember to update this when you increase the SQL version! -aa
 SQL_ENABLED
-DB_VERSION 35
+DB_VERSION 36
 ADDRESS 127.0.0.1
 PORT 3306
 FEEDBACK_DATABASE feedback


### PR DESCRIPTION
## Описание
Портировал с Парадизов, а не напрямую с ТГ, поскольку у них оно ушло далеко вперёд, а с Парой у нас всё достаточно просто. Открывает перспективы на модифицирование напрямую с ТГ, портирование улучшений с типсами взаимодействий над предметом и прочее. Следующие ПРы:
- https://github.com/ParadiseSS13/Paradise/pull/16505
- https://github.com/ParadiseSS13/Paradise/pull/25783
- https://github.com/ParadiseSS13/Paradise/pull/22753

**Затрагивает ДБ!!**

## Причина создания ПР / Почему это хорошо для игры
Не знаю, почему это не портанули раньше, поскольку статусбар слева внизу никому не всрался, альт-клик меню перенесли на ТГУИ, а правая клавиша мыши выводит уродливое окно. Больше иммерсивности в игру про иммерсивность.

**Самое главное!** Это решает проблему того, что `name` предметов на английском, а русское название используется только в проках вывода текста в чат. Теперь же всё станет гораздо понятней!

## Демонстрация изменений
_Я няшка, вопросы?_

https://github.com/user-attachments/assets/9f01b744-a0c7-4602-a6d2-f8086a911c39

## Тесты
Локалка, работает.