### PR TITLE
tweak: наручники теперь можно снимать будучи скованным или в движении

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -92,7 +92,7 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "bola_cult"
 	item_state = "bola_cult"
-	breakout_time = 45
+	breakout_time = 4 SECONDS
 	knockdown_amt = 2 SECONDS
 
 

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -14,7 +14,7 @@
 	throw_range = 5
 	materials = list(MAT_METAL=500)
 	origin_tech = "engineering=3;combat=3"
-	breakout_time = 600 //Deciseconds = 60s = 1 minutes
+	breakout_time = 3 MINUTES
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
 	var/trashtype = null //For disposable cuffs
@@ -124,7 +124,7 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "sinewcuff"
 	item_state = "sinewcuff"
-	breakout_time = 300 //Deciseconds = 30s
+	breakout_time = 1 MINUTES
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 
 /obj/item/restraints/handcuffs/cable
@@ -133,7 +133,7 @@
 	icon_state = "cuff_white"
 	origin_tech = "engineering=2"
 	materials = list(MAT_METAL=150, MAT_GLASS=75)
-	breakout_time = 300 //Deciseconds = 30s
+	breakout_time = 1 MINUTES
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 
 /obj/item/restraints/handcuffs/cable/red
@@ -231,7 +231,7 @@
 	name = "zipties"
 	desc = "Plastic, disposable zipties that can be used to restrain temporarily but are destroyed after use."
 	icon_state = "cuff_white"
-	breakout_time = 450 //Deciseconds = 45s
+	breakout_time = 2 MINUTES
 	materials = list()
 	trashtype = /obj/item/restraints/handcuffs/cable/zipties/used
 
@@ -253,7 +253,7 @@
 	righthand_file = 'icons/mob/inhands/antag/ninja_righthand.dmi'
 	icon_state = "manacle_lock"
 	item_state = "manacle"
