### PR TITLE
balance: Небольшие правки способностей ниндзи, фикс хамелеона

### DIFF
--- a/code/__DEFINES/ninja.dm
+++ b/code/__DEFINES/ninja.dm
@@ -17,7 +17,8 @@
 //ninja alpha defines
 #define NINJA_ALPHA_NORMAL 255
 #define NINJA_ALPHA_SPIRIT_FORM 64
-#define NINJA_ALPHA_INVISIBILITY 0
+// not actually invisible anymore
+#define NINJA_ALPHA_INVISIBILITY 20
 
 //ninja suit tgui related flags
 #define NINJA_TGUI_MAIN_SCREEN_STATE 0

--- a/code/datums/helper_datums/icon_snapshot.dm
+++ b/code/datums/helper_datums/icon_snapshot.dm
@@ -22,7 +22,7 @@
 	name = target_mob.name
 	icon = target_mob.icon
 	icon_state = target_mob.icon_state
-	examine_text = target_mob.examine()
+	examine_text = target_mob.examine(target_mob)
 	overlays = target_mob.get_overlays_copy(list(L_HAND_LAYER,R_HAND_LAYER))
 	var/obj/item/id_slot_item = GetIdCard(target_mob)
 	if(istype(id_slot_item, /obj/item/card/id))

--- a/code/modules/antagonists/space_ninja/components/ninja_states_breaker.dm
+++ b/code/modules/antagonists/space_ninja/components/ninja_states_breaker.dm
@@ -29,7 +29,6 @@
 		COMSIG_MOB_APPLY_DAMAGE,
 		COMSIG_SIMPLE_ANIMAL_ATTACKEDBY,
 		COMSIG_ATOM_HITBY), PROC_REF(cancel_states))
-	RegisterSignal(parent, COMSIG_LIVING_UNARMED_ATTACK, PROC_REF(cancel_stealth))
 
 
 /datum/component/ninja_states_breaker/UnregisterFromParent()
@@ -44,8 +43,7 @@
 		COMSIG_MOB_ITEM_ATTACK,
 		COMSIG_MOB_APPLY_DAMAGE,
 		COMSIG_SIMPLE_ANIMAL_ATTACKEDBY,
-		COMSIG_ATOM_HITBY,
-		COMSIG_LIVING_UNARMED_ATTACK))
+		COMSIG_ATOM_HITBY))
 
 /// Собственно код выключающий сам инвиз и хамелион режимы костюма
 /datum/component/ninja_states_breaker/proc/cancel_states()
@@ -54,8 +52,3 @@
 		my_suit.cancel_stealth()
 	if(my_suit.disguise_active)
 		my_suit.restore_form()
-
-/// Отключает только инвиз при любых действиях рукой
-/datum/component/ninja_states_breaker/proc/cancel_stealth()
-	if(my_suit.stealth)
-		my_suit.cancel_stealth()

--- a/code/modules/antagonists/space_ninja/components/ninja_states_breaker.dm
+++ b/code/modules/antagonists/space_ninja/components/ninja_states_breaker.dm
@@ -29,6 +29,7 @@
 		COMSIG_MOB_APPLY_DAMAGE,
 		COMSIG_SIMPLE_ANIMAL_ATTACKEDBY,
 		COMSIG_ATOM_HITBY), PROC_REF(cancel_states))
+	RegisterSignal(parent, COMSIG_LIVING_UNARMED_ATTACK, PROC_REF(cancel_stealth))
 
 
 /datum/component/ninja_states_breaker/UnregisterFromParent()
@@ -43,7 +44,8 @@
 		COMSIG_MOB_ITEM_ATTACK,
 		COMSIG_MOB_APPLY_DAMAGE,
 		COMSIG_SIMPLE_ANIMAL_ATTACKEDBY,
-		COMSIG_ATOM_HITBY))
+		COMSIG_ATOM_HITBY,
+		COMSIG_LIVING_UNARMED_ATTACK))
 
 /// Собственно код выключающий сам инвиз и хамелион режимы костюма
 /datum/component/ninja_states_breaker/proc/cancel_states()
