### PR TITLE
balance: штуки в наномедах теперь платные

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2003,7 +2003,8 @@
 					/obj/item/reagent_containers/hypospray/safety = 200,
 					/obj/item/pinpointer/crew = 300, /obj/item/sensor_device = 600,
 					/obj/item/reagent_containers/hypospray/autoinjector/salbutamol = 25,
-					/obj/item/reagent_containers/hypospray/autoinjector/charcoal = 25)
+					/obj/item/reagent_containers/hypospray/autoinjector/charcoal = 25,
+					/obj/item/reagent_containers/applicator/brute = 150, /obj/item/reagent_containers/applicator/burn = 150)
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/medical

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1976,7 +1976,9 @@
 		"М+ожет с+ами пр+имете?"
 	)
 	req_access = list(ACCESS_MEDICAL)
-	products = list(/obj/item/reagent_containers/hypospray/autoinjector = 5,
+	products = list(/obj/item/reagent_containers/hypospray/autoinjector = 10,
+					/obj/item/reagent_containers/hypospray/autoinjector/salbutamol = 10,
+					/obj/item/reagent_containers/hypospray/autoinjector/charcoal = 10,
 					/obj/item/stack/medical/bruise_pack = 4, /obj/item/stack/medical/ointment = 4,
 					/obj/item/stack/medical/bruise_pack/advanced = 4, /obj/item/stack/medical/ointment/advanced = 4,
 					/obj/item/stack/medical/bruise_pack/extended = 2, /obj/item/stack/medical/ointment/extended = 2,
@@ -1996,7 +1998,12 @@
 					/obj/item/reagent_containers/syringe = 12, /obj/item/reagent_containers/dropper = 4, /obj/item/reagent_containers/glass/beaker = 4,
 					/obj/item/reagent_containers/iv_bag/slime = 1)
 	contraband = list(/obj/item/reagent_containers/glass/bottle/sulfonal = 1, /obj/item/reagent_containers/glass/bottle/pancuronium = 1)
-	prices = list(/obj/item/stack/medical/bruise_pack/extended = 200, /obj/item/stack/medical/ointment/extended = 200)
+	prices = list(/obj/item/stack/medical/bruise_pack/extended = 200, /obj/item/stack/medical/ointment/extended = 200,
+					/obj/item/stack/medical/bruise_pack/advanced = 100, /obj/item/stack/medical/ointment/advanced = 100,
+					/obj/item/reagent_containers/hypospray/safety = 200,
+					/obj/item/pinpointer/crew = 300, /obj/item/sensor_device = 600,
+					/obj/item/reagent_containers/hypospray/autoinjector/salbutamol = 25,
+					/obj/item/reagent_containers/hypospray/autoinjector/charcoal = 25)
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/medical
@@ -2083,8 +2090,16 @@
 	deny_overlay = "wallmed_deny"
 
 	density = FALSE //It is wall-mounted, and thus, not dense. --Superxpdude
-	products = list(/obj/item/stack/medical/bruise_pack = 2, /obj/item/stack/medical/ointment = 2, /obj/item/reagent_containers/hypospray/autoinjector = 4, /obj/item/healthanalyzer = 1)
+	products = list(/obj/item/stack/medical/bruise_pack = 2,
+					/obj/item/stack/medical/ointment = 2,
+					/obj/item/reagent_containers/hypospray/autoinjector = 4,
+					/obj/item/reagent_containers/hypospray/autoinjector/salbutamol = 2,
+					/obj/item/reagent_containers/hypospray/autoinjector/charcoal = 2,
+					/obj/item/healthanalyzer = 1)
 	contraband = list(/obj/item/reagent_containers/syringe/charcoal = 4, /obj/item/reagent_containers/syringe/antiviral = 4, /obj/item/reagent_containers/food/pill/tox = 1)
+	prices = list(/obj/item/reagent_containers/hypospray/autoinjector/salbutamol = 75,
+					/obj/item/reagent_containers/hypospray/autoinjector/charcoal = 75,
+					/obj/item/healthanalyzer = 100)
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/wallmed


### PR DESCRIPTION
## Что этот ПР делает

То что описано. Директ апргейды в виде китов и подобных им айтемов теперь платные. 

По мелочи инжекторы из аптечки крю мембера добавлены в наномед и настенный наномед с разной ценой

## Почему это хорошо для игры

Директ апгрейды/нестандартные вещи должны быть платными, чтобы заработали зарплаты и страховки. 

## Тестирование

Оно компилится