### PR TITLE
bugfix: Изменение рецепта cure curse

### DIFF
--- a/code/modules/food_and_drinks/recipes/recipes_tribal.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_tribal.dm
@@ -77,7 +77,7 @@
 	items = list(
 		/obj/item/kitchen/knife/combat/survival/bone,
 		/obj/item/organ/internal/heart,
-		/obj/item/organ/internal/heart/unathi,
+		/obj/item/organ/internal/heart,
 	)
 	result = /obj/item/reagent_containers/food/snacks/lavaland_food/cure_curse
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- Список тегов для ПРа:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map Вы меняете только карту.
- local Вы делаете добавляете новый текст на русском или переводите на русский.
- imageadd:  Вы добавили новый спрайт.
- imagedel:  Вы удалили старый спрайт.
- soundadd: Вы добавили новый звук.
- sounddel: Вы удалили старый звук.
- spellcheck: Вы исправили опечатку.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает

Изменяет рецепт блюда cure curse с сердца и сердца унатха на два любых сердца.

Из-за того, что сердце унатха является также обычным сердце, при неправильной последовательности добавления ингредиентов, получается говно, то есть: 

Добавив сначала обычное сердце, а после него сердце унатха, то получается кал, а если добавить сначала обычное сердце, а затем унатха, то рецепт будет правильным.
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->

## Почему это хорошо для игры

Очевидный баг, заставляющий сомневаться в своих интеллектуальных способностях любого, кто попытается готовить это блюдо.

## Тестирование

Не нуждается
