### PR TITLE
tweak: Списывание страховки теперь напоминает о привязке карты + span

### DIFF
--- a/code/modules/economy/insurance.dm
+++ b/code/modules/economy/insurance.dm
@@ -23,19 +23,19 @@
 
 /proc/do_insurance_collection(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/money_account/connected_acc)
 	if(!istype(target))
-		balloon_alert(user, "цель не обнаружена")
+		user.balloon_alert(user, "цель не обнаружена")
 		return FALSE
 
 	var/list/access = user?.get_access()
 	if(user && !(ACCESS_MEDICAL in access))
-		balloon_alert(user, "нет доступа!")
+		user.balloon_alert(user, "нет доступа!")
 		return FALSE
 
 	var/req = get_req_insurance(target)
 	var/datum/money_account/acc = get_insurance_account(target)
 
 	if(!acc)
-		balloon_alert(user, "нет аккаунта!")
+		user.balloon_alert(user, "нет аккаунта!")
 		return FALSE
 
 	if(!COOLDOWN_FINISHED(acc, insurance_collecting))

--- a/code/modules/economy/insurance.dm
+++ b/code/modules/economy/insurance.dm
@@ -23,19 +23,19 @@
 
 /proc/do_insurance_collection(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/money_account/connected_acc)
 	if(!istype(target))
-		to_chat(user, span_warning("Некорректная цель списания страховки."))
+		balloon_alert(user, "цель не обнаружена")
 		return FALSE
 
 	var/list/access = user?.get_access()
 	if(user && !(ACCESS_MEDICAL in access))
-		to_chat(user, span_warning("Недостаточно доступа для списания страховки."))
+		balloon_alert(user, "нет доступа!")
 		return FALSE
 
 	var/req = get_req_insurance(target)
 	var/datum/money_account/acc = get_insurance_account(target)
 
 	if(!acc)
-		to_chat(user, span_warning("Аккаунт не обнаружен."))
+		balloon_alert(user, "нет аккаунта!")
 		return FALSE
 
 	if(!COOLDOWN_FINISHED(acc, insurance_collecting))

--- a/code/modules/economy/insurance.dm
+++ b/code/modules/economy/insurance.dm
@@ -28,17 +28,18 @@
 
 	var/list/access = user?.get_access()
 	if(user && !(ACCESS_MEDICAL in access))
-		user.balloon_alert(user, "нет доступа!")
+		user.balloon_alert(user, "нет доступа")
 		return FALSE
 
 	var/req = get_req_insurance(target)
 	var/datum/money_account/acc = get_insurance_account(target)
 
 	if(!acc)
-		user.balloon_alert(user, "нет аккаунта!")
+		user.balloon_alert(user, "нет аккаунта")
 		return FALSE
 
 	if(!COOLDOWN_FINISHED(acc, insurance_collecting))
+		user.balloon_alert(user, "слишком рано")
 		to_chat(user, span_warning("С цели недавно уже списывалась страховка. Подождите немного."))
 		return FALSE
 	COOLDOWN_START(acc, insurance_collecting, 60 SECONDS)
@@ -56,8 +57,6 @@
 				ignored_mobs = user,
 			)
 			return FALSE
-
-	if(from_money_acc)
 		send_insurance_alert(acc)
 
 	acc.addInsurancePoints(-from_insurance)

--- a/code/modules/economy/insurance.dm
+++ b/code/modules/economy/insurance.dm
@@ -23,35 +23,38 @@
 
 /proc/do_insurance_collection(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/money_account/connected_acc)
 	if(!istype(target))
-		target.visible_message("Некорректная цель списания страховки.")
+		to_chat(user, span_warning("Некорректная цель списания страховки."))
 		return FALSE
 
 	var/list/access = user?.get_access()
 	if(user && !(ACCESS_MEDICAL in access))
-		target.visible_message("Недостаточно доступа для списания страховки.")
+		to_chat(user, span_warning("Недостаточно доступа для списания страховки."))
 		return FALSE
 
 	var/req = get_req_insurance(target)
 	var/datum/money_account/acc = get_insurance_account(target)
 
 	if(!acc)
