### PR TITLE
bugfix: ru_names -> get_ru_names() мендеров, капельниц, гипо/инжекторов

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -240,7 +240,7 @@
 		temp_id = wear_id.GetID()
 
 	if(!temp_id)
-		if(dna.real_name == get_face_name())
+		if(dna.real_name == get_visible_name(add_id_name = FALSE))
 			account = get_insurance_account_DNA(src)
 	else
 		account = get_money_account(temp_id.associated_account_number)

--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -1,14 +1,6 @@
 /obj/item/reagent_containers/applicator
 	name = "auto-mender"
 	desc = "Небольшое электронное устройство, предназначенное для местного применения лекарственных препаратов."
-	ru_names = list(
-        NOMINATIVE = "авто-мендер",
-        GENITIVE = "авто-мендера",
-        DATIVE = "авто-мендеру",
-        ACCUSATIVE = "авто-мендер",
-        INSTRUMENTAL = "авто-мендером",
-        PREPOSITIONAL = "авто-мендере"
-	)
 	gender = MALE
 	icon = 'icons/goonstation/objects/objects.dmi'
 	icon_state = "mender"
@@ -27,6 +19,15 @@
 	var/applied_amount = 8 // How much it applies
 	var/applying = FALSE // So it can't be spammed.
 
+/obj/item/reagent_containers/applicator/get_ru_names()
+	return list(
+        NOMINATIVE = "авто-мендер",
+        GENITIVE = "авто-мендера",
+        DATIVE = "авто-мендеру",
+        ACCUSATIVE = "авто-мендер",
+        INSTRUMENTAL = "авто-мендером",
+        PREPOSITIONAL = "авто-мендере"
+	)
 
 /obj/item/reagent_containers/applicator/emag_act(mob/user)
 	if(!emagged)
@@ -142,7 +143,10 @@
 /obj/item/reagent_containers/applicator/brute
 	name = "brute auto-mender"
 	desc = "Небольшое электронное устройство, предназначенное для местного применения лекарственных препаратов. Эта версия - для заживления механических повреждений."
