### PR TITLE
tweak: Исправление цели БСА чтобы выпадало на всех типах лаваленда

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -112,10 +112,6 @@ GLOBAL_LIST_EMPTY(BSA_modes_list)
 		– Центральное Командование Nanotrasen"}
 
 
-/datum/station_goal/bluespace_cannon/can_gain()
-	return SSmapping.lavaland_theme.lavaland_type != LAVALAND_TYPE_PLASMA
-
-
 /datum/station_goal/bluespace_cannon/on_report()
 	//Unlock BSA parts
 	var/datum/supply_packs/misc/station_goal/bsa/P = SSshuttle.supply_packs["[/datum/supply_packs/misc/station_goal/bsa]"]
@@ -125,10 +121,9 @@ GLOBAL_LIST_EMPTY(BSA_modes_list)
 /datum/station_goal/bluespace_cannon/check_completion()
 	if(..())
 		return TRUE
-
-	if(SSmapping.lavaland_theme.lavaland_type == LAVALAND_TYPE_PLASMA)
-		return TRUE
-
+	for(var/obj/machinery/bsa/full/bsa in SSmachines.get_by_type(/obj/machinery/bsa/full))
+		if(bsa.bfl_crack_fired)
+			return TRUE
 	return FALSE
 
 /obj/machinery/bsa
@@ -285,6 +280,7 @@ GLOBAL_LIST_EMPTY(BSA_modes_list)
 	var/obj/machinery/computer/bsa_control/controller
 	var/cannon_direction = WEST
 	var/static/image/top_layer = null
+	var/bfl_crack_fired = FALSE
 	var/last_fire_time = 0 // The time at which the gun was last fired
 	var/last_calibrate_time = 0 // The time at which the gun was last fired
 	var/reload_cooldown = BSA_INITIAL_COOLDOWN
@@ -387,6 +383,11 @@ GLOBAL_LIST_EMPTY(BSA_modes_list)
 /obj/machinery/bsa/full/proc/check_goal_complete(target_signal)
 	if(!istype(target_signal, /obj/item/gps/internal/bfl_crack))
 		return
+	// Fire at target gps - goal complete.
+	bfl_crack_fired = TRUE
+	// Optional: change lazis type to plasma.
+	if(SSmapping.lavaland_theme.lavaland_type == LAVALAND_TYPE_PLASMA)
+		return // Already plasma, do nothing
 	to_chat(usr, span_big("Вы замечаете как планета начинается трястись!"))
 	set_lazis_type(/datum/lavaland_theme/plasma)
 

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -103,6 +103,14 @@ GLOBAL_LIST_EMPTY(BSA_modes_list)
 	name = "Блюспейс Артиллерия"
 
 /datum/station_goal/bluespace_cannon/get_report()
+	if(SSmapping.lavaland_theme.lavaland_type == LAVALAND_TYPE_PLASMA)
+		return {"<b>Постройка Блюспейс Артиллерии</b><br>
+			Вам необходимо построить Блюспейс Артиллерию №[rand(1,99)]. \
+			После постройки необходимо проверить работоспособность выстрелив по любой цели.
+			<br><br>
+			Основные части артиллерии должны быть доступны для заказа в отделе снабжения.
+			<br>
+			– Центральное Командование Nanotrasen"}
 	return {"<b>Смена цикла Лазиса</b><br>
 		Вам необходимо построить Блюспейс Артиллерию №[rand(1,99)]. \
 		После постройки необходимо выстрелить по огромному месторождению плазмы на Лазисе, отмеченному как \"[/obj/item/gps/internal/bfl_crack::gpstag]\"".
@@ -381,13 +389,15 @@ GLOBAL_LIST_EMPTY(BSA_modes_list)
 	new /obj/effect/overlay/temp/blinking_laser(target)
 
 /obj/machinery/bsa/full/proc/check_goal_complete(target_signal)
+	// if lavaland is plasma, goal complete after any shot
+	if(SSmapping.lavaland_theme.lavaland_type == LAVALAND_TYPE_PLASMA)
+		bfl_crack_fired = TRUE
+		return
+	// else check target gps
 	if(!istype(target_signal, /obj/item/gps/internal/bfl_crack))
 		return
-	// Fire at target gps - goal complete.
+	// Fire at target gps - change lavaland to plasma
 	bfl_crack_fired = TRUE
-	// Optional: change lazis type to plasma.
-	if(SSmapping.lavaland_theme.lavaland_type == LAVALAND_TYPE_PLASMA)
-		return // Already plasma, do nothing
 	to_chat(usr, span_big("Вы замечаете как планета начинается трястись!"))
 	set_lazis_type(/datum/lavaland_theme/plasma)
 


### PR DESCRIPTION

## Описание

Сейчас выпадение цели БСА завязано на условии что на планете не плазмленд, что отсекает возможность выпадения этой цели у трети всех раундов.

Убрал условие выпадения из цели бса, изменил условие выполнения цели на то что был совершен выстрел с бса по гпс маркеру трещины с плазмой (*раньше была проверка что планета стала плазмалендом*). При выстреле с бса смотрит на нацеленную гпс и поднимает флаг что нужный выстрел был произведен. Если у нас не плазмаленд - как и раньше меняет его на плазму, если уже плазма - ничего не делает.
**Этот пр также исправит баг что при повторном выстреле происходило повторная смена на плазмаленд**

## Почему это хорошо для игры

БСА стал слишком редко выпадать.
Как автор переделки интерфейса бса я недоволен что не могу потестить нововведение в игре :с


## Тесты

Цель теперь выпадает как и раньше без завязки на типе планеты, проверил на локалке.
