### PR TITLE
balance: Добавлен кд использования телепорта культистов

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -391,6 +391,8 @@
 		step(src, pick(GLOB.alldirs))
 		to_chat(user, span_warning("[src] flickers out of your hands, too eager to move!"))
 		return
+	if(!do_after(user, 1 SECONDS, user))
+		return
 
 	var/outer_tele_radius = 9
 


### PR DESCRIPTION

## Описание
Добавить КД в 1 секунду при использовании айтему Veil Shifter по аналогии с БС кристаллом.

## Причина создания ПР
Требуется отчет предложки
https://discord.com/channels/617003227182792704/618952559607939072/1401066810505166939

## Тесты
использование занимает 1 секунду как бс кристаллы.