### PR TITLE
balance: Больше нельзя использовать зелье ускорения на транспорте

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -529,19 +529,19 @@
 		return
 	..()
 	if(!istype(O))
-		to_chat(user, "<span class='warning'>The potion can only be used on items!</span>")
+		to_chat(user, span_warning("The potion can only be used on items!"))
 		return
 	if(SEND_SIGNAL(O, COMSIG_SPEED_POTION_APPLIED, src, user) & SPEED_POTION_STOP)
 		return
 	if(isitem(O))
 		var/obj/item/I = O
 		if(I.slowdown <= 0 || (I.item_flags & IGNORE_SLOWDOWN) || (I.item_flags & SPEEDPOTION_APPLIED))
-			to_chat(user, "<span class='warning'>[I] can't be made any faster!</span>")
+			to_chat(user, span_warning("[I] can't be made any faster!"))
 			return ..()
 		if(isclothing(O))
 			var/obj/item/clothing/cloth = O
 			if(cloth.clothing_flags & FIXED_SLOWDOWN)
-				to_chat(user, "<span class='warning'>[I] can't be made any faster!</span>")
+				to_chat(user, span_warning("[I] can't be made any faster!</span>"))
 				return
 		I.slowdown /= 2
 		I.item_flags |= SPEEDPOTION_APPLIED
@@ -556,7 +556,7 @@
 
 	O.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 	O.add_atom_colour(COLOR_RED, WASHABLE_COLOUR_PRIORITY)
-	to_chat(user, "<span class='notice'>You slather the red gunk over [O], making it faster.</span>")
+	to_chat(user, span_notice("You slather the red gunk over [O], making it faster.</span>"))
 	qdel(src)
 
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -529,7 +529,7 @@
 		return
 	..()
 	if(!istype(O))
-		to_chat(user, "<span class='warning'>The potion can only be used on items or vehicles!</span>")
+		to_chat(user, "<span class='warning'>The potion can only be used on items!</span>")
 		return
 	if(SEND_SIGNAL(O, COMSIG_SPEED_POTION_APPLIED, src, user) & SPEED_POTION_STOP)
 		return


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- Список тегов для ПРа:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map Вы меняете только карту.
- local Вы делаете добавляете новый текст на русском или переводите на русский.
- imageadd:  Вы добавили новый спрайт.
- imagedel:  Вы удалили старый спрайт.
- soundadd: Вы добавили новый звук.
- sounddel: Вы удалили старый звук.
- spellcheck: Вы исправили опечатку.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает

Убирает возможность использовать зелье ускорения на транспорте.

## Почему это хорошо для игры

Чизовая механика, которая используется только для преимущества в ПВП.

- balance: Удалена возможность ускорить транспорт зельем ускорения.
