### PR TITLE
bugfix: Мехи больше не могут бить дистанционно

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -70,6 +70,8 @@
 /atom/movable/Adjacent(atom/neighbor, atom/target, atom/movable/mover)
 	if(neighbor == loc)
 		return TRUE
+	if(neighbor?.loc == src)
+		return TRUE
 	var/turf/T = loc
 	if(!istype(T))
 		return FALSE

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -232,7 +232,7 @@
 
 	if(GLOB.pacifism_after_gt)
 		var/mob/living/L = user
-		if(!target.Adjacent(src))
+		if(!Adjacent(target))
 			if(selected && selected.is_ranged())
 				if(selected.harmful)
 					to_chat(L, span_warning("Вы не хотите навредить другим живым существам!"))
@@ -259,7 +259,7 @@
 		if(user.mind?.martial_art?.no_guns)
 			to_chat(L, span_warning("[L.mind.martial_art.no_guns_message]"))
 			return
-		if(!target.Adjacent(src))
+		if(!Adjacent(target))
 			selected.action(target, params)
 			return
 		else
@@ -275,7 +275,7 @@
 
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		target = safepick(oview(1, src))
-	if(!melee_can_hit || !isatom(target))
+	if(!melee_can_hit || !isatom(target) || !Adjacent(target))
 		return
 	target.mech_melee_attack(src)
 	melee_can_hit = FALSE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Теперь мехи, как и задумывалось, могут бить только вблизи. По сути просто сделал adjacent() как на ТГ, добавив две строчки в adjacent.dm, поменяв их у меха и добавив эту проверку перед мили ударом
## Причина создания ПР / Почему это хорошо для игры
Теперь не будет подобного https://discord.com/channels/617003227182792704/619006931184517131/1400857620402802818
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Запустил локалку, побегал, побил вульп, побить дистанционно не получилось
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
