### PR TITLE
balance: Расовых резистов больше нет

### DIFF
--- a/code/modules/mob/living/carbon/human/species/kidan.dm
+++ b/code/modules/mob/living/carbon/human/species/kidan.dm
@@ -9,8 +9,6 @@
 	language = LANGUAGE_KIDAN
 	unarmed_type = /datum/unarmed_attack/claws
 
-	brute_mod = 0.8
-	tox_mod = 1.7
 
 	inherent_traits = list(
 		TRAIT_HAS_REGENERATION,

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -15,8 +15,6 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
-	brute_mod = 1 // 100% * 2.28 * 0.66 (robolimbs) ~= 150% // nope
-	burn_mod = 1  // So they take 50% extra damage from brute/burn overall // nope
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "изда%(ёт,ют)% резкие пронзительные звуки и, конвульсивно подёргивая шасси, окончательно отключа%(ет,ют)%ся."

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -29,9 +29,8 @@
 
 	breathid = "tox"
 
-	brute_mod = 0.9
-	burn_mod = 1.5
-	heatmod = 1.5
+	burn_mod = 1.2
+	heatmod = 1.2
 
 	//Has default darksight of 2.
 
@@ -253,7 +252,7 @@
 /datum/species/plasmaman/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
 	switch(R.id)
 		if("plasma")
-			H.heal_overall_damage(0.25, 0.25)
+			H.heal_overall_damage(0.5, 0.5)
 			H.adjust_alien_plasma(20)
 			H.reagents.remove_reagent(R.id, REAGENTS_METABOLISM)
 			return FALSE //Handling reagent removal on our own. Prevents plasma from dealing toxin damage to Plasmaman

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -11,10 +11,9 @@
 	unarmed_type = /datum/unarmed_attack/claws
 	primitive_form = /datum/species/monkey/unathi
 
-	brute_mod = 0.9
 	heatmod = 0.8
 	coldmod = 1.2
-	hunger_drain_mod = 1.6
+	hunger_drain_mod = 1.3
 
 	blurb = "A heavily reptillian species, Unathi (or 'Sinta as they call themselves) hail from the \
 	Uuosa-Eso system, which roughly translates to 'burning mother'.<br/><br/>Coming from a harsh, radioactive \

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -165,7 +165,7 @@
 
 	language = LANGUAGE_UNATHI
 	default_language = LANGUAGE_UNATHI
-
+	brute_mod = 0.9
 	speed_mod = -0.50
 
 	inherent_traits = list(

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -1051,8 +1051,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(make_tough)
 		tough = TRUE
 	else
-		brute_mod = 0.66
-		burn_mod = 0.66
 		dismember_at_max_damage = TRUE
 
 	// Robot parts also lack bones


### PR DESCRIPTION

## Что этот ПР делает

Все расы потеряли резисты к прямому урону. Не касается особых рас, вроде големов, драконидов, тенеморфов.
## Почему это хорошо для игры

https://discord.com/channels/617003227182792704/755125334097133628/1400110728505200714

## Тестирование

<img width="1353" height="622" alt="image" src="https://github.com/user-attachments/assets/fe16ae61-ba71-4b43-b65b-36e3f6bf2611" />
Бьём мобов на локалке тулбоксом в 10 урона пабеда

P.S изменение резистов КПБ также будет касаться любых кибер конечностей. Т.Е хуманы с кибер руками также теряют этот резист к урону.
