### PR TITLE
bugfix: Починка спелла blood_pool и вцелом джаунта при пристегнутой кукле

### DIFF
--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -35,6 +35,10 @@
 	// mech supress escape
 	if(HAS_TRAIT_FROM(target, TRAIT_IMMOBILIZED, MECH_SUPRESSED_TRAIT))
 		target.remove_traits(list(TRAIT_IMMOBILIZED, TRAIT_FLOORED), MECH_SUPRESSED_TRAIT)
+
+	if(target.buckled)
+		target.buckled.unbuckle_mob(target, TRUE)
+
 	ADD_TRAIT(target, TRAIT_NO_TRANSFORM, UNIQUE_TRAIT_SOURCE(src))
 	var/turf/mobloc = get_turf(target)
 	var/obj/effect/dummy/spell_jaunt/holder = new jaunt_type_path(mobloc)

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -349,6 +349,10 @@
 	sound_in = 'sound/misc/enter_blood.ogg'
 	sound_out = 'sound/misc/exit_blood.ogg'
 
+/obj/effect/proc_holder/spell/ethereal_jaunt/blood_pool/cast(list/targets, mob/user = usr)
+	if(user.buckled)
+		user.buckled.unbuckle_mob(user, force- TRUE)
+	. = ..()
 
 /obj/effect/proc_holder/spell/ethereal_jaunt/blood_pool/after_spell_init()
 	update_vampire_spell_name()

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -349,10 +349,6 @@
 	sound_in = 'sound/misc/enter_blood.ogg'
 	sound_out = 'sound/misc/exit_blood.ogg'
 
-/obj/effect/proc_holder/spell/ethereal_jaunt/blood_pool/cast(list/targets, mob/user = usr)
-	if(user.buckled)
-		user.buckled.unbuckle_mob(user, force- TRUE)
-	. = ..()
 
 /obj/effect/proc_holder/spell/ethereal_jaunt/blood_pool/after_spell_init()
 	update_vampire_spell_name()


### PR DESCRIPTION
<!-- **ВАЖНО!!!** Если Ваш ПР содержит много .dmi файлов, которые могут создать излишнюю нагрузку на IconDiffBot2, тогда добавьте в название ПРа тэг [IDB IGNORE] -->
<!-- Например, "Добавил 1kk новых спрайтов [IDB IGNORE]" -->

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- Список тегов для ПРа:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map Вы меняете только карту.
- local Вы делаете добавляете новый текст на русском или переводите на русский.
- imageadd:  Вы добавили новый спрайт.
- imagedel:  Вы удалили старый спрайт.
- soundadd: Вы добавили новый звук.
- sounddel: Вы удалили старый звук.
- spellcheck: Вы исправили опечатку.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает

При пристегнутой кукле вампира, если тот использует способность blood pool - "разум" уйдет в кровь, но тело останется на месте и с ним можно будет взаимодействовать. С данным ПРом при использовании данной способности - куклу будет форсировано отстегивать при использовании спелла.

## Почему это хорошо для игры

Багфикс, баги плохо, отсутствие багов хорошо

## Демонстрация изменений

N/A

## Тестирование

Локалка
