### PR TITLE
bugfix: Исправление рантайма при выстреле последнего патрона из комбат шотгана

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -146,7 +146,7 @@
 
 /obj/item/gun/energy/kinetic_accelerator/shoot_live_shot(mob/living/user, atom/target, pointblank = FALSE, message = TRUE)
 	. = ..()
-	attempt_reload()
+	addtimer(CALLBACK(src, PROC_REF(attempt_reload)), 1)
 
 
 /obj/item/gun/energy/kinetic_accelerator/equipped(mob/user, slot, initial)

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -356,7 +356,7 @@
 
 /obj/item/gun/projectile/shotgun/automatic/shoot_live_shot(mob/living/user, atom/target, pointblank = FALSE, message = TRUE)
 	..()
-	pump(user)
+	addtimer(CALLBACK(src, PROC_REF(pump), user), 1)
 
 /obj/item/gun/projectile/shotgun/automatic/combat
 	name = "combat shotgun"


### PR DESCRIPTION
## Описание

Рантайм возникал из-за того что комбат шотган сразу вызывал прок pump который удалял chambered если это был последний патрон. Перенес pump на вызов таймера через 1 тик.

## Причина создания ПР
<img width="871" height="163" alt="image" src="https://github.com/user-attachments/assets/49c0f2ac-0cda-48e1-95c4-cf275f4d24f1" />

Создал рантайм в попытке починить другой, испраляю.

## Тесты

Теперь на локалке комбат шотган не создает рантаймы.
