### PR TITLE
tweak: изменение урона острого трея на соответствующий предложке

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -707,8 +707,8 @@
 	)
 	icon = 'icons/obj/food/containers.dmi'
 	icon_state = "dangertray"
-	force = 25
-	throwforce = 25.0
+	force = 5
+	throwforce = 25
 	throw_speed = 3
 	throw_range = 7
 	armour_penetration = 15


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

Сменил урон с 25 до 5 как и должно быть исходя из предложки -> https://discord.com/channels/617003227182792704/755125334097133628/1133438238460215306

## Причина создания ПР / Почему это хорошо для игры

Фикс неправильно установленного урона? В техах не должно лежать итема который дамажит лучше двуручного топора?

## Тесты
Теперь наносит 5 урона но все еще 25 при броске как и должно быть