### PR TITLE
balance: Эффект запутанности ног от тазера при попадании в цель под адереналами, метом и прочим 

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -36,6 +36,7 @@
 #define EYE_BLUR	"eye_blur"
 #define DROWSY		"drowsy"
 #define JITTER		"jitter"
+#define CONFUSED	"confused"
 
 //I hate adding defines like this but I'd much rather deal with bitflags than lists and string searches
 #define BRUTELOSS (1<<0)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -81,6 +81,9 @@
 #define ORGANIC 1
 #define SYNTHETIC 2
 
+// Reagent tag flags, define reagent behaviour (now use only for anti-stun reagents)
+#define REAGENT_TAG_ANTI_STUN (1<<0)
+
 // Appearance change flags
 #define APPEARANCE_UPDATE_DNA (1<<0)
 #define APPEARANCE_RACE	(1<<1|APPEARANCE_UPDATE_DNA)

--- a/code/__DEFINES/traits/declarations.dm
+++ b/code/__DEFINES/traits/declarations.dm
@@ -338,3 +338,6 @@
 #define TRAIT_NOT_TURRET_GUN "not_turret_gun"
 
 #define TRAIT_BALD "bald"
+
+/// Anti stun reagent in blood
+#define TRAIT_ANTI_STUN_REAGENT "anti_stun_reagent"

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -288,12 +288,16 @@
 			Jitter(effect * blocked)
 		if(KNOCKDOWN)
 			Knockdown(effect * blocked)
+		if(CONFUSED)
+			Confused(effect * blocked)
+
+
 	updatehealth("apply effect")
 	return TRUE
 
 
 /// Applies multiple status effects at once via [apply_effect][/mob/living/proc/apply_effect]
-/mob/living/proc/apply_effects(blocked = 0, stun = 0, weaken = 0, paralyze = 0, irradiate = 0, slur = 0,stutter = 0, eyeblur = 0, drowsy = 0, stamina = 0, jitter = 0, knockdown = 0)
+/mob/living/proc/apply_effects(blocked = 0, stun = 0, weaken = 0, paralyze = 0, irradiate = 0, slur = 0,stutter = 0, eyeblur = 0, drowsy = 0, stamina = 0, jitter = 0, knockdown = 0, confused = 0)
 	if(blocked >= 100)
 		return FALSE
 	if(stun)
@@ -318,6 +322,8 @@
 		apply_effect(jitter, JITTER, blocked)
 	if(knockdown)
 		apply_effect(knockdown, KNOCKDOWN, blocked)
+	if(confused)
+		apply_effect(confused, CONFUSED, blocked)
 	return TRUE
 
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -85,6 +85,7 @@
 	var/stamina = 0
 	var/jitter = 0
 	var/knockdown = 0
+	var/confused = 0
 
 	/// Number of times an object can pass through an object. -1 is infinite
 	var/forcedodge = 0
@@ -240,12 +241,17 @@
 				if(L.mind == objective.target)
 					objective.take_damage(damage, damage_type)
 
-	var/were_affects_applied = L.apply_effects(blocked, stun, weaken, paralyze, irradiate, slur, stutter, eyeblur, drowsy, stamina, jitter, knockdown)
+	var/were_affects_applied = apply_effect_on_hit(L, blocked, def_zone)
 
 	if(!log_override && firer && original)
 		add_attack_logs(firer, L, "Shot [organ_hit_text][blocked ? " blocking [blocked]%" : null]. [fire_log_text]")
 
 	return were_affects_applied
