### PR TITLE
add: Тихий режим для диктофона

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -126,7 +126,7 @@
 
 /obj/item/taperecorder/proc/toggle_silent_mode(mob/user)
 	silent_mode = !silent_mode
-	balloon_alert(user, "Вы [silent_mode ? "включили" : "выключили"] тихий режим.")
+	balloon_alert(user, "тихий режим [silent_mode ? "включён" : "выключен"]")
 	playsound(src, 'sound/machines/switch.ogg', 20, FALSE)
 
 /obj/item/taperecorder/click_alt(mob/living/user)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -124,7 +124,7 @@
 		record()
 
 #define PLAYBACK_TAPE "Воспроизведение кассеты"
-#define PRINT_TRANSCRIPT "Распечатка транскрипта"
+#define PRINT_TRANSCRIPT "Распечатать стенограмму"
 #define EJECT_TAPE "Достать кассету"
 #define SILENT_MODE "Тихий режим"
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -130,6 +130,7 @@
 
 /obj/item/taperecorder/proc/toggle_silent_mode(mob/user)
 	silent_mode = !silent_mode
+	update_sound()
 	balloon_alert(user, "тихий режим [silent_mode ? "включён" : "выключен"]")
 	playsound(src, 'sound/machines/switch.ogg', 20, FALSE)
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -66,10 +66,7 @@
 
 
 /obj/item/taperecorder/proc/update_sound()
-	if(silent_mode)
-		return
-	
-	if(!playing && !recording)
+	if(!playing && !recording || silent_mode)
 		soundloop.stop()
 	else
 		soundloop.start()

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -66,7 +66,10 @@
 
 
 /obj/item/taperecorder/proc/update_sound()
-	if(!playing && !recording || silent_mode)
+	if(silent_mode)
+		return
+	
+	if(!playing && !recording)
 		soundloop.stop()
 	else
 		soundloop.start()

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -169,7 +169,10 @@
 	else
 		tts_seed = initial(tts_seed)
 		atom_say_verb = "говорит"
-		silent_mode ? balloon_alert(ismob(loc) ? loc : null, "[message]") : atom_say("[message]")
+		if(silent_mode)
+			balloon_alert(ismob(loc) ? loc : null, "[message]")
+			return
+		atom_say("[message]")
 
 /obj/item/taperecorder/proc/eject(mob/user)
 	if(mytape)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -123,6 +123,10 @@
 	else
 		record()
 
+#define PLAYBACK_TAPE "Воспроизведение кассеты"
+#define PRINT_TRANSCRIPT "Распечатка транскрипта"
+#define EJECT_TAPE "Достать кассету"
+#define SILENT_MODE "Тихий режим"
 
 /obj/item/taperecorder/proc/toggle_silent_mode(mob/user)
 	silent_mode = !silent_mode
@@ -133,24 +137,29 @@
 	if(!mytape)
 		return NONE
 
