### PR TITLE
bugfix: Страховка на медхудах теперь корректно учитывает маски/шлемы

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -240,7 +240,7 @@
 		temp_id = wear_id.GetID()
 
 	if(!temp_id)
-		if(real_name == name)
+		if(dna.real_name == real_name)
 			account = get_insurance_account_DNA(src)
 	else
 		account = get_money_account(temp_id.associated_account_number)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -229,18 +229,21 @@
 
 /mob/living/carbon/human/proc/med_hud_insurance_set_overlay()
 	var/image/holder = hud_list[STATUS_HUD]
-	var/perpname = get_visible_name(add_id_name = FALSE)
-	
+	var/datum/money_account/account = null
+	var/obj/item/card/id/temp_id = null
 	holder.overlays.Cut()
 
-	if(!perpname || perpname == "Unknown" || perpname == "Неизвестный")
-		return
+	if(!wear_id)
+		if((wear_mask && wear_mask.flags_inv & HIDENAME) || (head && head.flags_inv & HIDENAME))
+			return
+	else
+		temp_id = wear_id.GetID()
 
-	var/datum/money_account/account = get_insurance_account(src)
-	if(wear_id)
-		var/obj/item/card/id/temp_id = wear_id.GetID()
-		if(temp_id)
-			account = get_money_account(temp_id.associated_account_number)
+	if(!temp_id)
+		if(real_name == name)
+			account = get_insurance_account_DNA(src)
+	else
+		account = get_money_account(temp_id.associated_account_number)
 
 	if(account)
 		holder.overlays += image('icons/mob/hud.dmi', icon_state = "hudhealthy_[account.insurance_type]")

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -240,7 +240,7 @@
 		temp_id = wear_id.GetID()
 
 	if(!temp_id)
-		if(dna.real_name == real_name)
+		if(dna.real_name == get_face_name())
 			account = get_insurance_account_DNA(src)
 	else
 		account = get_money_account(temp_id.associated_account_number)

--- a/code/modules/economy/insurance.dm
+++ b/code/modules/economy/insurance.dm
@@ -16,6 +16,11 @@
 	else
 		return null
 
+/proc/get_insurance_account_DNA(mob/living/carbon/human/user)
+	if(user.dna in GLOB.dna2account)
+		return GLOB.dna2account[user.dna]
+	return null
+
 /proc/do_insurance_collection(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/money_account/connected_acc)
 	if(!istype(target))
 		target.visible_message("Некорректная цель списания страховки.")

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -1163,6 +1163,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 			)
 
 	status |= ORGAN_DISFIGURED
+	owner.update_hud_set()
+
 	return TRUE
 
 
@@ -1178,6 +1180,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return FALSE
 
 	status &= ~ORGAN_DISFIGURED
+	owner.update_hud_set()
 
 	return TRUE
 


### PR DESCRIPTION
## Что этот ПР делает

Теперь оверлей страховки корректно учитывает то, скрывает ли маска или шлем лицо. Показывает страховку без карты и без маски только в том случае, если лицо не прошло через пластическую операцию или не было обезображено ожогами/переломом.

- Убрал `get_visible_name()` для проверки, добавил проверку на флаги - скрывает ли экипированная маска/шлем лицо персонажа.
- Добавил `get_insurance_account_DNA()` для специализированного вызова только ДНК.
- Добавил `get_face_name()` в проверку.
- Добавил `update_set_hud()` при уродстве.

## Почему это хорошо для игры

Исправляет возможные ошибки, убирает костыль.

## Тестирование

Во время тестирования рантаймов не было обнаружено. Оверлей меняется согласно задуманному поведению.
