### PR TITLE
bugfix: удаляет энерго топор с сцк

### DIFF
--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -33747,7 +33747,6 @@
 /obj/item/storage/toolbox/syndicate{
 	pixel_y = 9
 	},
-/obj/item/melee/energy/axe,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull"
 	},


### PR DESCRIPTION
## Что этот ПР делает

То что написано в описании

## Почему это хорошо для игры

Не должен в зоне в которую могут попасть игроки находиться топор ваншотающий людей независимо от брони


## Тестирование

Бля поверьте пж