-	breakout_time = 450 //Deciseconds = 45s
+	breakout_time = 2 MINUTES
 	cuffsound = 'sound/items/zippoclose.ogg'
 	onmob_sheets = list(
 		ITEM_SLOT_HANDCUFFED_STRING = 'icons/obj/ninjaobjects.dmi'

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -681,8 +681,8 @@
 	item_state = "straight_jacket"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
-	strip_delay = 60
-	breakout_time = 3000
+	strip_delay = 6 SECONDS
+	breakout_time = 2 MINUTES
 	sprite_sheets = list(
 		SPECIES_PLASMAMAN = 'icons/mob/clothing/species/plasmaman/suit.dmi',
 		SPECIES_ASHWALKER_BASIC = 'icons/mob/clothing/species/unathi/suit.dmi',

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -696,7 +696,8 @@
 		restraints = wear_suit
 
 	if(restraints)
-		breakout_time = restraints.breakout_time
+		resist_restraints()
+		return
 
 	var/list/breakouttime_modifiers = list()
 	SEND_SIGNAL(src, COMSIG_GET_BREAKOUTTIME_MODIFIERS, breakouttime_modifiers)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -12,7 +12,6 @@
 
 	var/life_tick = 0      // The amount of life ticks that have processed on this mob.
 
-	var/obj/item/handcuffed = null //Whether or not the mob is handcuffed
 	var/obj/item/legcuffed = null  //Same as handcuffs but for legs. Bear traps use this.
 
 	var/obj/item/head = null
@@ -35,4 +34,8 @@
 	var/revival_in_progress = FALSE
 	/// Just a timer stamp for [/mob/living/carbon/relaymove]
 	var/last_stomach_attack
+	///Whether or not the mob is currently handcuffed, defined as the handcuff item restraining them
+	var/obj/item/restraints/handcuffs/handcuffed = null
+	///used to track how many times the mob has tried breaking away from their handcuffs since being cuffed. Reset to zero in update_handcuffed()
+	var/cuff_breakout_attempts = 0
 

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -116,7 +116,7 @@
 		balloon_alert(src, "попытка снять [cuffs.declent_ru(ACCUSATIVE)]...")
 		while(do_after(src, 5 SECONDS, src, DA_IGNORE_USER_LOC_CHANGE|DEFAULT_DOAFTER_IGNORE|DA_IGNORE_HELD_ITEM))
 			cuff_breakout_attempts++
-			if(cuff_breakout_attempts * 5 SECONDS >= breakout_time || (prob(cuff_breakout_attempts/4)))
+			if(cuff_breakout_attempts * 5 SECONDS >= breakout_time || (prob(cuff_breakout_attempts / 4)))
 				. = clear_cuffs(cuffs, cuff_break)
 				break
 			else if(prob(4))

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -65,6 +65,7 @@
 	else if(handcuffed)
 		throw_alert(ALERT_HANDCUFFED, /atom/movable/screen/alert/restrained/handcuffed, new_master = handcuffed)
 		ADD_TRAIT(src, TRAIT_RESTRAINED, HANDCUFFED_TRAIT)
+		cuff_breakout_attempts = 0
 
 	update_hands_HUD()
 	update_inv_handcuffed()
@@ -93,9 +94,9 @@
 
 
 /// General proc to resist passed item.
-/mob/living/carbon/proc/cuff_resist(obj/item/I, cuff_break = FALSE)
+/mob/living/carbon/proc/cuff_resist(obj/item/cuffs, cuff_break = FALSE)
 	. = FALSE
-	var/breakout_time = cuff_break ? 5 SECONDS : I.breakout_time
+	var/breakout_time = cuff_break ? 5 SECONDS : cuffs.breakout_time
 	var/list/breakouttime_modifiers = list()
 	SEND_SIGNAL(src, COMSIG_GET_BREAKOUTTIME_MODIFIERS, breakouttime_modifiers)
 	for(var/mod in breakouttime_modifiers)
@@ -103,26 +104,37 @@
 
 	if(cuff_break)
 		visible_message(
-			span_warning("[name] пыта[pluralize_ru(gender, "ет", "ют")]ся сломать [I.declent_ru(ACCUSATIVE)]!"),
-			span_notice("Вы пытаетесь сломать [I.declent_ru(ACCUSATIVE)]. Это займёт примерно 5 секунд."),
+			span_warning("[name] пыта[pluralize_ru(gender, "ет", "ют")]ся сломать [cuffs.declent_ru(ACCUSATIVE)]!"),
+			span_notice("Вы пытаетесь сломать [cuffs.declent_ru(ACCUSATIVE)]. Это займёт примерно 5 секунд."),
 		)
-		if(do_after(src, breakout_time, src, DEFAULT_DOAFTER_IGNORE|DA_IGNORE_HELD_ITEM))
-			. = clear_cuffs(I, cuff_break)
+		if(do_after(src, breakout_time, src, DA_IGNORE_USER_LOC_CHANGE|DEFAULT_DOAFTER_IGNORE|DA_IGNORE_HELD_ITEM))
+			. = clear_cuffs(cuffs, cuff_break)
 		else
-			to_chat(src, span_warning("Вам не удалось сломать [I.declent_ru(ACCUSATIVE)]!"))
+			to_chat(src, span_warning("Вам не удалось сломать [cuffs.declent_ru(ACCUSATIVE)]!"))
+
+	else if(istype(cuffs, /obj/item/restraints/handcuffs))
+		to_chat(src, span_notice("Вы пытаетесь снять [cuffs.declent_ru(ACCUSATIVE)]..."))
+		while(do_after(src, 5 SECONDS, src, DA_IGNORE_USER_LOC_CHANGE|DEFAULT_DOAFTER_IGNORE|DA_IGNORE_HELD_ITEM))
+			cuff_breakout_attempts++
+			if(cuff_breakout_attempts * 5 SECONDS >= breakout_time || (prob(cuff_breakout_attempts/4)))
+				. = clear_cuffs(cuffs, cuff_break)
+				break
+			else if(prob(4))
+				visible_message(span_warning("[name]пыта[pluralize_ru(gender, "ет", "ют")]ся снять [cuffs.declent_ru(ACCUSATIVE)]!"))
+
 	else
 		visible_message(
-			span_warning("[name] пыта[pluralize_ru(gender, "ет", "ют")]ся снять [I.declent_ru(ACCUSATIVE)]!"),
-			span_notice("Вы пытаетесь снять [I.declent_ru(ACCUSATIVE)]. Это займёт примерно [breakout_time / 10] секунд[declension_ru(breakout_time / 10, "у", "ы", "")]."),
+			span_warning("[name] пыта[pluralize_ru(gender, "ет", "ют")]ся снять [cuffs.declent_ru(ACCUSATIVE)]!"),
+			span_notice("Вы пытаетесь снять [cuffs.declent_ru(ACCUSATIVE)]. Это займёт примерно [breakout_time / 10] секунд[declension_ru(breakout_time / 10, "у", "ы", "")]."),
 		)
-		if(do_after(src, breakout_time, src, DEFAULT_DOAFTER_IGNORE|DA_IGNORE_HELD_ITEM))
-			. = clear_cuffs(I, cuff_break)
+		if(do_after(src, breakout_time, src, DA_IGNORE_USER_LOC_CHANGE|DEFAULT_DOAFTER_IGNORE|DA_IGNORE_HELD_ITEM))
+			. = clear_cuffs(cuffs, cuff_break)
 		else
-			to_chat(src, span_warning("Вам не удалось снять [I.declent_ru(ACCUSATIVE)]!"))
+			to_chat(src, span_warning("Вам не удалось снять [cuffs.declent_ru(ACCUSATIVE)]!"))
 
 
 /mob/living/carbon/proc/clear_cuffs(obj/item/I, cuff_break)
-	if(!I.loc || buckled)
+	if(!I.loc)
 		return FALSE
 	if(I != handcuffed && I != legcuffed && I != wear_suit)
 		return FALSE

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -110,17 +110,17 @@
 		if(do_after(src, breakout_time, src, DA_IGNORE_USER_LOC_CHANGE|DEFAULT_DOAFTER_IGNORE|DA_IGNORE_HELD_ITEM))
 			. = clear_cuffs(cuffs, cuff_break)
 		else
-			to_chat(src, span_warning("Вам не удалось сломать [cuffs.declent_ru(ACCUSATIVE)]!"))
+			balloon_alert(src, "не вышло снять [cuffs.declent_ru(ACCUSATIVE)]!!")
 
 	else if(istype(cuffs, /obj/item/restraints/handcuffs))
-		to_chat(src, span_notice("Вы пытаетесь снять [cuffs.declent_ru(ACCUSATIVE)]..."))
+		balloon_alert(src, "попытка снять [cuffs.declent_ru(ACCUSATIVE)]...")
 		while(do_after(src, 5 SECONDS, src, DA_IGNORE_USER_LOC_CHANGE|DEFAULT_DOAFTER_IGNORE|DA_IGNORE_HELD_ITEM))
 			cuff_breakout_attempts++
 			if(cuff_breakout_attempts * 5 SECONDS >= breakout_time || (prob(cuff_breakout_attempts/4)))
 				. = clear_cuffs(cuffs, cuff_break)
 				break
 			else if(prob(4))
-				visible_message(span_warning("[name]пыта[pluralize_ru(gender, "ет", "ют")]ся снять [cuffs.declent_ru(ACCUSATIVE)]!"))
+				visible_message(span_warning("[name] пыта[pluralize_ru(gender, "ет", "ют")]ся снять [cuffs.declent_ru(ACCUSATIVE)]!"))
 
 	else
 		visible_message(
@@ -130,7 +130,7 @@
 		if(do_after(src, breakout_time, src, DA_IGNORE_USER_LOC_CHANGE|DEFAULT_DOAFTER_IGNORE|DA_IGNORE_HELD_ITEM))
 			. = clear_cuffs(cuffs, cuff_break)
 		else
-			to_chat(src, span_warning("Вам не удалось снять [cuffs.declent_ru(ACCUSATIVE)]!"))
+			balloon_alert(src, "не вышло снять [cuffs.declent_ru(ACCUSATIVE)]!!")
 
 
 /mob/living/carbon/proc/clear_cuffs(obj/item/I, cuff_break)


### PR DESCRIPTION
<!-- **ВАЖНО!!!** Если Ваш ПР содержит много .dmi файлов, которые могут создать излишнюю нагрузку на IconDiffBot2, тогда добавьте в название ПРа тэг [IDB IGNORE] -->
<!-- Например, "Добавил 1kk новых спрайтов [IDB IGNORE]" -->

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- Список тегов для ПРа:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map Вы меняете только карту.
- local Вы делаете добавляете новый текст на русском или переводите на русский.
- imageadd:  Вы добавили новый спрайт.
- imagedel:  Вы удалили старый спрайт.
- soundadd: Вы добавили новый звук.
- sounddel: Вы удалили старый звук.
- spellcheck: Вы исправили опечатку.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает

Порт https://github.com/BeeStation/BeeStation-Hornet/pull/12602

Если совсем вкратце: 
Наручники теперь снимаются три минуты, пластиковые стяжки две минуты, стяжки минуту.
Наручники можно снимать будучи прикованным к креслу, в движении или лежа.
Наручники теперь вместо одного длинного таймера запускают пятисекундные таймеры, приближающие к общей цели развязаться из наручников. При этом после каждого такого таймера есть небольшой шанс оповестить всех о том, что вы вырываетесь из наручников и еще более низкий шанс на то, что вы вырветесь из наручников до истечения таймера.

В добавок, теперь из жакета нужно вырываться 2 минуты с возможностью так же двигаться в процессе. При этом жакет работает по старой системе, так что если хочется подушить игроков, можно держать его в жакете и станлочить.


<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->

## Почему это хорошо для игры
Ну наверное минутный (двухминутный) таймер наручников, который сбивается любым раундстарт оружием (тазером), которой имеет два этапа, каждый из которых невероятно душный и сбрасывается тем, что вставшего из-за стула человека просто прикуют обратно. Что уж говорить, что половина варденов меняет стандартные стулья в процедурке на комфортные исключительно потому что у них видно, когда человек сидит в стуле, а когда стоит, чтобы быстро замечать развязывающихся и садить их обратно. Охуенный жеймплев.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Демонстрация изменений
я короче записал видео принципа работы, но случайно не обновил ОБС и оно записалось в формате мкв, поверьте пожалуйста что всё работает хорошо, ладно!!
<!-- Заполните, если Вы меняли спрайты, карту или ваши изменения требуют визуальной демонстрации изменений. -->