-	var/list/options = list( "Playback Tape" = image(icon = 'icons/obj/device.dmi', icon_state = "taperecorder_playing"),
-					"Print Transcript" = image(icon = 'icons/obj/bureaucracy.dmi', icon_state = "paper_words"),
-					"Eject Tape" = image(icon = 'icons/obj/device.dmi', icon_state = "[mytape.icon_state]"),
-					"Silent mode" = image(icon = silent_mode ? 'icons/obj/items.dmi' : 'icons/obj/device.dmi' , icon_state = silent_mode ? "earmuffs" : "megaphone")
+	var/list/options = list( PLAYBACK_TAPE = image(icon = 'icons/obj/device.dmi', icon_state = "taperecorder_playing"),
+					PRINT_TRANSCRIPT = image(icon = 'icons/obj/bureaucracy.dmi', icon_state = "paper_words"),
+					EJECT_TAPE = image(icon = 'icons/obj/device.dmi', icon_state = "[mytape.icon_state]"),
+					SILENT_MODE = image(icon = silent_mode ? 'icons/obj/items.dmi' : 'icons/obj/device.dmi' , icon_state = silent_mode ? "earmuffs" : "megaphone")
 					)
 	var/choice = show_radial_menu(user, src, options, require_near = TRUE)
 	if(!choice || user.incapacitated())
 		return CLICK_ACTION_BLOCKING
 	switch(choice)
-		if("Playback Tape")
+		if(PLAYBACK_TAPE)
 			play(user)
-		if("Print Transcript")
+		if(PRINT_TRANSCRIPT)
 			print_transcript(user)
-		if("Eject Tape")
+		if(EJECT_TAPE)
 			eject(user)
-		if("Silent mode")
+		if(SILENT_MODE)
 			toggle_silent_mode(user)
 	return CLICK_ACTION_SUCCESS
+
+#undef PLAYBACK_TAPE
+#undef PRINT_TRANSCRIPT
+#undef EJECT_TAPE
+#undef SILENT_MODE
 
 /obj/item/taperecorder/proc/recorder_say(message, datum/tape_piece/record_datum)
 	if(record_datum)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -26,6 +26,8 @@
 	var/starts_with_tape = TRUE
 	/// Sound loop that plays when recording or playing back.
 	var/datum/looping_sound/tape_recorder_hiss/soundloop
+	/// Sound or loud mode
+	var/silent_mode = FALSE
 
 
 /obj/item/taperecorder/empty
@@ -64,7 +66,7 @@
 
 
 /obj/item/taperecorder/proc/update_sound()
-	if(!playing && !recording)
+	if(!playing && !recording || silent_mode)
 		soundloop.stop()
 	else
 		soundloop.start()
@@ -122,13 +124,19 @@
 		record()
 
 
+/obj/item/taperecorder/proc/toggle_silent_mode(mob/user)
+	silent_mode = !silent_mode
+	balloon_alert(user, "Вы [silent_mode ? "включили" : "выключили"] тихий режим.")
+	playsound(src, 'sound/machines/switch.ogg', 20, FALSE)
+
 /obj/item/taperecorder/click_alt(mob/living/user)
 	if(!mytape)
 		return NONE
 
 	var/list/options = list( "Playback Tape" = image(icon = 'icons/obj/device.dmi', icon_state = "taperecorder_playing"),
 					"Print Transcript" = image(icon = 'icons/obj/bureaucracy.dmi', icon_state = "paper_words"),
-					"Eject Tape" = image(icon = 'icons/obj/device.dmi', icon_state = "[mytape.icon_state]")
+					"Eject Tape" = image(icon = 'icons/obj/device.dmi', icon_state = "[mytape.icon_state]"),
+					"Silent mode" = image(icon = silent_mode ? 'icons/obj/items.dmi' : 'icons/obj/device.dmi' , icon_state = silent_mode ? "earmuffs" : "megaphone")
 					)
 	var/choice = show_radial_menu(user, src, options, require_near = TRUE)
 	if(!choice || user.incapacitated())
@@ -140,6 +148,8 @@
 			print_transcript(user)
 		if("Eject Tape")
 			eject(user)
+		if("Silent mode")
+			toggle_silent_mode(user)
 	return CLICK_ACTION_SUCCESS
 
 /obj/item/taperecorder/proc/recorder_say(message, datum/tape_piece/record_datum)
@@ -150,8 +160,7 @@
 	else
 		tts_seed = initial(tts_seed)
 		atom_say_verb = "говорит"
-		atom_say("[message]")
-
+		silent_mode ? balloon_alert(ismob(loc) ? loc : null, "[message]") : atom_say("[message]")
 
 /obj/item/taperecorder/proc/eject(mob/user)
 	if(mytape)


### PR DESCRIPTION
## Что этот ПР делает
Добавляем новый режим для диктофона - Тихий. Через альт можно включить этот режим
Тихий режим позволяет беззвучно включать диктофон без кричащего "ЗАПИСЬ НАЧАЛАСЬ" "ЗАПИСЬ ЗАКОНЧИЛАСЬ", а так же убирает шум от диктофона.

## Почему это хорошо для игры
Новый полезный функционал диктофона 
## Демонстрация изменений

<img width="272" height="207" alt="dreamseeker_L4hpzVxjHH" src="https://github.com/user-attachments/assets/000a16de-89d7-41c7-8d66-249946ed53b9" />

## Тестирование

Тестировал на локалке, вроде рантаймов и ошибок не было
