### PR TITLE
bugfix: Исправление бага с магазинами к огнестрельному оружию

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -38,7 +38,7 @@
 		if(!user.drop_transfer_item_to_loc(new_magazine, src))
 			return ..()
 		if(magazine)
-			magazine.forceMove(drop_location())
+			magazine.forceMove(get_turf(src))
 			magazine.update_appearance()
 		balloon_alert(user, "заряжено")
 		alarmed = FALSE	// Reset the alarm once a magazine is loaded


### PR DESCRIPTION

## Описание бага

При перезарядке оружия которое лежит внутр любого хранилища, старый магазин телепортируется внутрь этого хранилища без учета вместимости самого хранилища. Так что можно сделать вот так 
<img width="538" height="604" alt="image" src="https://github.com/user-attachments/assets/be9b2a91-4dd6-48b8-92cc-f777d8c86608" />

Работает с любым огнестрелом с магазинами в любых хранилищах (*даже внутри импланта хранилища*)

## Исправление

При перезарядке оружия магазин автоматически падает на пол, вне зависимости от того где находится оружие.

## Тесты

Проверено на локалке, баг исправлен.