### PR TITLE
bugfix: Дебрисы, описание сигарет, скринтипы

### DIFF
--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -146,4 +146,3 @@
 
 /// Adds the debris element for projectile impacts.
 /atom/proc/add_debris_element()
-	AddElement(/datum/element/debris, null, -40, 8, 0.7)

--- a/code/_onclick/hud/screentip.dm
+++ b/code/_onclick/hud/screentip.dm
@@ -4,7 +4,7 @@
 	screen_loc = "TOP,LEFT"
 	maptext_height = 480
 	maptext_width = 480
-	maptext_y = -15
+	maptext_y = -25
 	maptext = ""
 
 /atom/movable/screen/screentip/Initialize(mapload, _hud)

--- a/code/_onclick/hud/screentip.dm
+++ b/code/_onclick/hud/screentip.dm
@@ -4,7 +4,7 @@
 	screen_loc = "TOP,LEFT"
 	maptext_height = 480
 	maptext_width = 480
-	maptext_y = -40
+	maptext_y = -15
 	maptext = ""
 
 /atom/movable/screen/screentip/Initialize(mapload, _hud)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -148,7 +148,7 @@
 
 	if(names && !GLOB.cached_ru_names[type])
 		GLOB.cached_ru_names[type] = names
-		
+
 	ru_names = null
 
 	if(flags & INITIALIZED)
@@ -1845,7 +1845,7 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 		return
 
 	//We inline a MAPTEXT() here, because there's no good way to statically add to a string like this
-	active_hud.screentip_text.maptext = MAPTEXT("<span style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[capitalize(src.declent_ru(NOMINATIVE))]</span>")
+	active_hud.screentip_text.maptext = MAPTEXT("<span style='font-family: sans-serif; text-align: center; font-size: [screentip_mode]px; color: [usr.client.prefs.screentip_color]'>[src.declent_ru(NOMINATIVE)]</span>")
 
 // This is normal, I assure you. Paradise optimization.
 /atom/MouseExited(location, control, params)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -163,6 +163,8 @@ Class Procs:
 	end_processing()
 	return ..()
 
+/obj/machinery/add_debris_element()
+	AddElement(/datum/element/debris, null, -40, 8, 0.7)
 
 /*
  * reimp, attempts to flicker this machinery if the behavior is supported.

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -244,12 +244,12 @@ LIGHTERS ARE IN LIGHTERS.DM
 		ru_names = get_ru_names_cached()
 
 	ru_names = list(
-		NOMINATIVE = "[lit ? "прикуренная " : ""]сигарета",
-		GENITIVE = "[lit ? "прикуренной " : ""]сигареты",
-		DATIVE = "[lit ? "прикуренной " : ""]сигарете",
-		ACCUSATIVE = "[lit ? "прикуренную " : ""]сигарету",
-		INSTRUMENTAL = "[lit ? "прикуренной " : ""]сигаретой",
-		PREPOSITIONAL = "[lit ? "прикуренной " : ""]сигарете"
+		NOMINATIVE = "[lit ? "прикуренная " : ""]" + ru_names[NOMINATIVE],
+		GENITIVE = "[lit ? "прикуренной " : ""]" + ru_names[GENITIVE],
+		DATIVE = "[lit ? "прикуренной " : ""]" + ru_names[DATIVE],
+		ACCUSATIVE = "[lit ? "прикуренную " : ""]" + ru_names[ACCUSATIVE],
+		INSTRUMENTAL = "[lit ? "прикуренной " : ""]" + ru_names[INSTRUMENTAL],
+		PREPOSITIONAL = "[lit ? "прикуренной " : ""]" + ru_names[PREPOSITIONAL]
 	)
 
 /obj/item/clothing/mask/cigarette/get_heat()

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -154,7 +154,7 @@
 /obj/item/kitchen/knife/Initialize(mapload)
 	. = ..()
 	default_force = force
-	default_throwforce = throwforce	
+	default_throwforce = throwforce
 
 /obj/item/kitchen/knife/sharpen_act(obj/item/whetstone/whetstone, mob/user)
 	. = ..()
@@ -170,7 +170,7 @@
 
 /obj/item/kitchen/knife/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = INFINITY, dodgeable = TRUE)
 	. = ..()
-	playsound(src, 'sound/weapons/knife_holster/knife_throw.ogg', 30, 1)
+	playsound(src, 'sound/weapons/knife_holster/knife_throw.ogg', 30, TRUE)
 
 
 /obj/item/kitchen/knife/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -45,6 +45,8 @@
 		STOP_PROCESSING(SSobj, src)
 	return ..()
 
+/obj/structure/add_debris_element()
+	AddElement(/datum/element/debris, null, -40, 8, 0.7)
 
 /obj/structure/Move(atom/newloc, direct = NONE, glide_size_override = 0, update_dir = TRUE)
 	var/atom/old_loc = loc

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -14,6 +14,9 @@
 	. = ..()
 	add_debris_element()
 
+/turf/simulated/add_debris_element()
+	AddElement(/datum/element/debris, null, -40, 8, 0.7)
+
 /turf/simulated/proc/break_tile()
 	return
 

--- a/code/game/turfs/simulated/openspace.dm
+++ b/code/game/turfs/simulated/openspace.dm
@@ -6,6 +6,7 @@
 	baseturf = /turf/simulated/openspace
 	//mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pathing_pass_method = TURF_PATHING_PASS_PROC
+	flags = NO_SCREENTIPS
 	var/can_cover_up = TRUE
 	var/can_build_on = TRUE
 


### PR DESCRIPTION
## Что этот ПР делает
- Поднял скринтипы выше и убрал капиталайз.
- Перенёс элемент дебрисов с `/atom` на `/turf/simulated | /obj/machinery | /obj/structure`
- Убрал скринтип у опенспейса.
- Описание сигарет снова подсасывает рунеймс.
