### PR TITLE
bugfix: Прикуренная сигарета отображается корректно

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -243,12 +243,14 @@ LIGHTERS ARE IN LIGHTERS.DM
 	if(!ru_names)
 		ru_names = get_ru_names_cached()
 
-	ru_names[NOMINATIVE] = "прикуренная " + ru_names[NOMINATIVE]
-	ru_names[GENITIVE] = "прикуренной " + ru_names[GENITIVE]
-	ru_names[DATIVE] = "прикуренной " + ru_names[DATIVE]
-	ru_names[ACCUSATIVE] = "прикуренную " + ru_names[ACCUSATIVE]
-	ru_names[INSTRUMENTAL] = "прикуренной " + ru_names[INSTRUMENTAL]
-	ru_names[PREPOSITIONAL] = "прикуренной " + ru_names[PREPOSITIONAL]
+	ru_names = list(
+		NOMINATIVE = "[lit ? "прикуренная " : ""]сигарета",
+		GENITIVE = "[lit ? "прикуренной " : ""]сигареты",
+		DATIVE = "[lit ? "прикуренной " : ""]сигарете",
+		ACCUSATIVE = "[lit ? "прикуренную " : ""]сигарету",
+		INSTRUMENTAL = "[lit ? "прикуренной " : ""]сигаретой",
+		PREPOSITIONAL = "[lit ? "прикуренной " : ""]сигарете"
+	)
 
 /obj/item/clothing/mask/cigarette/get_heat()
 	return lit * 1000


### PR DESCRIPTION
## Что этот ПР делает
<details><summary>Бросайте курить</summary>
<p>

<img width="681" height="89" alt="image" src="https://github.com/user-attachments/assets/76d51f06-eaa3-4106-9200-40bde500f06e" />

<img width="515" height="404" alt="image" src="https://github.com/user-attachments/assets/ad4d75a7-0e06-4a2f-a9a7-2b7ff31013b5" />

</p>
</details> 

## Демонстрация изменений
<details><summary>Бросайте курить</summary>
<p>

<img width="369" height="173" alt="image" src="https://github.com/user-attachments/assets/de752d03-bb8e-4276-82dd-8259482eecf3" />

</p>
</details> 