-	ru_names = list(
+	list_reagents = list("styptic_powder" = 200)
+
+/obj/item/reagent_containers/applicator/brute/get_ru_names()
+	return list(
         NOMINATIVE = "авто-мендер (Мех. Повреждения)",
         GENITIVE = "авто-мендера (Мех. Повреждения)",
         DATIVE = "авто-мендеру (Мех. Повреждения)",
@@ -150,12 +154,14 @@
         INSTRUMENTAL = "авто-мендером (Мех. Повреждения)",
         PREPOSITIONAL = "авто-мендере (Мех. Повреждения)"
 	)
-	list_reagents = list("styptic_powder" = 200)
 
 /obj/item/reagent_containers/applicator/burn
 	name = "burn auto-mender"
 	desc = "Небольшое электронное устройство, предназначенное для местного применения лекарственных препаратов. Эта версия - для заживления термических повреждений."
-	ru_names = list(
+	list_reagents = list("silver_sulfadiazine" = 200)
+
+/obj/item/reagent_containers/applicator/burn/get_ru_names()
+	return list(
         NOMINATIVE = "авто-мендер (Терм. Повреждения)",
         GENITIVE = "авто-мендера (Терм. Повреждения)",
         DATIVE = "авто-мендеру (Терм. Повреждения)",
@@ -163,12 +169,14 @@
         INSTRUMENTAL = "авто-мендером (Терм. Повреждения)",
         PREPOSITIONAL = "авто-мендере (Терм. Повреждения)"
 	)
-	list_reagents = list("silver_sulfadiazine" = 200)
 
 /obj/item/reagent_containers/applicator/dual
 	name = "dual auto-mender"
 	desc = "Небольшое электронное устройство, предназначенное для местного применения лекарственных препаратов. Эта версия - для заживления как механических, так и термических повреждений."
-	ru_names = list(
+	list_reagents = list("synthflesh" = 200)
+
+/obj/item/reagent_containers/applicator/dual/get_ru_names()
+	return list(
         NOMINATIVE = "авто-мендер (Синт-плоть)",
         GENITIVE = "авто-мендера (Синт-плоть)",
         DATIVE = "авто-мендеру (Синт-плоть)",
@@ -176,7 +184,7 @@
         INSTRUMENTAL = "авто-мендером (Синт-плоть)",
         PREPOSITIONAL = "авто-мендере (Синт-плоть)"
 	)
-	list_reagents = list("synthflesh" = 200)
 
 /obj/item/reagent_containers/applicator/dual/syndi // It magically goes through hardsuits. Don't ask how.
 	ignore_flags = TRUE
+

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -5,14 +5,6 @@
 /obj/item/reagent_containers/hypospray
 	name = "hypospray"
 	desc = "Гипоспрей - это стерильный автоинъектор с воздушной иглой для быстрого введения лекарств пациентам."
-	ru_names = list(
-        NOMINATIVE = "гипоспрей",
-        GENITIVE = "гипоспрея",
-        DATIVE = "гипоспрею",
-        ACCUSATIVE = "гипоспрей",
-        INSTRUMENTAL = "гипоспреем",
-        PREPOSITIONAL = "гипоспрее"
-	)
 	icon = 'icons/obj/hypo.dmi'
 	item_state = "hypo"
 	icon_state = "hypo"
@@ -26,6 +18,16 @@
 	var/ignore_flags = FALSE
 	var/emagged = FALSE
 	var/safety_hypo = FALSE
+
+/obj/item/reagent_containers/hypospray/get_ru_names()
+	return list(
+        NOMINATIVE = "гипоспрей",
+        GENITIVE = "гипоспрея",
+        DATIVE = "гипоспрею",
+        ACCUSATIVE = "гипоспрей",
+        INSTRUMENTAL = "гипоспреем",
+        PREPOSITIONAL = "гипоспрее"
+	)
 
 /obj/item/reagent_containers/hypospray/attack(mob/living/carbon/target, mob/living/user, params, def_zone, skip_attack_anim = FALSE)
 	. = ATTACK_CHAIN_PROCEED
@@ -87,7 +89,14 @@
 /obj/item/reagent_containers/hypospray/safety
 	name = "medical hypospray"
 	desc = "Медицинский гипоспрей общего назначения для быстрого введения химических веществ. На курке имеется кнопка безопасности."
-	ru_names = list(
+	icon_state = "medivend_hypo"
+	belt_icon = "medical_hypospray"
+	safety_hypo = TRUE
+	var/paint_color
+	var/color_overlay = "colour_hypo"
+
+/obj/item/reagent_containers/hypospray/safety/get_ru_names()
+	return list(
         NOMINATIVE = "медицинский гипоспрей",
         GENITIVE = "медицинского гипоспрея",
         DATIVE = "медицинскому гипоспрею",
@@ -95,12 +104,6 @@
         INSTRUMENTAL = "медицинским гипоспреем",
         PREPOSITIONAL = "медицинском гипоспрее"
 	)
-	icon_state = "medivend_hypo"
-	belt_icon = "medical_hypospray"
-	safety_hypo = TRUE
-	var/paint_color
-	var/color_overlay = "colour_hypo"
-
 
 /obj/item/reagent_containers/hypospray/safety/proc/update_state()
 	update_icon(UPDATE_ICON_STATE)
@@ -142,7 +145,14 @@
 /obj/item/reagent_containers/hypospray/safety/upgraded
 	name = "upgraded medical hypospray"
 	desc = "Улучшенный медицинский гипоспрей общего назначения для быстрого введения химических веществ. Эта модель имеет увеличенную емкость."
-	ru_names = list(
+	item_state = "upg_hypo"
+	icon_state = "upg_hypo"
+	volume = 60
+	possible_transfer_amounts = list(1,2,5,10,15,20,25,30,40,60)
+	color_overlay = "colour_upgradedhypo"
+
+/obj/item/reagent_containers/hypospray/safety/upgraded/get_ru_names()
+	return list(
         NOMINATIVE = "улучшенный медицинский гипоспрей",
         GENITIVE = "улучшенного медицинского гипоспрея",
         DATIVE = "улучшенному медицинскому гипоспрею",
@@ -150,11 +160,6 @@
         INSTRUMENTAL = "улучшенным медицинским гипоспреем",
         PREPOSITIONAL = "улучшенном медицинском гипоспрее"
 	)
-	item_state = "upg_hypo"
-	icon_state = "upg_hypo"
-	volume = 60
-	possible_transfer_amounts = list(1,2,5,10,15,20,25,30,40,60)
-	color_overlay = "colour_upgradedhypo"
 
 /obj/item/reagent_containers/hypospray/safety/upgraded/update_icon_state()
 	icon_state = paint_color ? "upg_hypo_white" : "upg_hypo"
@@ -164,7 +169,10 @@
 
 /obj/item/reagent_containers/hypospray/safety/ert
 	name = "medical hypospray (Omnizine)"
-	ru_names = list(
+	list_reagents = list("omnizine" = 30)
+
+/obj/item/reagent_containers/hypospray/safety/ert/get_ru_names()
+	return list(
         NOMINATIVE = "медицинский гипоспрей (Омнизин)",
         GENITIVE = "медицинского гипоспрея (Омнизин)",
         DATIVE = "медицинскому гипоспрею (Омнизин)",
@@ -172,13 +180,22 @@
         INSTRUMENTAL = "медицинским гипоспреем (Омнизин)",
         PREPOSITIONAL = "медицинском гипоспрее (Омнизин)"
 	)
-	list_reagents = list("omnizine" = 30)
 
 /obj/item/reagent_containers/hypospray/CMO
 	volume = 250
 	possible_transfer_amounts = list(1,2,3,4,5,10,15,20,25,30,35,40,45,50)
 	list_reagents = list("omnizine" = 100)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+
+/obj/item/reagent_containers/hypospray/CMO/get_ru_names()
+	return list(
+        NOMINATIVE = "гипоспрей Главного Врача",
+        GENITIVE = "гипоспрея Главного Врача",
+        DATIVE = "гипоспрею Главного Врача",
+        ACCUSATIVE = "гипоспрей Главного Врача",
+        INSTRUMENTAL = "гипоспреем Главного Врача",
+        PREPOSITIONAL = "гипоспрее Главного Врача"
+	)
 
 /obj/item/reagent_containers/hypospray/CMO/Initialize(mapload)
 	. = ..()
@@ -190,7 +207,15 @@
 /obj/item/reagent_containers/hypospray/combat
 	name = "combat stimulant injector"
 	desc = "Модифицированный автоинъектор с воздушной иглой, используемый оперативниками поддержки для быстрого заживления ран в бою."
-	ru_names = list(
+	amount_per_transfer_from_this = 15
+	possible_transfer_amounts = null
+	icon_state = "combat_hypo"
+	volume = 90
+	ignore_flags = 1 // So they can heal their comrades.
+	list_reagents = list("epinephrine" = 30, "weak_omnizine" = 30, "salglu_solution" = 30)
+
+/obj/item/reagent_containers/hypospray/combat/get_ru_names()
+	return list(
         NOMINATIVE = "боевой инъектор",
         GENITIVE = "боевого инъектора",
         DATIVE = "боевому инъектору",
@@ -198,12 +223,6 @@
         INSTRUMENTAL = "боевым инъектором",
         PREPOSITIONAL = "боевом инъекторе"
 	)
-	amount_per_transfer_from_this = 15
-	possible_transfer_amounts = null
-	icon_state = "combat_hypo"
-	volume = 90
-	ignore_flags = 1 // So they can heal their comrades.
-	list_reagents = list("epinephrine" = 30, "weak_omnizine" = 30, "salglu_solution" = 30)
 
 /obj/item/reagent_containers/hypospray/ertm
 	volume = 90
@@ -215,7 +234,11 @@
 	amount_per_transfer_from_this = 10
 	name = "Hydrocodon combat stimulant injector"
 	desc = "Модифицированный автоинъектор с воздушной иглой, используемый оперативниками поддержки для быстрого заживления ран в бою. Содержит гидрокодон."
-	ru_names = list(
+	icon_state = "hypocombat-hydro"
+	list_reagents = list("hydrocodone" = 90)
+
+/obj/item/reagent_containers/hypospray/ertm/hydrocodone/get_ru_names()
+	return list(
         NOMINATIVE = "боевой инъектор (Гидрокодон)",
         GENITIVE = "боевого инъектора (Гидрокодон)",
         DATIVE = "боевому инъектору (Гидрокодон)",
@@ -223,15 +246,16 @@
         INSTRUMENTAL = "боевым инъектором (Гидрокодон)",
         PREPOSITIONAL = "боевом инъекторе (Гидрокодон)"
 	)
-	icon_state = "hypocombat-hydro"
-	list_reagents = list("hydrocodone" = 90)
 
 /obj/item/reagent_containers/hypospray/ertm/perfluorodecalin
 	amount_per_transfer_from_this = 3
 	name = "Perfluorodecalin combat stimulant injector"
 	icon_state = "hypocombat-perfa"
 	desc = "Модифицированный автоинъектор с воздушной иглой, используемый оперативниками поддержки для быстрого заживления ран в бою. Содержит Перфтордекалин."
-	ru_names = list(
+	list_reagents = list("perfluorodecalin" = 90)
+
+/obj/item/reagent_containers/hypospray/ertm/perfluorodecalin/get_ru_names()
+	return list(
         NOMINATIVE = "боевой инъектор (Перфтодекалин)",
         GENITIVE = "боевого инъектора (Перфтодекалин)",
         DATIVE = "боевому инъектору (Перфтодекалин)",
@@ -239,14 +263,16 @@
         INSTRUMENTAL = "боевым инъектором (Перфтодекалин)",
         PREPOSITIONAL = "боевом инъекторе (Перфтодекалин)"
 	)
-	list_reagents = list("perfluorodecalin" = 90)
 
 /obj/item/reagent_containers/hypospray/ertm/pentic_acid
 	amount_per_transfer_from_this = 5
 	name = "Pentic acid combat stimulant injector"
 	icon_state = "hypocombat-dtpa"
 	desc = "Модифицированный автоинъектор с воздушной иглой, используемый оперативниками поддержки для быстрого заживления ран в бою. Содержит пентетовую кислоту."
-	ru_names = list(
+	list_reagents = list("pen_acid" = 90)
+
+/obj/item/reagent_containers/hypospray/ertm/pentic_acid/get_ru_names()
+	return list(
         NOMINATIVE = "боевой инъектор (Пентетовая кислота)",
         GENITIVE = "боевого инъектора (Пентетовая кислота)",
         DATIVE = "боевому инъектору (Пентетовая кислота)",
@@ -254,14 +280,16 @@
         INSTRUMENTAL = "боевым инъектором (Пентетовая кислота)",
         PREPOSITIONAL = "боевом инъекторе (Пентетовая кислота)"
 	)
-	list_reagents = list("pen_acid" = 90)
 
 /obj/item/reagent_containers/hypospray/ertm/epinephrine
 	amount_per_transfer_from_this = 5
 	name = "Epinephrine combat stimulant injector"
 	icon_state = "hypocombat-epi"
 	desc = "Модифицированный автоинъектор с воздушной иглой, используемый оперативниками поддержки для быстрого заживления ран в бою. Содержит эпинефрин."
-	ru_names = list(
+	list_reagents = list("epinephrine" = 90)
+
+/obj/item/reagent_containers/hypospray/ertm/epinephrine/get_ru_names()
+	return list(
         NOMINATIVE = "боевой инъектор (Эпинефрин)",
         GENITIVE = "боевого инъектора (Эпинефрин)",
         DATIVE = "боевому инъектору (Эпинефрин)",
@@ -269,13 +297,16 @@
         INSTRUMENTAL = "боевым инъектором (Эпинефрин)",
         PREPOSITIONAL = "боевом инъекторе (Эпинефрин)"
 	)
-	list_reagents = list("epinephrine" = 90)
 
 /obj/item/reagent_containers/hypospray/ertm/mannitol
 	amount_per_transfer_from_this = 5
 	name = "Mannitol combat stimulant injector"
 	desc = "Модифицированный автоинъектор с воздушной иглой, используемый оперативниками поддержки для быстрого заживления ран в бою. Содержит маннитол."
-	ru_names = list(
+	icon_state = "hypocombat-mani"
+	list_reagents = list("mannitol" = 90)
+
+/obj/item/reagent_containers/hypospray/ertm/mannitol/get_ru_names()
+	return list(
         NOMINATIVE = "боевой инъектор (Маннитол)",
         GENITIVE = "боевого инъектора (Маннитол)",
         DATIVE = "боевому инъектору (Маннитол)",
@@ -283,15 +314,16 @@
         INSTRUMENTAL = "боевым инъектором (Маннитол)",
         PREPOSITIONAL = "боевом инъекторе (Маннитол)"
 	)
-	icon_state = "hypocombat-mani"
-	list_reagents = list("mannitol" = 90)
 
 /obj/item/reagent_containers/hypospray/ertm/oculine
 	amount_per_transfer_from_this = 5
 	name = "Oculine combat stimulant injector"
 	icon_state = "hypocombat-ocu"
 	desc = "Модифицированный автоинъектор с воздушной иглой, используемый оперативниками поддержки для быстрого заживления ран в бою. Содержит окулин."
-	ru_names = list(
+	list_reagents = list("oculine" = 90)
+
+/obj/item/reagent_containers/hypospray/ertm/oculine/get_ru_names()
+	return list(
         NOMINATIVE = "боевой инъектор (Окулин)",
         GENITIVE = "боевого инъектора (Окулин)",
         DATIVE = "боевому инъектору (Окулин)",
@@ -299,14 +331,17 @@
         INSTRUMENTAL = "боевым инъектором (Окулин)",
         PREPOSITIONAL = "боевом инъекторе (Окулин)"
 	)
-	list_reagents = list("oculine" = 90)
 
 /obj/item/reagent_containers/hypospray/ertm/omnisal
 	amount_per_transfer_from_this = 10
 	name = "DilOmni-Salglu solution combat stimulant injector"
 	icon_state = "hypocombat-womnisal"
 	desc = "Модифицированный автоинъектор с воздушной иглой, используемый оперативниками поддержки для быстрого заживления ран в бою. Содержит разбавленный омнизин и физиологический раствор."
-	ru_names = list(
+	list_reagents = list("weak_omnizine" = 45, "salglu_solution" = 45)
+	possible_transfer_amounts = list(10, 20, 30)
+
+/obj/item/reagent_containers/hypospray/ertm/omnisal/get_ru_names()
+	return list(
         NOMINATIVE = "боевой инъектор (Разб. омнизин + Физраствор)",
         GENITIVE = "боевого инъектора (Разб. омнизин + Физраствор)",
         DATIVE = "боевому инъектору (Разб. омнизин + Физраствор)",
@@ -314,12 +349,14 @@
         INSTRUMENTAL = "боевым инъектором (Разб. омнизин + Физраствор)",
         PREPOSITIONAL = "боевом инъекторе (Разб. омнизин + Физраствор)"
 	)
-	list_reagents = list("weak_omnizine" = 45, "salglu_solution" = 45)
-	possible_transfer_amounts = list(10, 20, 30)
 
 /obj/item/reagent_containers/hypospray/combat/nanites
 	desc = "Модифицированный автоинъектор с воздушной иглой, используемый оперативниками поддержки для быстрого заживления ран в бою. Заполнен дорогостоящими медицинскими нанитами для быстрого заживления."
-	ru_names = list(
+	volume = 100
+	list_reagents = list("nanites" = 100)
+
+/obj/item/reagent_containers/hypospray/combat/nanites/get_ru_names()
+	return list(
         NOMINATIVE = "боевой инъектор (Боевые наниты)",
         GENITIVE = "боевого инъектора (Боевые наниты)",
         DATIVE = "боевому инъектору (Боевые наниты)",
@@ -327,20 +364,10 @@
         INSTRUMENTAL = "боевым инъектором (Боевые наниты)",
         PREPOSITIONAL = "боевом инъекторе (Боевые наниты)"
 	)
-	volume = 100
-	list_reagents = list("nanites" = 100)
 
 /obj/item/reagent_containers/hypospray/autoinjector
 	name = "emergency autoinjector"
 	desc = "Маленький инъектор в форме ручки, содержащий внутри дозу эпинефрина. Быстрый и безопасный способ стабилизации пациентов в критическом состоянии для персонала, не обладающего глубокими медицинскими знаниями."
-	ru_names = list(
-        NOMINATIVE = "аварийный автоинъектор",
-        GENITIVE = "аварийного автоинъектора",
-        DATIVE = "аварийному автоинъектору",
-        ACCUSATIVE = "аварийный автоинъектор",
-        INSTRUMENTAL = "аварийным автоинъектором",
-        PREPOSITIONAL = "аварийном автоинъекторе"
-	)
 	icon_state = "autoinjector"
 	item_state = "autoinjector"
 	belt_icon = "autoinjector"
@@ -360,6 +387,15 @@
 	/// Is it used?
 	var/spent = FALSE
 
+/obj/item/reagent_containers/hypospray/autoinjector/get_ru_names()
+	return list(
+        NOMINATIVE = "аварийный автоинъектор",
+        GENITIVE = "аварийного автоинъектора",
+        DATIVE = "аварийному автоинъектору",
+        ACCUSATIVE = "аварийный автоинъектор",
+        INSTRUMENTAL = "аварийным автоинъектором",
+        PREPOSITIONAL = "аварийном автоинъекторе"
+	)
 
 /obj/item/reagent_containers/hypospray/autoinjector/update_icon_state()
 	var/base_state
@@ -474,7 +510,9 @@
 	desc = "Содержит в себе яйца настоящего ужаса, готового сокрушить станцию."
 	icon_state = "spider-injector"
 	list_reagents = list("terror_eggs" = 10)
-	ru_names = list(
+
+/obj/item/reagent_containers/hypospray/autoinjector/death_book/eggs_terror/get_ru_names()
+	return list(
 		NOMINATIVE = "зловещий зелёный инъектор",
 		GENITIVE = "зловещего зелёного инъектора",
 		DATIVE = "зловещему зелёному инъектору",
@@ -488,7 +526,9 @@
 	desc = "Содержит в себе агрессивные ксеномикробы. Не облизывать!"
 	list_reagents = list("xenomicrobes_phantom" = 10)
 	icon_state = "xeno-injector"
-	ru_names = list(
+
+/obj/item/reagent_containers/hypospray/autoinjector/death_book/xeno/get_ru_names()
+	return list(
 		NOMINATIVE = "зловещий фиолетовый инъектор",
 		GENITIVE = "зловещего фиолетового инъектора",
 		DATIVE = "зловещему фиолетовому инъектору",
@@ -500,7 +540,11 @@
 /obj/item/reagent_containers/hypospray/autoinjector/teporone //basilisks
 	name = "teporone autoinjector"
 	desc = "Маленький инъектор в форме ручки, содержащий внутри дозу тепорона. Быстрый способ восстановления температуры тела до естественных показателей."
-	ru_names = list(
+	icon_state = "lepopen"
+	list_reagents = list("teporone" = 10)
+
+/obj/item/reagent_containers/hypospray/autoinjector/teporone/get_ru_names()
+	return list(
         NOMINATIVE = "автоинъектор (Тепорон)",
         GENITIVE = "автоинъектора (Тепорон)",
         DATIVE = "автоинъектору (Тепорон)",
@@ -508,13 +552,17 @@
         INSTRUMENTAL = "автоинъектором (Тепорон)",
         PREPOSITIONAL = "автоинъекторе (Тепорон)"
 	)
-	icon_state = "lepopen"
-	list_reagents = list("teporone" = 10)
 
 /obj/item/reagent_containers/hypospray/autoinjector/stimpack //goliath kiting
 	name = "stimpack autoinjector"
 	desc = "Маленький инъектор в форме ручки, содержащий внутри дозу стимуляторов. Для тех случаев, когда вам срочно нужна доза адреналина."
-	ru_names = list(
+	icon_state = "stimpen"
+	volume = 20
+	amount_per_transfer_from_this = 20
+	list_reagents = list("methamphetamine" = 10, "coffee" = 10)
+
+/obj/item/reagent_containers/hypospray/autoinjector/stimpack/get_ru_names()
+	return list(
         NOMINATIVE = "автоинъектор (Стим-пак)",
         GENITIVE = "автоинъектора (Стим-пак)",
         DATIVE = "автоинъектору (Стим-пак)",
@@ -522,15 +570,17 @@
         INSTRUMENTAL = "автоинъектором (Стим-пак)",
         PREPOSITIONAL = "автоинъекторе (Стим-пак)"
 	)
-	icon_state = "stimpen"
-	volume = 20
-	amount_per_transfer_from_this = 20
-	list_reagents = list("methamphetamine" = 10, "coffee" = 10)
 
 /obj/item/reagent_containers/hypospray/autoinjector/stimulants
 	name = "Stimulants autoinjector"
 	desc = "Маленький инъектор в форме ручки, содержащий внутри дозу стимуляторов, кратковременно увеличивающих физическую силу, заживляющих повреждения, ускоряющих работу нервной системы и так далее. "
-	ru_names = list(
+	icon_state = "stimpen"
+	amount_per_transfer_from_this = 50
+	volume = 50
+	list_reagents = list("stimulants" = 50)
+
+/obj/item/reagent_containers/hypospray/autoinjector/stimulants/get_ru_names()
+	return list(
         NOMINATIVE = "автоинъектор (Стимуляторы)",
         GENITIVE = "автоинъектора (Стимуляторы)",
         DATIVE = "автоинъектору (Стимуляторы)",
@@ -538,15 +588,18 @@
         INSTRUMENTAL = "автоинъектором (Стимуляторы)",
         PREPOSITIONAL = "автоинъекторе (Стимуляторы)"
 	)
-	icon_state = "stimpen"
-	amount_per_transfer_from_this = 50
-	volume = 50
-	list_reagents = list("stimulants" = 50)
 
 /obj/item/reagent_containers/hypospray/autoinjector/survival
 	name = "survival medipen"
 	desc = "Маленький инъектор в форме ручки, содержащий внутри дозу веществ для спасения во время экстренных ситуаций, которые могут произойти на пустошах Лазиса.\n" + span_boldwarning("ПРЕДУПРЕЖДЕНИЕ: Не используйте более одного за раз!")
-	ru_names = list(
+	icon_state = "stimpen"
+	belt_icon = "survival_medipen"
+	volume = 42
+	amount_per_transfer_from_this = 42
+	list_reagents = list("salbutamol" = 10, "teporone" = 15, "epinephrine" = 10, "lavaland_extract" = 2, "weak_omnizine" = 5) //Short burst of healing, followed by minor healing from the saline
+
+/obj/item/reagent_containers/hypospray/autoinjector/survival/get_ru_names()
+	return list(
         NOMINATIVE = "автоинъектор выживания",
         GENITIVE = "автоинъектора выживания",
         DATIVE = "автоинъектору выживания",
@@ -554,16 +607,17 @@
         INSTRUMENTAL = "автоинъектором выживания",
         PREPOSITIONAL = "автоинъекторе выживания"
 	)
-	icon_state = "stimpen"
-	belt_icon = "survival_medipen"
-	volume = 42
-	amount_per_transfer_from_this = 42
-	list_reagents = list("salbutamol" = 10, "teporone" = 15, "epinephrine" = 10, "lavaland_extract" = 2, "weak_omnizine" = 5) //Short burst of healing, followed by minor healing from the saline
 
 /obj/item/reagent_containers/hypospray/autoinjector/survival/luxury
 	name = "luxury medipen"
 	desc = "Улучшенная версия стандартного автоинъектора выживания, вмещающая в себя до 40 единиц мощных медикаментов." + span_boldwarning("ПРЕДУПРЕЖДЕНИЕ: Не используйте более одного за раз!")
-	ru_names = list(
+	icon_state = "redinjector"
+	volume = 40
+	amount_per_transfer_from_this = 40
+	list_reagents = list("salbutamol" = 10, "adv_lava_extract" = 10, "teporone" = 10, "hydrocodone" = 10)
+
+/obj/item/reagent_containers/hypospray/autoinjector/survival/luxury/get_ru_names()
+	return list(
         NOMINATIVE = "улучшенный автоинъектор выживания",
         GENITIVE = "улучшенного автоинъектора выживания",
         DATIVE = "улучшенному автоинъектору выживания",
@@ -571,11 +625,6 @@
         INSTRUMENTAL = "улучшенным автоинъектором выживания",
         PREPOSITIONAL = "улучшенном автоинъекторе выживания"
 	)
-	icon_state = "redinjector"
-	volume = 40
-	amount_per_transfer_from_this = 40
-	list_reagents = list("salbutamol" = 10, "adv_lava_extract" = 10, "teporone" = 10, "hydrocodone" = 10)
-
 
 /obj/item/reagent_containers/hypospray/autoinjector/survival/luxury/attack(mob/living/carbon/target, mob/living/user, params, def_zone, skip_attack_anim = FALSE)
 	if(lavaland_equipment_pressure_check(get_turf(user)))
@@ -593,7 +642,13 @@
 /obj/item/reagent_containers/hypospray/autoinjector/nanocalcium
 	name = "protoype nanite autoinjector"
 	desc = "Маленький инъектор в форме ручки, содержащий внутри дозу экспериментального вещества, предназначенного для заживления внутренних повреждений. Имеются побочные эффекты."
-	ru_names = list(
+	icon_state = "bonepen"
+	amount_per_transfer_from_this = 15
+	volume = 15
+	list_reagents = list("nanocalcium" = 15)
+
+/obj/item/reagent_containers/hypospray/autoinjector/nanocalcium/get_ru_names()
+	return list(
         NOMINATIVE = "экспериментальный автоинъектор (Нано-Кальций)",
         GENITIVE = "экспериментального автоинъектора (Нано-Кальций)",
         DATIVE = "экспериментальному автоинъектору (Нано-Кальций)",
@@ -601,10 +656,6 @@
         INSTRUMENTAL = "экспериментальным автоинъектором (Нано-Кальций)",
         PREPOSITIONAL = "экспериментальном автоинъекторе (Нано-Кальций)"
 	)
-	icon_state = "bonepen"
-	amount_per_transfer_from_this = 15
-	volume = 15
-	list_reagents = list("nanocalcium" = 15)
 
 
 /obj/item/reagent_containers/hypospray/autoinjector/nanocalcium/attack(mob/living/carbon/target, mob/living/user, params, def_zone, skip_attack_anim = FALSE)
@@ -616,14 +667,6 @@
 /obj/item/reagent_containers/hypospray/autoinjector/selfmade
 	name = "autoinjector"
 	desc = "Кустарно произведённая копия автоинъектора. Из-за особенностей конструкции его невозможно использовать на ком-то, кроме себя."
-	ru_names = list(
-        NOMINATIVE = "самодельный автоинъектор",
-        GENITIVE = "самодельного автоинъектора",
-        DATIVE = "самодельному автоинъектору",
-        ACCUSATIVE = "самодельный автоинъектор",
-        INSTRUMENTAL = "самодельным автоинъектором",
-        PREPOSITIONAL = "самодельном автоинъекторе"
-	)
 	volume = 15
 	amount_per_transfer_from_this = 15
 	list_reagents = list()
@@ -631,6 +674,15 @@
 	reskin_allowed = TRUE
 	container_type = OPENCONTAINER
 
+/obj/item/reagent_containers/hypospray/autoinjector/selfmade/get_ru_names()
+	return list(
+        NOMINATIVE = "самодельный автоинъектор",
+        GENITIVE = "самодельного автоинъектора",
+        DATIVE = "самодельному автоинъектору",
+        ACCUSATIVE = "самодельный автоинъектор",
+        INSTRUMENTAL = "самодельным автоинъектором",
+        PREPOSITIONAL = "самодельном автоинъекторе"
+	)
 
 /obj/item/reagent_containers/hypospray/autoinjector/selfmade/attack(mob/living/carbon/target, mob/living/user, params, def_zone, skip_attack_anim = FALSE)
 	. = ..()
@@ -641,7 +693,13 @@
 /obj/item/reagent_containers/hypospray/autoinjector/salbutamol
 	name = "Salbutamol autoinjector"
 	desc = "Маленький инъектор в форме ручки, содержащий внутри дозу сальбутамола для экстренной помощи при удушье."
-	ru_names = list(
+	icon_state = "ablueinjector"
+	amount_per_transfer_from_this = 20
+	volume = 20
+	list_reagents = list("salbutamol" = 20)
+
+/obj/item/reagent_containers/hypospray/autoinjector/salbutamol/get_ru_names()
+	return list(
         NOMINATIVE = "автоинъектор (Сальбутамол)",
         GENITIVE = "автоинъектора (Сальбутамол)",
         DATIVE = "автоинъектору (Сальбутамол)",
@@ -649,15 +707,15 @@
         INSTRUMENTAL = "автоинъектором (Сальбутамол)",
         PREPOSITIONAL = "автоинъекторе (Сальбутамол)"
 	)
-	icon_state = "ablueinjector"
-	amount_per_transfer_from_this = 20
-	volume = 20
-	list_reagents = list("salbutamol" = 20)
 
 /obj/item/reagent_containers/hypospray/autoinjector/radium
 	name = "Radium autoinjector"
 	desc = "Маленький инъектор в форме ручки, содержащий внутри дозу радия для экстренной первой помощи нуклеациям."
-	ru_names = list(
+	icon_state = "ablueinjector"
+	list_reagents = list("radium" = 10)
+
+/obj/item/reagent_containers/hypospray/autoinjector/radium/get_ru_names()
+	return list(
         NOMINATIVE = "автоинъектор (Радий)",
         GENITIVE = "автоинъектора (Радий)",
         DATIVE = "автоинъектору (Радий)",
@@ -665,13 +723,17 @@
         INSTRUMENTAL = "автоинъектором (Радий)",
         PREPOSITIONAL = "автоинъекторе (Радий)"
 	)
-	icon_state = "ablueinjector"
-	list_reagents = list("radium" = 10)
 
 /obj/item/reagent_containers/hypospray/autoinjector/charcoal
 	name = "Charcoal autoinjector"
 	desc = "Маленький инъектор в форме ручки, содержащий внутри дозу активированного угля для экстренной помощи при отравлениях."
-	ru_names = list(
+	icon_state = "greeninjector"
+	amount_per_transfer_from_this = 20
+	volume = 20
+	list_reagents = list("charcoal" = 20)
+
+/obj/item/reagent_containers/hypospray/autoinjector/charcoal/get_ru_names()
+	return list(
         NOMINATIVE = "автоинъектор (Активированный уголь)",
         GENITIVE = "автоинъектора (Активированный уголь)",
         DATIVE = "автоинъектору (Активированный уголь)",
@@ -679,7 +741,4 @@
         INSTRUMENTAL = "автоинъектором (Активированный уголь)",
         PREPOSITIONAL = "автоинъекторе (Активированный уголь)"
 	)
-	icon_state = "greeninjector"
-	amount_per_transfer_from_this = 20
-	volume = 20
-	list_reagents = list("charcoal" = 20)
+

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -4,14 +4,6 @@
 /obj/item/reagent_containers/iv_bag
 	name = "IV Bag"
 	desc = "Пакет с тонкой иглой на конце. Предназначен для введения пациентам веществ прямо в кровоток в течение определённого времени."
-	ru_names = list(
-        NOMINATIVE = "капельница",
-        GENITIVE = "капельницы",
-        DATIVE = "капельнице",
-        ACCUSATIVE = "капельницу",
-        INSTRUMENTAL = "капельницей",
-        PREPOSITIONAL = "капельнице"
-	)
 	gender = FEMALE
 	icon = 'icons/goonstation/objects/iv.dmi'
 	lefthand_file = 'icons/goonstation/mob/inhands/items_lefthand.dmi'
@@ -26,6 +18,16 @@
 	var/mode = IV_INJECT
 	var/mob/living/carbon/human/injection_target
 	var/obj/item/organ/external/injection_limb
+
+/obj/item/reagent_containers/iv_bag/get_ru_names()
+	return list(
+        NOMINATIVE = "капельница",
+        GENITIVE = "капельницы",
+        DATIVE = "капельнице",
+        ACCUSATIVE = "капельницу",
+        INSTRUMENTAL = "капельницей",
+        PREPOSITIONAL = "капельнице"
+	)
 
 /obj/item/reagent_containers/iv_bag/empty()
 	set hidden = TRUE
@@ -211,6 +213,16 @@
 /obj/item/reagent_containers/iv_bag/salglu
 	list_reagents = list("salglu_solution" = 200)
 
+/obj/item/reagent_containers/iv_bag/salglu/get_ru_names()
+	return list(
+        NOMINATIVE = "капельница (Физраствор)",
+        GENITIVE = "капельницы (Физраствор)",
+        DATIVE = "капельнице (Физраствор)",
+        ACCUSATIVE = "капельницу (Физраствор)",
+        INSTRUMENTAL = "капельницей (Физраствор)",
+        PREPOSITIONAL = "капельнице (Физраствор)"
+	)
+
 /obj/item/reagent_containers/iv_bag/salglu/Initialize(mapload)
 	name = "[initial(name)] - Saline Glucose"
 	. = ..()
@@ -220,20 +232,44 @@
 	var/blood_species = "Human"
 	amount_per_transfer_from_this = 5 // Bloodbags are set to transfer 5 units by default.
 
+/obj/item/reagent_containers/iv_bag/blood/proc/get_ru_names_for_blood_species()
+	return list(
+		"Human" = "Человек",
+		"Diona" = "Диона",
+		"Drask" = "Драск",
+		"Grey" = "Грей",
+		"Kidan" = "Кидан",
+		"Tajaran" = "Таяран",
+		"Vulpkanin" = "Вульпканин",
+		"Skrell" = "Скрелл",
+		"Unathi" = "Унати",
+		"Nian" = "Ниан",
+		"Vox" = "Вокс",
+		"Wryn" = "Врин"
+	)
+
+/obj/item/reagent_containers/iv_bag/blood/get_ru_names()
+	return list(
+			NOMINATIVE = "капельница - [get_ru_names_for_blood_species()[blood_species]] ([blood_type])" ,
+			GENITIVE = "капельницы - [get_ru_names_for_blood_species()[blood_species]] ([blood_type])",
+			DATIVE = "капельнице - [get_ru_names_for_blood_species()[blood_species]] ([blood_type])",
+			ACCUSATIVE = "капельницу - [get_ru_names_for_blood_species()[blood_species]] ([blood_type])",
+			INSTRUMENTAL = "капельницей - [get_ru_names_for_blood_species()[blood_species]] ([blood_type])",
+			PREPOSITIONAL = "капельнице - [get_ru_names_for_blood_species()[blood_species]] ([blood_type])"
+		)
+
 /obj/item/reagent_containers/iv_bag/blood/Initialize(mapload)
 	if(blood_type != null && blood_species != null)
 		name = "[initial(name)] - [blood_species] ([blood_type])"
-		ru_names = list(
-			NOMINATIVE = "капельница - [blood_species] ([blood_type])" ,
-			GENITIVE = "капельницы - [blood_species] ([blood_type])",
-			DATIVE = "капельнице - [blood_species] ([blood_type])",
-			ACCUSATIVE = "капельницу - [blood_species] ([blood_type])",
-			INSTRUMENTAL = "капельницей - [blood_species] ([blood_type])",
-			PREPOSITIONAL = "капельнице - [blood_species] ([blood_type])"
-		)
 		reagents.add_reagent("blood", 200, list("donor"=null,"diseases"=null,"blood_DNA"=null,"blood_type"=blood_type,"blood_species"=blood_species,"resistances"=null,"trace_chem"=null))
 		update_icon(UPDATE_OVERLAYS)
 	. = ..()
+
+/obj/item/reagent_containers/iv_bag/blood/random/get_ru_names()
+	return null
+
+/obj/item/reagent_containers/iv_bag/blood/random/get_ru_names_cached()
+	return null
 
 /obj/item/reagent_containers/iv_bag/blood/random/Initialize(mapload)
 	blood_type = pick("A+", "A-", "B+", "B-", "O+", "O-")
@@ -301,10 +337,8 @@
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis
 	var/blood_species = "Oxygen - synthetic"
 
-/obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis/Initialize(mapload)
-	if(blood_type != null && blood_species != null)
-		name = "[initial(name)] - Oxygenis"
-		ru_names = list(
+/obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis/get_ru_names()
+	return list(
 			NOMINATIVE = "капельница - Синтетическая кровь (Кислород)" ,
 			GENITIVE = "капельницы - Синтетическая кровь (Кислород)",
 			DATIVE = "капельнице - Синтетическая кровь (Кислород)",
@@ -312,6 +346,10 @@
 			INSTRUMENTAL = "капельницей - Синтетическая кровь (Кислород)",
 			PREPOSITIONAL = "капельнице - Синтетическая кровь (Кислород)"
 		)
+
+/obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis/Initialize(mapload)
+	if(blood_type != null && blood_species != null)
+		name = "[initial(name)] - Oxygenis"
 		reagents.add_reagent("sbloodoxy", 200, list("donor"=null,"diseases"=null,"blood_DNA"=null,"blood_type"=blood_type,"blood_species"=blood_species,"resistances"=null,"trace_chem"=null))
 		update_icon(UPDATE_OVERLAYS)
 
@@ -319,10 +357,8 @@
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/nitrogenis
 	var/blood_species = "Vox - synthetic"
 
-/obj/item/reagent_containers/iv_bag/bloodsynthetic/nitrogenis/Initialize(mapload)
-	if(blood_type != null && blood_species != null)
-		name = "[initial(name)] - Nitrogenis"
-		ru_names = list(
+/obj/item/reagent_containers/iv_bag/bloodsynthetic/nitrogenis/get_ru_names()
+	return list(
 			NOMINATIVE = "капельница - Синтетическая кровь (Азот)" ,
 			GENITIVE = "капельницы - Синтетическая кровь (Азот)",
 			DATIVE = "капельнице - Синтетическая кровь (Азот)",
@@ -330,6 +366,10 @@
 			INSTRUMENTAL = "капельницей - Синтетическая кровь (Азот)",
 			PREPOSITIONAL = "капельнице - Синтетическая кровь (Азот)"
 		)
+
+/obj/item/reagent_containers/iv_bag/bloodsynthetic/nitrogenis/Initialize(mapload)
+	if(blood_type != null && blood_species != null)
+		name = "[initial(name)] - Nitrogenis"
 		reagents.add_reagent("sbloodvox", 200, list("donor"=null,"diseases"=null,"blood_DNA"=null,"blood_type"=blood_type,"blood_species"=blood_species,"resistances"=null,"trace_chem"=null))
 		update_icon(UPDATE_OVERLAYS)
 	. = ..()
@@ -337,9 +377,8 @@
 /obj/item/reagent_containers/iv_bag/slime
 	list_reagents = list("slimejelly" = 200)
 
-/obj/item/reagent_containers/iv_bag/slime/Initialize(mapload)
-	name = "[initial(name)] - Slime Jelly"
-	ru_names = list(
+/obj/item/reagent_containers/iv_bag/slime/get_ru_names()
+	return list(
 		NOMINATIVE = "капельница - Слаймовое желе" ,
 		GENITIVE = "капельницы - Слаймовое желе",
 		DATIVE = "капельнице - Слаймовое желе",
@@ -347,4 +386,8 @@
 		INSTRUMENTAL = "капельницей - Слаймовое желе",
 		PREPOSITIONAL = "капельнице - Слаймовое желе"
 	)
+
+/obj/item/reagent_containers/iv_bag/slime/Initialize(mapload)
+	name = "[initial(name)] - Slime Jelly"
 	. = ..()
+


### PR DESCRIPTION
## Что этот ПР делает

Возвращает перевод капельниц, инжекторов, гипо, мендеров. Наконец-то исправляет оверлей страховки (надеюсь).

## Почему это хорошо для игры

Перевод снова работает.

## Тестирование
Мендеры, инжекторы:
<img width="216" height="85" alt="изображение" src="https://github.com/user-attachments/assets/f9f9d993-ac91-4970-a0f3-64461eacec9e" />
<img width="233" height="112" alt="изображение" src="https://github.com/user-attachments/assets/9bd3a2fc-6f68-42bb-a3a5-011272bb785c" />

Капельницы:
<img width="276" height="611" alt="изображение" src="https://github.com/user-attachments/assets/428d5a08-bdd5-4378-96b0-ce2f66cf3edd" />


