### PR TITLE
balance: Убрать отбрасывание у биты и дать knockdown взамен

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -358,9 +358,8 @@
 		// No throwing mobs that have higher than normal move_resist.
 		// Covers: revenant, bot/mulebot, hostile/statue, hostile/megafauna, goliath
 		return .
-	var/atom/throw_target = get_edge_target_turf(target, user.dir)
 	if(!homerun_always_charged)
-		INVOKE_ASYNC(target, TYPE_PROC_REF(/atom/movable, throw_at), throw_target, rand(1, 2), 7, user)
+		target.Weaken(1 SECONDS)
 	next_throw_time = world.time + 10 SECONDS
 
 

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -359,7 +359,7 @@
 		// Covers: revenant, bot/mulebot, hostile/statue, hostile/megafauna, goliath
 		return .
 	if(!homerun_always_charged)
-		target.Weaken(1 SECONDS)
+		target.Knockdown(1 SECONDS)
 	next_throw_time = world.time + 10 SECONDS
 
 


### PR DESCRIPTION
## Что этот ПР делает

Убирает отбрасывание при ударе у биты.
Дает weaken на 1 секунду вместо отбрасывания.


## Почему это хорошо для игры

Мусорный предмет крафтящийся из палок имеет такой же функционал отбрасывания как у молота генки. 
Отбрасывание в стену дает 30 урона с переломами и внутряками, вместо 10 нормальных. Очевидно слишком сильный функционал для мусорного предмета. Чтобы полностью не  убивать предмет даем weaken на 1 секунду.

## Тестирование

Проверил на локалке, отбрасывания больше нет, раз в 10 секунд кладет цель на пол. 