+
+
+
+/obj/projectile/proc/apply_effect_on_hit(mob/living/target, blocked = 0, hit_zone)
+	return target.apply_effects(blocked, stun, weaken, paralyze, irradiate, slur, stutter, eyeblur, drowsy, stamina, jitter, knockdown, confused)
 
 
 /**

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -30,6 +30,7 @@
 	shockbull = TRUE
 	nodamage = TRUE
 	weaken = 0.2 SECONDS
+	confused = 1.5 SECONDS
 	stamina = 15
 	stutter = 8 SECONDS
 	jitter = 30 SECONDS
@@ -41,13 +42,24 @@
 	. = ..()
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
 		do_sparks(1, 1, src)
-	else if(iscarbon(target))
-		var/mob/living/carbon/C = target
-		if(HAS_TRAIT(C, TRAIT_HULK))
-			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
-		else if(C.status_flags & CANWEAKEN)
-			spawn(5)
-				C.Jitter(jitter)
+		return
+	if(!iscarbon(target))
+		return
+	var/mob/living/carbon/carbon = target
+	if(HAS_TRAIT(carbon, TRAIT_HULK))
+		carbon.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
+		return
+	if(carbon.status_flags & CANWEAKEN)
+		addtimer(CALLBACK(carbon, TYPE_PROC_REF(/mob/living/carbon, Jitter), jitter), 0.5 SECONDS)
+
+/obj/projectile/energy/electrode/apply_effect_on_hit(mob/living/target, blocked = 0, hit_zone)
+	var/weaken_effect = weaken
+	var/confused_effect = confused
+	if(HAS_TRAIT(target, TRAIT_ANTI_STUN_REAGENT))
+		weaken_effect = 0
+	else
+		confused_effect = 0
+	return target.apply_effects(blocked, stun, weaken_effect, paralyze, irradiate, slur, stutter, eyeblur, drowsy, stamina, jitter, knockdown, confused_effect)
 
 /obj/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
 	do_sparks(1, 1, src)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -47,7 +47,6 @@
 		return
 	var/mob/living/carbon/carbon = target
 	if(HAS_TRAIT(carbon, TRAIT_HULK))
-		carbon.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
 		return
 	if(carbon.status_flags & CANWEAKEN)
 		addtimer(CALLBACK(carbon, TYPE_PROC_REF(/mob/living/carbon, Jitter), jitter), 0.5 SECONDS)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -5,6 +5,7 @@
 /datum/reagent
 	var/name = "Реагент"
 	var/id = "reagent"
+	var/tags = 0
 	var/description = ""
 	var/datum/reagents/holder = null
 	var/reagent_state = SOLID
@@ -154,6 +155,9 @@
 	if(shock_reduction && ishuman(user))
 		user.update_movespeed_damage_modifiers()
 
+	if(tags & REAGENT_TAG_ANTI_STUN)
+		ADD_TRAIT(user, TRAIT_ANTI_STUN_REAGENT, id)
+
 
 /// Called when this reagent is removed while inside a mob
 /datum/reagent/proc/on_mob_delete(mob/living/carbon/human/user)
@@ -161,6 +165,9 @@
 
 	if(shock_reduction)
 		user.update_movespeed_damage_modifiers()
+
+	if(tags & REAGENT_TAG_ANTI_STUN)
+		REMOVE_TRAIT(user, TRAIT_ANTI_STUN_REAGENT, id)
 
 
 /datum/reagent/proc/on_move(mob/M)

--- a/code/modules/reagents/chemistry/reagents/admin.dm
+++ b/code/modules/reagents/chemistry/reagents/admin.dm
@@ -7,6 +7,7 @@
 	process_flags = ORGANIC | SYNTHETIC	//Adminbuse knows no bounds!
 	can_synth = FALSE
 	taste_description = "админ абуза"
+	tags = REAGENT_TAG_ANTI_STUN
 
 /datum/reagent/medicine/adminordrazine/on_mob_life(mob/living/carbon/M)
 	M.setCloneLoss(0, FALSE)

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -389,6 +389,7 @@
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	heart_rate_increase = 1
 	taste_description = "бодрости"
+	tags = REAGENT_TAG_ANTI_STUN
 
 
 /datum/reagent/methamphetamine/on_mob_add(mob/living/user)
@@ -468,6 +469,7 @@
 	shock_reduction = 60
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	taste_description = "нереальной бодрости"
+	tags = REAGENT_TAG_ANTI_STUN
 
 
 /datum/reagent/bath_salts/on_mob_add(mob/living/carbon/human/user)
@@ -1088,6 +1090,7 @@
 	taste_description = "неприятной горечи с примесью бедности"
 	shock_reduction = 100
 	metabolization_rate = 0.6 * REAGENTS_METABOLISM
+	tags = REAGENT_TAG_ANTI_STUN
 
 /datum/reagent/crack/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -1127,6 +1130,7 @@
 	taste_description = "легкой горечи, переходящей в чувство онемения"
 	shock_reduction = 140
 	metabolization_rate = 0.4 * REAGENTS_METABOLISM
+	tags = REAGENT_TAG_ANTI_STUN
 
 /datum/reagent/cocaine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -600,6 +600,7 @@
 	addiction_threshold = 10
 	harmless = FALSE
 	taste_description = "стимуляции"
+	tags = REAGENT_TAG_ANTI_STUN
 
 /datum/reagent/medicine/ephedrine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -771,6 +772,7 @@
 	overdose_threshold = 20
 	harmless = FALSE
 	taste_description = "выигранного времени"
+	tags = REAGENT_TAG_ANTI_STUN
 
 /datum/reagent/medicine/epinephrine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -1012,6 +1014,7 @@
 	overdose_threshold = 60
 	harmless = FALSE
 	can_synth = FALSE
+	tags = REAGENT_TAG_ANTI_STUN
 
 /datum/reagent/medicine/stimulative_agent/on_mob_life(mob/living/user)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -1574,6 +1577,7 @@
 	shock_reduction = 100
 	harmless = TRUE
 	can_synth = FALSE
+	tags = REAGENT_TAG_ANTI_STUN
 
 /datum/reagent/medicine/adrenaline/overdose_process(mob/living/M, severity)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -1591,6 +1595,7 @@
 	shock_reduction = 80
 	harmless = TRUE
 	can_synth = FALSE
+	tags = REAGENT_TAG_ANTI_STUN
 
 /datum/reagent/medicine/noradrenaline/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE


### PR DESCRIPTION

## Что этот ПР делает

Добавляет теги для реагентов `tags`.
Добавляет новый тег `REAGENT_TAG_ANTI_STUN` который выдает трейт `TRAIT_ANTI_STUN_REAGENT` для определения антистан реагентов в крови.
Добавляет запутанность ног на 1.5 секунды вместо Weaken у тазера, проверка идет через трейт.
В будущем возможно добавление новых тегов реагентов для групповых взаимодействий с реагентами.

## Почему это хорошо для игры

[Обсуждение в дсикорде](https://discord.com/channels/617003227182792704/1404393509418700861/1404393509418700861)

[Ну и разрешение](https://discord.com/channels/617003227182792704/1404393509418700861/1406356476716388422)

## Тестирование

Проверил на локалке, все согласно описанию.