### PR TITLE
balance: убраны деньги из рандомных кошельков

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -103,17 +103,9 @@
 
 
 /obj/item/storage/wallet/random/populate_contents()
-	var/cash = pick(/obj/item/stack/spacecash,
-		/obj/item/stack/spacecash/c10,
-		/obj/item/stack/spacecash/c100,
-		/obj/item/stack/spacecash/c500,
-		/obj/item/stack/spacecash/c1000)
 	var/coin = pickweight(list(/obj/item/coin/iron = 3,
 							   /obj/item/coin/silver = 2,
 							   /obj/item/coin/gold = 1))
-	new cash(src)
-	if(prob(50))
-		new cash(src)
 	new coin(src)
 
 //////////////////////////////////////


### PR DESCRIPTION
## Что этот ПР делает

Все кошельки с припиской /random лежащие в дормах и по техам теперь спавнятся только с монетками

## Почему это хорошо для игры

Введение в игру экономики и её развитие полностью контрится одним сбухой который пойдет на 10ой секунде раунда оббежит все дормы и в техи еще забежит, залутает 5к и купит себе и кентам че хочет

## Тестирование

Поверьте пж
