### PR TITLE
bugfix: Чинит рантаймы из-за элемента при смене расы

### DIFF
--- a/code/datums/elements/nutrition_effects.dm
+++ b/code/datums/elements/nutrition_effects.dm
@@ -8,10 +8,10 @@
 	if(!ishuman(target) || HAS_TRAIT(target, TRAIT_NO_HUNGER) || HAS_TRAIT(target, TRAIT_NO_NUTRITION_EFFECTS))
 		return ELEMENT_INCOMPATIBLE
 
-	RegisterSignal(target, COMSIG_LIVING_LIFE, PROC_REF(on_life))
-	RegisterSignal(target, COMSIG_HUMAN_NUTRITION_UPDATE, PROC_REF(on_nutrition_level_update))
-	RegisterSignal(target, COMSIG_HUMAN_NUTRITION_UPDATE_SLOWDOWN, PROC_REF(nutrition_update_slowdown))
-	RegisterSignal(target, COMSIG_HUMAN_SPECIES_CHANGED, PROC_REF(on_species_changed))
+	RegisterSignal(target, COMSIG_LIVING_LIFE, PROC_REF(on_life), override = TRUE)
+	RegisterSignal(target, COMSIG_HUMAN_NUTRITION_UPDATE, PROC_REF(on_nutrition_level_update), override = TRUE)
+	RegisterSignal(target, COMSIG_HUMAN_NUTRITION_UPDATE_SLOWDOWN, PROC_REF(nutrition_update_slowdown), override = TRUE)
+	RegisterSignal(target, COMSIG_HUMAN_SPECIES_CHANGED, PROC_REF(on_species_changed), override = TRUE)
 
 
 /datum/element/nutrition_effects/Detach(datum/source)


### PR DESCRIPTION
<!-- **ВАЖНО!!!** Если Ваш ПР содержит много .dmi файлов, которые могут создать излишнюю нагрузку на IconDiffBot2, тогда добавьте в название ПРа тэг [IDB IGNORE] -->
<!-- Например, "Добавил 1kk новых спрайтов [IDB IGNORE]" -->

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- Список тегов для ПРа:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map Вы меняете только карту.
- local Вы делаете добавляете новый текст на русском или переводите на русский.
- imageadd:  Вы добавили новый спрайт.
- imagedel:  Вы удалили старый спрайт.
- soundadd: Вы добавили новый звук.
- sounddel: Вы удалили старый звук.
- spellcheck: Вы исправили опечатку.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает
Добавляет в сигналы override = TRUE, чтобы не было рантаймов из-за перезаписи сигналов, возникающих при втором добавлении элемента из-за смены расы. На локалке через ВВ проверил, что при добавлении нового элемента второй не создается, так что проблем быть не должно (надеюсь)
<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->
