### PR TITLE
bugfix: фикс аммо вендора

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -22,14 +22,6 @@
 /obj/item/storage/box
 	name = "box"
 	desc = "Это обычная коробка."
-	ru_names = list(
-		NOMINATIVE = "коробка",
-		GENITIVE = "коробки",
-		DATIVE = "коробке",
-		ACCUSATIVE = "коробку",
-		INSTRUMENTAL = "коробкой",
-		PREPOSITIONAL = "коробке"
-	)
 	icon_state = "box"
 	item_state = "syringe_kit"
 	resistance_flags = FLAMMABLE


### PR DESCRIPTION
## Описание

Удаляет ру_неймс у дефолт коробки, чинит вендор патрон 

## Причина создания ПР / Почему это хорошо для игры

Вендор не сломан, все коробки в игре которые имеют кастомное название можно пихать в вендоры
