### PR TITLE
tweak: Новые хоткеи ИИ для зон теперь только для малфа

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -273,6 +273,8 @@
 // AREAS
 
 /mob/living/silicon/ai/proc/MiddleControlClickOn(atom/A)
+	if(!ismalfAI(mind))
+		return
 	var/turf/turf = get_turf(A)
 	if (!turf)
 		return
@@ -283,6 +285,8 @@
 		airlock.AICtrlClick(src)
 
 /mob/living/silicon/ai/MiddleShiftClickOn(atom/A)
+	if(!ismalfAI(mind))
+		return
 	var/turf/turf = get_turf(A)
 	if (!turf)
 		return
@@ -293,6 +297,8 @@
 		airlock.AIShiftClick(src)
 
 /mob/living/silicon/ai/proc/MiddleAltClickOn(atom/A)
+	if(!ismalfAI(mind))
+		return
 	var/turf/turf = get_turf(A)
 	if (!turf)
 		return
@@ -303,6 +309,8 @@
 		airlock.ai_click_alt(src)
 
 /mob/living/silicon/ai/proc/MiddleShiftAltClickOn(atom/A)
+	if(!ismalfAI(mind))
+		return
 	var/turf/turf = get_turf(A)
 	if (!turf)
 		return


### PR DESCRIPTION

## Описание

Новые хоткеи для быстрого управления зонами теперь только для малфа.

## Причина создания ПР

Предложка почти прошла голосование
https://discord.com/channels/617003227182792704/1219014729742159952/1399446861013712928


## Тесты
Просто добавил if с проверкой на малфа и ретурн, ничего не ломается.