### PR TITLE
balance: никакого акимбо для вт и сп

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -154,6 +154,7 @@
 	accuracy = new /datum/gun_accuracy/rifle/extend_spread()
 	actions_types = null
 	recoil = GUN_RECOIL_MEDIUM
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/projectile/automatic/wt550/ComponentInitialize()
 	AddComponent( \
@@ -196,6 +197,7 @@
 	accuracy = new /datum/gun_accuracy/rifle/extend_spread()
 	actions_types = null
 	recoil = GUN_RECOIL_MEDIUM
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/projectile/automatic/sp91rc/ComponentInitialize()
 	AddComponent( \
@@ -236,6 +238,7 @@ TODO Use this name and desc for localisation*/
 	burst_size = 1
 	accuracy = GUN_ACCURACY_PISTOL
 	recoil = GUN_RECOIL_LOW
+	actions_types = null
 
 /obj/item/gun/projectile/automatic/mini_uzi/ComponentInitialize()
 	AddComponent( \


### PR DESCRIPTION
## Что этот ПР делает

Все что написано в названии. Теперь чтобы стрелять с СП и ВТ нужна вторая свободная рука.

## Почему это хорошо для игры

Акимбо пушечки со скорострельностью не круто.

## Тестирование

Все работает.
