### PR TITLE
bugfix: Перенос sharpen из названия в описание

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -278,9 +278,9 @@
 	icon_state = "cult_sharpener"
 	increment = 5
 	max = 40
-	prefix = "darkened"
 	claws_increment = 4
-
+	gender = MALE
+	prefix = "Потемневшее"
 
 /obj/item/whetstone/cult/update_icon_state()
 	icon_state = "cult_sharpener[!uses ? "_used" : ""]"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1351,7 +1351,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 /// Default item sharpening effect.
 /// Return `FALSE` to stop sharpening.
 /obj/item/proc/sharpen_act(obj/item/whetstone/whetstone, mob/user)
-	name = "[whetstone.prefix] [name]"
+	desc = "[initial(desc)] [span_boldwarning("[whetstone.prefix]!")]"
 	force = clamp(force + whetstone.increment, 0, whetstone.max)
 	throwforce = clamp(throwforce + whetstone.increment, 0, whetstone.max)
 	set_sharpness(TRUE)

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -15,7 +15,7 @@
 	/// Maximum force sharpening items with the whetstone can result in.
 	var/max = 30
 	/// The prefix a whetstone applies when an item is sharpened with it.
-	var/prefix = "sharpened"
+	var/prefix = "Острое"
 	/// If TRUE, the whetstone will only sharpen already sharp items.
 	var/requires_sharpness = TRUE
 
@@ -106,7 +106,7 @@
 	desc = "Каменный блок, который заточит ваше оружие острее, чем Эйнштейн на аддералле."
 	increment = 200
 	max = 200
-	prefix = "super-sharpened"
+	prefix = "Крайне острое"
 	requires_sharpness = FALSE
 	claws_increment = 200
 

--- a/code/modules/games/52card.dm
+++ b/code/modules/games/52card.dm
@@ -121,7 +121,7 @@
 	)
 
 /obj/item/deck/cards/syndicate/sharpen_act(obj/item/whetstone/whetstone, mob/user)
-	name = "[whetstone.prefix] [name]"
+	desc = "[initial(desc)] [span_boldnotice("[whetstone.prefix]!")]"
 	card_force = clamp(card_force + whetstone.increment, 0, whetstone.max)
 	card_throwforce = clamp(card_throwforce + whetstone.increment, 0, whetstone.max)
 	set_sharpness(TRUE)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -77,7 +77,7 @@
 				if(!drop_item_ground(r_hand))
 					continue
 
-			custom_emote(EMOTE_VISIBLE, "броса[pluralize_ru(gender,"ет","ют")] предмет, который держал[genderize_ru(gender,"","а","о","и")] держали, [genderize_ru(gender,"его","её","его","их")] [bodypart.declent_ru(NOMINATIVE)] выход[pluralize_ru(bodypart.gender,"ит","ят")] из строя!")
+			custom_emote(EMOTE_VISIBLE, "броса[pluralize_ru(gender,"ет","ют")] предмет, который держал[genderize_ru(gender,"","а","о","и")], [genderize_ru(gender,"его","её","его","их")] [bodypart.declent_ru(NOMINATIVE)] выход[pluralize_ru(bodypart.gender,"ит","ят")] из строя!")
 
 			do_sparks(5, FALSE, src)
 


### PR DESCRIPTION
## Что этот ПР делает
Муть с рунеймсами и неймами меня огорчает. Перенос информации о заточке в описание из названия.

P.S. spellcheck:
<img width="674" height="44" alt="image" src="https://github.com/user-attachments/assets/6cfd9c16-2735-4906-9cf6-3ccb47322379" />
