### PR TITLE
balance: Улучшение комплекта шахтерской взрывчатки

### DIFF
--- a/code/modules/mining/equipment/mining_charges.dm
+++ b/code/modules/mining/equipment/mining_charges.dm
@@ -181,11 +181,15 @@
 	boom_sizes = list(4,6,8) //did you see the price? It has to be better..
 
 /obj/item/storage/backpack/duffel/miningcharges/populate_contents()
-	for(var/i in 1 to 4)
-		new /obj/item/grenade/plastic/miningcharge/lesser(src)
 	for(var/i in 1 to 2)
+		new /obj/item/grenade/plastic/miningcharge/mega(src)
+	for(var/i in 1 to 4)
 		new /obj/item/grenade/plastic/miningcharge(src)
+	for(var/i in 1 to 5)
+		new /obj/item/grenade/plastic/miningcharge/lesser(src)
 	new /obj/item/detonator(src)
+	new /obj/item/t_scanner/adv_mining_scanner/lesser(src)
+	new /obj/item/storage/bag/ore/bigger(src)
 
 
 //MINING CHARGE HACKER


### PR DESCRIPTION
## Описание
Изменяет содержимое набора взрывчатки по ваучеру у шахтеров. 
Теперь в наборе:

- 2 экспериментальных шахтерских заряда.
- 4 индустриальных шахтерских заряда.
- 5 обычных шахтерских заряда.
- Детонатор.
- Автоматический шахтерский сканер руды. 
- Индустриальная сумка для руды. 

## Причина создания ПР / Почему это хорошо для игры
Ориг. автор идеи - https://discord.com/channels/617003227182792704/1402911758602993725

## Демонстрация изменений
<img width="593" height="594" alt="Screenshot_1" src="https://github.com/user-attachments/assets/1d6a237a-3245-4406-836f-910bbe1496a0" />
<img width="625" height="376" alt="Screenshot_29" src="https://github.com/user-attachments/assets/469e7450-023f-4d62-8f04-1dfddc3f4c00" />

## Тесты
Проверил на локальном сервере, ошибок нет. 