### PR TITLE
bugfix: БСХ теперь под спрайтами кукол на турфах выше

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -21,7 +21,8 @@
 #define FLOOR_PLANE -10
 
 #define WALL_PLANE -9
-#define GAME_PLANE -8
+#define BELOW_GAME_PLANE -8
+#define GAME_PLANE -7
 
 #define ABOVE_GAME_PLANE -2
 

--- a/code/_onclick/hud/plane_master/plane_master_subtypes.dm
+++ b/code/_onclick/hud/plane_master/plane_master_subtypes.dm
@@ -103,6 +103,13 @@
 	plane = WALL_PLANE
 	render_relay_planes = list(RENDER_PLANE_GAME_WORLD, EMISSIVE_MASK_PLANE)
 
+/atom/movable/screen/plane_master/below_game
+	name = "Под основными объектами"
+	documentation = "Содержит то, что должно быть выше турфов, но ниже большинства игровых объектов. \
+					Используется в случаях, когда спрайт объекта вылазит за свою плитку и перекрывает спрайты находящиеся выше."
+	plane = BELOW_GAME_PLANE
+	render_relay_planes = list(RENDER_PLANE_GAME_WORLD)
+
 /atom/movable/screen/plane_master/game
 	name = "Lower game world"
 	documentation = "Holds anything that draws just above floor. Runes, crayons and etc."

--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -218,6 +218,7 @@
 	max_integrity = 300
 	pixel_x = -32	//shamelessly stolen from dna vault
 	pixel_y = -64
+	plane = BELOW_GAME_PLANE
 	/// For faking having a big machine, dummy 'machines' that are hidden inside the large sprite and make certain tiles dense. See new and destroy.
 	var/list/obj/structure/fillers = list()
 	use_power = NO_POWER_USE	// power usage is handelled manually


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Помещает спрайт БСХ на план (новый) ниже большинства объектов. Это сделано из-за того, что из-за порядка генерации, объекты на плитках выше на более высоком слое отображались ниже.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Тесты
Защитспавнил БСХ.
Позаходил в разные его плитки. Кукла была выше БСХ.
Свет не умер как при первом тесте в котором я чуть сдвинул слой стен.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
