### PR TITLE
tweak: Убрал замедление у каталок

### DIFF
--- a/code/modules/vehicle/ambulance.dm
+++ b/code/modules/vehicle/ambulance.dm
@@ -48,6 +48,7 @@
 	icon = 'icons/obj/vehicles/CargoTrain.dmi'
 	icon_state = "ambulance"
 	anchored = FALSE
+	pull_push_slowdown = 0	// used for transporting lying mobs
 
 /obj/structure/bed/amb_trolley/examine(mob/user)
 	. = ..()


### PR DESCRIPTION

## Описание

Убрал замедление при пулле каталки парамеда.
У другой обычной каталки итак замедления нет.

## Причина создания ПР

Предложка:
https://discord.com/channels/617003227182792704/618952559607939072/1400535372399902824

## Демонстрация изменений

Сверху каталка парамеда, сниззу каталка на колесиках.
<img width="197" height="218" alt="image" src="https://github.com/user-attachments/assets/55c3b6e8-c114-4ec1-b110-9ed4c193cd90" />


## Тесты

Потаскал с телами и без, амедления нет. Багов тоже нет.
