### PR TITLE
bugfix: Исправлен рантайм при выстреле с боеприпасов без гильз

### DIFF
--- a/code/datums/elements/ranged_attacks.dm
+++ b/code/datums/elements/ranged_attacks.dm
@@ -38,6 +38,7 @@
 		var/obj/item/ammo_casing/casing = new casingtype(startloc)
 		playsound(firer, projectilesound, 100)
 		casing.fire(target, firer, zone_override = ran_zone())
+		casing.after_fire()
 
 	else if(projectiletype)
 		var/obj/projectile/P = new projectiletype(startloc)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -576,6 +576,7 @@
 		var/obj/item/ammo_casing/casing = new casingtype(startloc)
 		playsound(src, projectilesound, 100, TRUE)
 		casing.fire(targeted_atom, src, zone_override = ran_zone())
+		casing.after_fire()
 	else if(projectiletype)
 		var/obj/projectile/P = new projectiletype(startloc)
 		playsound(src, projectilesound, 100, TRUE)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -148,6 +148,9 @@
 	else
 		H.gunshot_residue = caliber
 
+/obj/item/ammo_casing/proc/after_fire()
+	return
+
 //Boxes of ammo
 /obj/item/ammo_box
 	name = "ammo box (generic)"

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -490,11 +490,8 @@
 /obj/item/ammo_casing/caseless
 	desc = "A caseless bullet casing."
 
-/obj/item/ammo_casing/caseless/fire(atom/target, mob/living/user, params, distro, quiet, zone_override = "", spread, atom/firer_source_atom)
-	if(..())
-		qdel(src)
-		return TRUE
-	return FALSE
+/obj/item/ammo_casing/caseless/after_fire()
+	qdel(src)
 
 /obj/item/ammo_casing/caseless/a75
 	desc = "A .75 bullet casing."

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -324,6 +324,7 @@
 						shoot_live_shot(user, target, TRUE, message)
 					else
 						shoot_live_shot(user, target, FALSE, message)
+				chambered.after_fire()
 			else
 				shoot_with_empty_chamber(user)
 				break
@@ -346,6 +347,7 @@
 					shoot_live_shot(user, target, TRUE, message)
 				else
 					shoot_live_shot(user, target, FALSE, message)
+			chambered.after_fire()
 		else
 			shoot_with_empty_chamber(user)
 			return

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -327,7 +327,9 @@
 					shoot_self(user, zone)
 				else
 					user.visible_message(span_danger("[user.name] cowardly fires [src] at [user.p_their()] [zone]!"), span_userdanger("You cowardly fire [src] at your [zone]!"), span_italics("You hear a gunshot!"))
+				chambered.after_fire()
 				return
+			chambered.after_fire()
 
 		user.visible_message(span_danger("*click*"))
 		playsound(user, 'sound/weapons/empty.ogg', 100, TRUE)


### PR DESCRIPTION

## Описание

Баг возникает из-за того что `ammo_casing/caseless` во время вызова прока fire удалял себя через qdel, но `item/gun` после выстрела еще использует эту пулю для звука и вспышки выстрела. 

Добавлен новый прок after_fire для боеприпасов (*пустой*) который вызывается после fire когда использованный боеприпас больше не нужен в оружии. В caseless этот прок переопределяется и удаляет себя.


## Причина создания ПР
При выстреле с гранатомета и донксофт оружия каждый раз вылетает рантайм.
Да и звук выстрела и вспышка на стволе из-за него не воспроизводились.

## Тесты

Проверил на локалке.
