### PR TITLE
bugfix: Удален вывод в логи шаттла космокладбища если пристыкован шаттл доп целей

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -33,6 +33,7 @@
 
 // Shuttle return values
 #define SHUTTLE_CAN_DOCK "can_dock"
+#define SHUTTLE_LOCKED "shuttle_locked"
 #define SHUTTLE_NOT_A_DOCKING_PORT "not_a_docking_port"
 #define SHUTTLE_DWIDTH_TOO_LARGE "docking_width_too_large"
 #define SHUTTLE_WIDTH_TOO_LARGE "width_too_large"

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -317,6 +317,8 @@
 
 //this is to check if this shuttle can physically dock at dock S
 /obj/docking_port/mobile/proc/canDock(obj/docking_port/stationary/S)
+	if(locked_move)
+		return SHUTTLE_LOCKED
 	if(!istype(S))
 		return SHUTTLE_NOT_A_DOCKING_PORT
 	if(istype(S, /obj/docking_port/stationary/transit))
@@ -344,6 +346,8 @@
 
 /obj/docking_port/mobile/proc/check_dock(obj/docking_port/stationary/S)
 	var/status = canDock(S)
+	if(status == SHUTTLE_LOCKED)
+		return FALSE
 	if(status == SHUTTLE_CAN_DOCK)
 		return TRUE
 	else if(status == SHUTTLE_ALREADY_DOCKED)

--- a/code/modules/shuttle/shuttle_manipulator.dm
+++ b/code/modules/shuttle/shuttle_manipulator.dm
@@ -236,6 +236,9 @@
 		throw EXCEPTION(m)
 
 	var/result = preview_shuttle.canDock(D)
+	if(result == SHUTTLE_LOCKED)
+		// currenct shuttle is locked, do nothing
+		return
 	// truthy value means that it cannot dock for some reason
 	// but we can ignore the someone else docked error because we'll
 	// be moving into their place shortly


### PR DESCRIPTION


## Что этот ПР делает

Убирает вывод в лог когда шаттл доп целей пристыкован на станции и кто-то пытается прилететь на шаттле космокладбища.

## Почему это хорошо для игры

Не будет срать в логи.


## Тестирование

Пристыковал шаттл доп целей на локалке, нажатие на кнопку шаттла космокладбища ничего не делает.
