### PR TITLE
balance: нерфы разрывных патронов доступных на станции

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -824,12 +824,11 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/security/armory/shotgun_shells
 	name = "Various Shotgun Shells Crate"
 	containername = "various shotgun shells crate"
-	cost = 250
+	cost = 200
 	contains = list(
 		/obj/item/ammo_box/shotgun/stunslug,
 		/obj/item/ammo_box/shotgun/pulseslug,
 		/obj/item/ammo_box/shotgun/dragonsbreath,
-		/obj/item/ammo_box/shotgun/frag12,
 		/obj/item/ammo_box/shotgun/ion,
 		/obj/item/ammo_box/shotgun/laserslug,
 	)
@@ -3139,12 +3138,6 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 					/obj/item/ammo_casing/rocket)
 	credits_cost = 25000
 	containername = "rockets crate"
-
-/datum/supply_packs/contraband/grenades
-	name = "40mm grenade box crate"
-	contains = list(/obj/item/ammo_box/a40mm)
-	credits_cost = 16000
-	containername = "40mm grenade boxe crate"
 
 /datum/supply_packs/contraband/bombard_grenades
 	name = "Bombarda grenades crate"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -3139,6 +3139,12 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	credits_cost = 25000
 	containername = "rockets crate"
 
+/datum/supply_packs/contraband/grenades
+	name = "40mm grenade box crate"
+	contains = list(/obj/item/ammo_box/a40mm)
+	credits_cost = 20000
+	containername = "40mm grenade boxe crate"
+
 /datum/supply_packs/contraband/bombard_grenades
 	name = "Bombarda grenades crate"
 	contains = list(/obj/item/ammo_casing/a40mm/improvised/exp_shell,

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -5508,7 +5508,6 @@
 		/obj/item/storage/box/barrier = 2,
 		/obj/item/storage/box/teargas = 2,
 		/obj/item/ammo_box/a357 = 1,
-		/obj/item/ammo_box/secgl/exp = 1,
 	)
 
 	prices = list(
@@ -5516,7 +5515,6 @@
 		/obj/item/storage/box/barrier = 70,
 		/obj/item/storage/box/teargas = 100,
 		/obj/item/ammo_box/a357 = 300,
-		/obj/item/ammo_box/secgl/exp = 500,
 	)
 
 /obj/machinery/vending/ammo/get_ru_names()

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -261,9 +261,9 @@
 	name = "FRAG-12 Shell"
 	result = /obj/item/ammo_casing/shotgun/frag12
 	reqs = list(/obj/item/ammo_casing/shotgun/techshell = 1,
-				/datum/reagent/glycerol = 5,
-				/datum/reagent/acid = 5,
-				/datum/reagent/acid/facid = 5,)
+				/datum/reagent/glycerol = 15,
+				/datum/reagent/acid = 15,
+				/datum/reagent/acid/facid = 15,)
 	tools = list(TOOL_SCREWDRIVER)
 	time = 5
 	category = CAT_WEAPONRY

--- a/code/modules/projectiles/guns/projectile/bombarda.dm
+++ b/code/modules/projectiles/guns/projectile/bombarda.dm
@@ -313,7 +313,8 @@
 /datum/crafting_recipe/explosion_shell
 	name = "Improvised explosive shell"
 	result = /obj/item/ammo_casing/a40mm/improvised/exp_shell
-	reqs = list(/obj/item/grenade/iedcasing = 1,
+	reqs = list(/datum/reagent/blackpowder = 20,
+				/obj/item/grenade/iedcasing = 1,
 				/obj/item/grenade/chem_grenade = 1,
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/assembly/prox_sensor = 1)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -457,8 +457,8 @@
 		INSTRUMENTAL = "разрывной пулей",
 		PREPOSITIONAL = "разрывной пуле"
 	)
-	damage = 25
-	weaken = 10 SECONDS
+	damage = 20
+	knockdown = 3 SECONDS
 
 /obj/projectile/bullet/frag12/on_hit(atom/target, blocked = 0)
 	..()

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -458,7 +458,7 @@
 		PREPOSITIONAL = "разрывной пуле"
 	)
 	damage = 20
-	knockdown = 3 SECONDS
+	knockdown = 5 SECONDS
 
 /obj/projectile/bullet/frag12/on_hit(atom/target, blocked = 0)
 	..()


### PR DESCRIPTION
## Что этот ПР делает

-Усложнён крафт разрывных патронов для бомбаги. Теперь требуют 20ю пороха для крафта

-Из вендора патронов СБ убраны фраг гранаты для греника
-Контрабандный ящик с нюкерскими 40 мм гранатами стоит на 4к кредитов больше(20к)
-Из ящика с экзотическими патронами на дробовик убраны фраг 12, цена ящика снижена с 250 до 200

-Фраг12 патроны больше не станят на ДЕСЯТЬ секунд, вместо этого нокдаун 5
-Урон снижен с 25 до 20
-Увеличено колво реагентов для крафта в 3 раза (с 5 до 15ю)


## Почему это хорошо для игры

Начиная издалека - взрывы ебаное говно. Они не оставляют тебе шансов на выживание, никогда. Радиус взрыва "light" у стандартных снарядов бомбаги вводит в заблуждение, своим названием не отражая реальность, ведь это все еще 50~ дамага с отрывом конечностей(шанс) и станами, от которого невозможно защититься вне рига РД. 

Крафт этих патронов это выбор без выбора. Зачем делать огненные патроны, если есть ваншот говно? Правильно, ни за чем. Статы этих гранат практически идентичны раковым фраг 12 и нюкерскому гранатомету борга/м90.

Также в вендор СБ без ченжлога были добавлены ФРАГ гранаты со шрапнелью и хеви взрывом, гарантированно отрывающие конечности и в целом при директ хите являющиеся ваншотом для любого гуманоида.

Разрывные патроны это неинтеррактивный механ. Гранату в руке можно взрорвать выстрелом, ее могут передержать и взорваться, от неё можно убежать.  На пулю все это не работает, она в тебя прилетает и ты умираешь, и это говно.

## Тестирование
Демонстрация причины почему это нам надо
https://discord.com/channels/617003227182792704/734823601110515882/1411353618510250126