@@ -52,3 +54,8 @@
 		my_suit.cancel_stealth()
 	if(my_suit.disguise_active)
 		my_suit.restore_form()
+
+/// Отключает только инвиз при любых действиях рукой
+/datum/component/ninja_states_breaker/proc/cancel_stealth()
+	if(my_suit.stealth)
+		my_suit.cancel_stealth()

--- a/code/modules/antagonists/space_ninja/drain_act/carbon.dm
+++ b/code/modules/antagonists/space_ninja/drain_act/carbon.dm
@@ -10,6 +10,7 @@
 		//Got that electric touch
 		var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread()
 		spark_system.set_up(5, 0, loc)
+		ninja_suit.cancel_stealth()
 		playsound(src, 'sound/machines/defib_zap.ogg', 50, TRUE, 5)
 		visible_message(span_danger("[ninja] electrocutes [src] with [ninja.p_their()] touch!"), span_userdanger("[ninja] electrocutes you with [ninja.p_their()] touch!"))
 		Weaken(0.5 SECONDS)

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_johyo.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_johyo.dm
@@ -92,7 +92,7 @@
 	armour_penetration = 100
 	damage_type = BRUTE
 	hitsound = 'sound/weapons/whip.ogg'
-	weaken = 2 SECONDS
+	knockdown = 2 SECONDS
 
 /obj/projectile/johyo/fire(setAngle)
 	if(firer)

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_stealth.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_stealth.dm
@@ -37,7 +37,7 @@
 			animate(ninja, alpha = NINJA_ALPHA_INVISIBILITY, time = 6)
 			ninja.alpha_set(standartize_alpha(NINJA_ALPHA_INVISIBILITY), ALPHA_SOURCE_NINJA)
 			new /obj/effect/temp_visual/dir_setting/ninja/cloak(get_turf(ninja), ninja.dir)
-			ninja.visible_message(span_warning("[ninja.name] расстворил[genderize_ru(ninja.gender, "ся", "ась", "ось", "ись") ] в воздухе!"), span_notice("Теперь вас невозможно увидеть невооружённым глазом. Ровно как и стандартными оптическими приборами. Нагрузка костюма начала увеличиваться..."))
+			ninja.visible_message(span_warning("[ninja.name] расстворил[genderize_ru(ninja.gender, "ся", "ась", "ось", "ись") ] в воздухе!"), span_notice("Теперь вас практически невозможно увидеть невооружённым глазом. Ровно как и стандартными оптическими приборами. Нагрузка костюма начала увеличиваться..."))
 			ninja.AddComponent(/datum/component/ninja_states_breaker, src)
 			if(auto_smoke)
 				if(locate(/datum/action/item_action/advanced/ninja/ninja_smoke_bomb) in actions)

--- a/code/modules/antagonists/space_ninja/suit/suit.dm
+++ b/code/modules/antagonists/space_ninja/suit/suit.dm
@@ -700,7 +700,7 @@
 			"Крысы в техах шумят что ле...?")
 		switch(rand(1,3))
 			if(1)
-				for(var/mob/living/carbon/other_mob in view(7,ninja))
+				for(var/mob/living/carbon/other_mob in view(7, ninja))
 					if(other_mob == ninja)
 						continue
 					to_chat(other_mob, span_notice(random_subtle_text))

--- a/code/modules/antagonists/space_ninja/suit/suit.dm
+++ b/code/modules/antagonists/space_ninja/suit/suit.dm
@@ -78,7 +78,7 @@
 	/// The space ninja's headset
 	var/obj/item/radio/headset/ninja/n_headset
 	/// The space ninja's backpack
-	var/obj/item/radio/headset/ninja/n_backpack
+	var/obj/item/storage/backpack/ninja/n_backpack
 	/// The space ninja's chameleon id card
 	/// used only to fake sechuds while using chameleon
 	var/obj/item/card/id/ninja/n_id_card
