### PR TITLE
bugfix: фикс библии в наборе миссионера

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -295,7 +295,7 @@
 	var/obj/item/storage/bible/B = new /obj/item/storage/bible(src)
 	if(prob(25))	//an omen of success to come?
 		B.deity_name = "Success"
-		B.icon_state = "greentext"
+		B.icon_state = "bible_greentext"
 		B.item_state = "greentext"
 
 
@@ -815,7 +815,7 @@ To apply, hold the injector a short distance away from the outer thigh before ap
 	new /obj/item/gun_module/rail/scope/collimator(src)
 	new /obj/item/gun_module/rail/scope/x4(src)
 	new /obj/item/gun_module/under/hand/angle(src)
-  
+
 /obj/item/storage/box/syndie_kit/compact_sniper
 	name = "compact sniper rifle kit"
 	desc = "Коробка, содержащая компактную снайперскую винтовку \"Bubz Mini\", дополнительный магазин, и коробку патронов."

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -13,7 +13,7 @@
 		if(client.handle_spam_prevention(msg, MUTE_PRAY, OOC_COOLDOWN))
 			return
 
-	var/image/cross = image('icons/obj/storage.dmi',"bible")
+	var/image/cross = image('icons/obj/library.dmi',"bible")
 	var/font_color = "purple"
 	var/prayer_type = "PRAYER"
 	var/deity

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -20,11 +20,11 @@
 	if(job == JOB_TITLE_CHAPLAIN)
 		if(SSticker && SSticker.Bible_deity_name)
 			deity = SSticker.Bible_deity_name
-		cross = image('icons/obj/storage.dmi',"kingyellow")
+		cross = image('icons/obj/library.dmi',"bible_kingyellow")
 		font_color = "blue"
 		prayer_type = "CHAPLAIN PRAYER"
 	else if(iscultist(usr))
-		cross = image('icons/obj/storage.dmi',"tome")
+		cross = image('icons/obj/cult.dmi',"tome")
 		font_color = "red"
 		prayer_type = "CULTIST PRAYER"
 		deity = SSticker.cultdat.entity_name


### PR DESCRIPTION
## Что этот ПР делает

Меняет название стейта у библии в наборе миссионера на актуальное + чинит пути для иконок перед админлогами молитв.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Демонстрация изменений

<img width="1514" height="141" alt="изображение" src="https://github.com/user-attachments/assets/488f49ec-1a65-4ed1-a76d-a590b63725c4" />
<img width="470" height="147" alt="изображение" src="https://github.com/user-attachments/assets/d32f28b0-edb0-463a-95f3-f20d8f68acb8" />

<!-- Заполните, если Вы меняли спрайты, карту или ваши изменения требуют визуальной демонстрации изменений. -->

## Тестирование

сделал распрыжку на святоше и культисте - рантаймов нет.
