### PR TITLE
bugfix: БС и Энерго аномалли не будут тепаться/залазить в стены

### DIFF
--- a/code/modules/anomalies/anomalies/bluespace.dm
+++ b/code/modules/anomalies/anomalies/bluespace.dm
@@ -27,6 +27,15 @@
 	if(isliving(target))
 		investigate_log("teleported [key_name_log(target)] to [COORD(target)]", INVESTIGATE_TELEPORTATION)
 
+	var/turf/atom_loc = get_turf(target.loc)
+	if(!atom_loc.is_blocked_turf(exclude_mobs = TRUE))
+		return
+
+	for(var/turf/turf in orange(7, target))
+		if(target.Move(turf))
+			return
+
+
 /obj/effect/anomaly/bluespace/mob_touch_effect(mob/living/mob)
 	..()
 	var/radius = bump_tp_min + round((bump_tp_max - bump_tp_min) * get_strength() / 100)

--- a/code/modules/anomalies/impulses/energetic.dm
+++ b/code/modules/anomalies/impulses/energetic.dm
@@ -29,6 +29,14 @@
 		anomaly.after_move()
 		sleep(2)
 
+	for(var/turf/turf in orange(7, src))
+		if(iswallturf(turf))
+			continue
+
+		anomaly.jump(turf)
+		anomaly.after_move()
+
+
 /datum/anomaly_impulse/move/energ_fastmove/tier1
 	period_low = 5 SECONDS
 	period_high = 20 SECONDS


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
БС аномалии не будут тепаться в стены (и тепать в них других)
Энерго аномалии не будут заканчивать рывки в стенах.
<!-- Опишите, что делает ваш Pull request. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Сегодня на мейне сбежавшая тир 3 бс аномалия убила всё рнд, случайного ассистуху и половину меда (Вторая половина меда застряла в стенах 3*3 на полигоне). Судя по отзывам в гост чате нужно сделать чтоб бс аномалии не застревали в стенах т.к. при застревании до них не достают лазеры.
Энерго аномалия изменена аналогично.
<!-- Здесь можно оставить ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если отчёта нет, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество : https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Тесты
Создал бс и энерго аномалии. За несколько минут наблюдения не заметил чтобы они застревали в стенах.
<!-- Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. -->
