### PR TITLE
bugfix: Убирает рантайм из текста стола

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -178,48 +178,48 @@
 
 /obj/structure/proc/structure_shaken()
 
-	for(var/mob/living/M in get_turf(src))
+	for(var/mob/living/mob in get_turf(src))
 
-		if(M.body_position == LYING_DOWN)
-			return //No spamming this on people.
+		if(mob.body_position == LYING_DOWN)
+			continue //No spamming this on people.
 
-		M.Weaken(10 SECONDS)
-		to_chat(M, span_warning("Вы теряете равновесие, когда [declent_ru(NOMINATIVE)] двигается под вами!"))
+		mob.Weaken(10 SECONDS)
+		to_chat(mob, span_warning("Вы теряете равновесие, когда [declent_ru(NOMINATIVE)] двигается под вами!"))
 
 		if(prob(25))
 
 			var/damage = rand(15,30)
-			var/mob/living/carbon/human/H = M
-			if(!istype(H))
-				to_chat(H, span_warning("Вы тяжело приземляетесь!"))
-				M.adjustBruteLoss(damage)
-				return
+			var/mob/living/carbon/human/human = mob
+			if(!istype(human))
+				to_chat(mob, span_warning("Вы тяжело приземляетесь!"))
+				mob.adjustBruteLoss(damage)
+				continue
 
 			var/obj/item/organ/external/affecting
 
 			switch(pick(list("ankle","wrist","head","knee","elbow")))
 				if("ankle")
-					affecting = GLOB.body_zone[pick(BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_R_FOOT)][ACCUSATIVE]
+					affecting = human.get_organ(pick(BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_R_FOOT))
 				if("knee")
-					affecting = GLOB.body_zone[pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)][ACCUSATIVE]
+					affecting = human.get_organ(pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
 				if("wrist")
-					affecting = GLOB.body_zone[pick(BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_HAND)][ACCUSATIVE]
+					affecting = human.get_organ(pick(BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_HAND))
 				if("elbow")
-					affecting = GLOB.body_zone[pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)][ACCUSATIVE]
+					affecting = human.get_organ(pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 				if("head")
-					affecting = GLOB.body_zone[BODY_ZONE_HEAD][ACCUSATIVE]
+					affecting = human.get_organ(BODY_ZONE_HEAD)
 
 			if(affecting)
-				to_chat(M, span_warning("Вы тяжело приземляетесь на [affecting]!"))
-				H.apply_damage(damage, def_zone = affecting)
+				to_chat(human, span_warning("Вы тяжело приземляетесь на [GLOB.body_zone[affecting][ACCUSATIVE]]!"))
+				human.apply_damage(damage, def_zone = affecting)
 				if(affecting?.parent)
 					affecting.parent.add_autopsy_data("Misadventure", damage)
 			else
-				to_chat(H, span_warning("Вы тяжело приземляетесь!"))
-				H.adjustBruteLoss(damage)
+				to_chat(human, span_warning("Вы тяжело приземляетесь!"))
+				human.adjustBruteLoss(damage)
 
-			H.UpdateDamageIcon()
-	return
+			human.UpdateDamageIcon()
+	return TRUE
 
 /obj/structure/proc/can_touch(mob/living/user)
 	if(!istype(user))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -210,7 +210,7 @@
 					affecting = human.get_organ(BODY_ZONE_HEAD)
 
 			if(affecting)
-				to_chat(human, span_warning("Вы тяжело приземляетесь на [GLOB.body_zone[affecting][ACCUSATIVE]]!"))
+				to_chat(human, span_warning("Вы тяжело приземляетесь на [GLOB.body_zone[affecting.limb_zone][ACCUSATIVE]]!"))
 				human.apply_damage(damage, def_zone = affecting)
 				if(affecting?.parent)
 					affecting.parent.add_autopsy_data("Misadventure", damage)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание

Меняет `return` на `continue` - стол переворачивает всех мобов, а не первого попавшегося.
Меняет переменные в structure_shaken() с одной буквы на несколько.
Чинит то, как орган выбирается. Не должно пытаться достать переменные у текста.

## Причина создания ПР / Почему это хорошо для игры

[Пинг в три часа ночи](https://discord.com/channels/617003227182792704/734823601110515882/1403130267715240086).
<img width="1579" height="396" alt="image" src="https://github.com/user-attachments/assets/6cbbb1e0-aecf-4db6-bdfe-29c8338badbc" />

## Тесты

Запустил локалку, встал на стол, потряс стол, получил урон по ноге.
