### PR TITLE
tweak: Удаление CQC у БЩ

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -219,19 +219,14 @@
 	pda = /obj/item/pda/heads/blueshield
 	backpack_contents = list(
 		/obj/item/storage/box/deathimp = 1,
-		/obj/item/gun/energy/gun/blueshield = 1
+		/obj/item/gun/energy/gun/blueshield = 1,
+		/obj/item/gun/projectile/automatic/proto = 1,
+		/obj/item/ammo_box/magazine/smgm9mm = 2
 	)
 	implants = list(/obj/item/implant/mindshield/ert)
 	backpack = /obj/item/storage/backpack/blueshield
 	satchel = /obj/item/storage/backpack/satchel_blueshield
 	dufflebag = /obj/item/storage/backpack/duffel/blueshield
-
-/datum/outfit/job/blueshield/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-	var/datum/martial_art/cqc/CQC = new
-	CQC.teach(H)
 
 /datum/job/judge
 	title = JOB_TITLE_JUDGE

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -220,7 +220,7 @@
 	backpack_contents = list(
 		/obj/item/storage/box/deathimp = 1,
 		/obj/item/gun/energy/gun/blueshield = 1,
-		/obj/item/gun/projectile/automatic/proto = 1,
+		/obj/item/gun/projectile/automatic/proto/rubber = 1,
 		/obj/item/ammo_box/magazine/smgm9mm = 2
 	)
 	implants = list(/obj/item/implant/mindshield/ert)

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -221,7 +221,7 @@
 		/obj/item/storage/box/deathimp = 1,
 		/obj/item/gun/energy/gun/blueshield = 1,
 		/obj/item/gun/projectile/automatic/proto/rubber = 1,
-		/obj/item/ammo_box/magazine/smgm9mm = 2
+		/obj/item/ammo_box/magazine/smgm9mm = 2,
 	)
 	implants = list(/obj/item/implant/mindshield/ert)
 	backpack = /obj/item/storage/backpack/blueshield

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -105,10 +105,6 @@
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_WEAK
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
-/obj/item/ammo_casing/c9mm/rubber
-	desc = "Резиновый патрон калибра 9 мм."
-	projectile_type = /obj/projectile/bullet/weakbullet2
-
 /obj/item/ammo_casing/c9mm/ap
 	materials = list(MAT_METAL = 1500, MAT_SILVER = 150)
 	projectile_type = /obj/projectile/bullet/armourpiercing

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -106,7 +106,7 @@
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
 /obj/item/ammo_casing/c9mm/rubber
-	desc = "Резиновый патрон калибра 9мм."
+	desc = "Резиновый патрон калибра 9 мм."
 	projectile_type = /obj/projectile/bullet/weakbullet2
 
 /obj/item/ammo_casing/c9mm/ap

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -105,6 +105,10 @@
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_WEAK
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
+/obj/item/ammo_casing/c9mm/rubber
+	desc = "Резиновый патрон калибра 9мм."
+	projectile_type = /obj/projectile/bullet/weakbullet2
+
 /obj/item/ammo_casing/c9mm/ap
 	materials = list(MAT_METAL = 1500, MAT_SILVER = 150)
 	projectile_type = /obj/projectile/bullet/armourpiercing

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -401,7 +401,7 @@
 		INSTRUMENTAL = "магазином SMG (резиновый)",
 		PREPOSITIONAL = "магазине SMG (резиновый)"
 	)
-	ammo_type = /obj/item/ammo_casing/c9mm/rubber
+	ammo_type = /obj/item/ammo_casing/rubber9mm
 
 /obj/item/ammo_box/magazine/smgm9mm/ap
 	name = "SMG magazine (Armour Piercing 9mm)"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -391,14 +391,15 @@
 	max_ammo = 21
 
 /obj/item/ammo_box/magazine/smgm9mm/rubber
-	name = "SMG magazine (Rubber 9mm)"
+	name = "magazine SMG (rubber)"
+	desc = "Магазин пистолет-пулемёта SMG, предназначенный для резиновых патронов."
 	ru_names = list(
-		NOMINATIVE = "магазин резиновых пуль калибра 9мм",
-		GENITIVE = "магазина резиновых пуль калибра 9мм",
-		DATIVE = "магазину резиновых пуль калибра 9мм",
-		ACCUSATIVE = "магазина резиновых пуль калибра 9мм",
-		INSTRUMENTAL = "магазином резиновых пуль калибра 9мм",
-		PREPOSITIONAL = "магазине резиновых пуль калибра 9мм"
+		NOMINATIVE = "магазин SMG (резиновый)",
+		GENITIVE = "магазина SMG (резиновый)",
+		DATIVE = "магазину SMG (резиновый)",
+		ACCUSATIVE = "магазина SMG (резиновый)",
+		INSTRUMENTAL = "магазином SMG (резиновый)",
+		PREPOSITIONAL = "магазине SMG (резиновый)"
 	)
 	ammo_type = /obj/item/ammo_casing/c9mm/rubber
 

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -390,6 +390,18 @@
 	caliber = "9mm"
 	max_ammo = 21
 
+/obj/item/ammo_box/magazine/smgm9mm/rubber
+	name = "SMG magazine (Rubber 9mm)"
+	ru_names = list(
+		NOMINATIVE = "магазин резиновых пуль калибра 9мм",
+		GENITIVE = "магазина резиновых пуль калибра 9мм",
+		DATIVE = "магазину резиновых пуль калибра 9мм",
+		ACCUSATIVE = "магазина резиновых пуль калибра 9мм",
+		INSTRUMENTAL = "магазином резиновых пуль калибра 9мм",
+		PREPOSITIONAL = "магазине резиновых пуль калибра 9мм"
+	)
+	ammo_type = /obj/item/ammo_casing/c9mm/rubber
+
 /obj/item/ammo_box/magazine/smgm9mm/ap
 	name = "SMG magazine (Armour Piercing 9mm)"
 	ammo_type = /obj/item/ammo_casing/c9mm/ap

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -93,6 +93,9 @@
 	fire_sound = 'sound/weapons/gunshots/1c20.ogg'
 	accuracy = GUN_ACCURACY_DEFAULT
 
+/obj/item/gun/projectile/automatic/proto/rubber
+	mag_type = /obj/item/ammo_box/magazine/smgm9mm/rubber
+
 //C-20r SMG//
 /obj/item/gun/projectile/automatic/c20r
 	name = "C-20r SMG"


### PR DESCRIPTION
## Описание

Удаляет сикуси у БЩ, добавляет ему сэйбер смг на резине взамен

## Причина создания ПР / Почему это хорошо для игры

Эшель сказал так надо 

## Демонстрация изменений

https://cdn.discordapp.com/attachments/1403147388088090655/1403153959941574757/Desktop_2025.08.08_-_02.12.38.01.mp4?ex=68968475&is=689532f5&hm=72b97c7c2b9307197407f11b0cf34a3d3048d4094926febe9c378f0852a62819&

## Тесты

В видео выше, вкладки БИ нет, пушка на резине - есть
