### PR TITLE
bugfix: Роль заключенных добавлена в блеклист консоли ГП

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -34,6 +34,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		/datum/job/ntspecops,
 		/datum/job/ntspecops/solgovspecops,
 		/datum/job/civilian,
+		/datum/job/civilian/prisoner,
 		/datum/job/syndicateofficer,
 		/datum/job/explorer // blacklisted so that HOPs don't try prioritizing it, then wonder why that doesn't work
 	)


### PR DESCRIPTION

## Описание
Просто добавил роль в черный список, чтобы гп не мог увеличивать или уменьшать количество слотов.

## Причина создания ПР / Почему это хорошо для игры
Ваня, автор предложки, попросил сделать.

## Тесты
Проверил на локалке, нету роли заключенных в консоли гп.