@@ -590,6 +590,9 @@
 	if(!istype(ninja.wear_mask, /obj/item/clothing/mask/gas/space_ninja))
 		to_chat(ninja, "[span_userdanger("ERROR")]: 110223 UNABLE TO LOCATE NINJA MASK\nABORTING...")
 		return FALSE
+	if(!istype(ninja.back, /obj/item/storage/backpack/ninja))
+		to_chat(ninja, "[span_userdanger("ERROR")]: 110223 UNABLE TO LOCATE NINJA BACKPACK\nABORTING...")
+		return FALSE
 	toggle_ninja_nodrop(src)
 	n_hood = ninja.head
 	toggle_ninja_nodrop(n_hood)
@@ -597,6 +600,8 @@
 	toggle_ninja_nodrop(n_shoes)
 	n_gloves = ninja.gloves
 	toggle_ninja_nodrop(n_gloves)
+	n_backpack = ninja.back
+	toggle_ninja_nodrop(n_backpack)
 	n_mask = ninja.wear_mask
 	//Записываем маску к очкам, чтобы менять ей визуал, вместе с режимами очков
 	var/obj/item/clothing/glasses/ninja/wear_glasses = ninja.glasses
@@ -695,13 +700,10 @@
 			"Крысы в техах шумят что ле...?")
 		switch(rand(1,3))
 			if(1)
-				if(stealth_ambient_chance >= 15)
-					spark_system.start()
-				else
-					for(var/mob/living/carbon/other_mob in view(7,ninja))
-						if(other_mob == ninja)
-							continue
-						to_chat(other_mob, span_notice(random_subtle_text))
+				for(var/mob/living/carbon/other_mob in view(7,ninja))
+					if(other_mob == ninja)
+						continue
+					to_chat(other_mob, span_notice(random_subtle_text))
 			if(2)
 				if(stealth_ambient_chance >= 40)
 					for(var/mob/living/carbon/other_mob in view(7,ninja))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- Список тегов для ПРа:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map Вы меняете только карту.
- local Вы делаете добавляете новый текст на русском или переводите на русский.
- imageadd:  Вы добавили новый спрайт.
- imagedel:  Вы удалили старый спрайт.
- soundadd: Вы добавили новый звук.
- sounddel: Вы удалили старый звук.
- spellcheck: Вы исправили опечатку.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает
Некоторые способности ниндзи были незначительно занерфлены:
— Инвиз теперь имеет альфу 20, а не 0, то есть ниндзя более не абсолютно невидим и его можно разглядеть, если быть внимательным;
— Теперь инвиз не искрит при длительном использовании, но атака перчатками раскрывает невидимость (хамелеон остался прежним);
— Хук ниндзи более не накладывает weaken (нельзя двигаться), теперь это knockdown (можно ползать);
— Рюкзак ниндзи с активированным костюмом более нельзя снять, чтобы было не так просто абузить телепорт катаны и скилла с сохом/бохом;
— Также пофикшен баг с пустым описанием при осмотре ниндзи в хамелеоне.
<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->

## Почему это хорошо для игры
— Абсолютная невидимость не интересна никому, кроме самого ниндзи. Теперь способность награждает внимательных возможностью заметить ниндзю и убирает "тут в техах воздух искрится".
— Телепорт имеет крайне низкий кулдаун, и с бохом это становится мгновенной кнопкой спасения из любой ситуации. БС кристаллы и прочие методы телепортации давно занерфлены, ниндзя должен соответствовать.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Демонстрация изменений

https://github.com/user-attachments/assets/c156abe1-84b5-49a9-bcd1-262f3f110758


<!-- Заполните, если Вы меняли спрайты, карту или ваши изменения требуют визуальной демонстрации изменений. -->

## Тестирование
Стал ниндзей, включил невидимость, потыкал во все рукой, попробовал снять рюкзак
<!-- Как Вы тестировали свои изменения? Ведь тестировали? -->