-		target.visible_message("Аккаунт не обнаружен.")
+		to_chat(user, span_warning("Аккаунт не обнаружен."))
 		return FALSE
 
 	if(!COOLDOWN_FINISHED(acc, insurance_collecting))
-		target.visible_message("С цели недавно уже списывалась страховка. Подождите немного.")
+		to_chat(user, span_warning("С цели недавно уже списывалась страховка. Подождите немного."))
 		return FALSE
 	COOLDOWN_START(acc, insurance_collecting, 60 SECONDS)
 
 	var/from_insurance = min(acc.insurance, req)
 	var/from_money_acc = (req - from_insurance) * 2
 
+
 	if(from_money_acc)
-		if(!acc.insurance_auto_replen)
-			target.visible_message(span_warning("Страховки не хватает на оплату лечения. Автопополнение страховки отключено."))
-			return FALSE
-		if(!acc.charge(from_money_acc))
-			target.visible_message(span_warning("Страховки не хватает на оплату лечения. Автопополнение страховки провалилось."))
+		if(!acc.insurance_auto_replen || !acc.charge(from_money_acc))
+			to_chat(user, span_warning("Страховки не хватает на оплату лечения. Автопополнение страховки отключено или провалилось."))
+			target.visible_message(
+				span_danger("[user] безуспешно пыта[pluralize_ru(user.gender, "ет", "ют")]ся списать страховку у [target]!"),
+				span_userdanger("[user] безуспешно пыта[pluralize_ru(user.gender, "ет", "ют")]ся списать вашу страховку!"),
+				ignored_mobs = user,
+			)
 			return FALSE
 
 	if(from_money_acc)
@@ -59,14 +62,26 @@
 
 	acc.addInsurancePoints(-from_insurance)
 
+	var/datum/money_account/money_account = null
 	if(connected_acc)
-		var/datum/money_account/money_account = attempt_account_access_nosec(connected_acc)
-		if(money_account)
-			money_account.money += round(round(req / 2))
+		money_account = attempt_account_access_nosec(connected_acc)
+	else
+		to_chat(user, span_warning("Привязанного аккаунта к сканеру не обнаружено. Рекомендуется авторизоваться."))
+		var/obj/item/card/id/user_id = user.get_id_card()
+		if(istype(user_id) && user_id.associated_account_number)
+			money_account = get_money_account(user_id.associated_account_number)
 
-	target.visible_message("Страховка списанна в размере: [req].")
+	if(money_account)
+		money_account.money += round(round(req / 2))
+
+	to_chat(user, span_notice("Вы списали страховку у [target] в размере: [req]."))
+	target.visible_message(
+		span_danger("[user] списыва[pluralize_ru(user.gender, "ет", "ют")] страховку у [target] в размере: [req]."),
+		span_userdanger("[user] списыва[pluralize_ru(user.gender, "ет", "ют")] вашу страховку в размере: [req]."),
+		ignored_mobs = user,
+	)
 	if(from_money_acc)
-		target.visible_message("Страховки не хватило. [from_money_acc / 2] недостающих очков страховки восполнено за счет [from_money_acc] кредитов со счета пациента.")
+		to_chat(user,(span_notice("Страховки не хватило. [from_money_acc / 2] недостающих очков страховки восполнено за счет [from_money_acc] кредитов со счета пациента. Уведомите пациента о его состоянии страховки")))
 
 	return TRUE
 


### PR DESCRIPTION
## Что этот ПР делает
 Списывание страховки теперь напоминает о привязке карты пользователю, но все же пополняет счет после снятия страховки пациента.
 
 Добавлены стили для сообщений. _БОЛЬШЕ НИКАКОГО СЕРОГО ТЕКСТА БЕЗ СТИЛЯ._

## Почему это хорошо для игры
Удобство использования медицинского сканера для списания страховки.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Демонстрация изменений

<img width="369" height="152" alt="изображение" src="https://github.com/user-attachments/assets/3ca3e865-83a2-44b3-9782-819ec8563ce2" />

## Тестирование
Во время запуска локального сервера ошибок не обнаружено

