### PR TITLE
balance: твики нюковских патронов на дробовик, изменения для дыхания дракона

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1043,15 +1043,15 @@
 	cost = 5
 
 /datum/uplink_item/ammo/bullbuck
-	name = "Барабан 12x70 — \"Картечь\""
-	desc = "Барабан на 12 патронов картечи калибра 12x70. Отлично подходит для ближней дистанции."
+	name = "Барабан 12x70 — \"Магнум Картечь\""
+	desc = "Барабан на 12 патронов магнум картечи калибра 12x70. Отлично подходит для ближней дистанции."
 	item = /obj/item/ammo_box/magazine/m12g
 	cost = 10
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/ammo/bulldragon
-	name = "Барабан 12x70 — \"Дыхание дракона\""
-	desc = "Барабан на 12 патронов \"Дыхание дракона\" калибра 12x70. Каждый снаряд содержит 4 поражающих элемента, которые при попадании поджигают цель."
+	name = "Барабан 12x70 — \"напалмовое Дыхание дракона\""
+	desc = "Барабан на 12 патронов \"напалмовое Дыхание дракона\" калибра 12x70. Каждый снаряд содержит 6 поражающих элементов, которые при попадании поджигают цель."
 	item = /obj/item/ammo_box/magazine/m12g/dragon
 	cost = 10
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
@@ -1067,20 +1067,12 @@
 	name = "Барабан 12x70 — \"Биотеррор\""
 	desc = "Барабан на 12 патронов \"Биотеррор\" калибра 12x70. Эти снаряды наносят повреждения за счёт токсинов и радиации."
 	item = /obj/item/ammo_box/magazine/m12g/bioterror
-	cost = 15
-	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
-
-/datum/uplink_item/ammo/bullmeteor
-	name = "Барабан 12x70 — \"Метеорит\""
-	desc = "Барабан на 12 патронов \"Метеорит\" калибра 12x70. Каждый выстрел отбрасывает цель на три тайла и на некоторое время оглушает её. \
-			С их помощью можно выбить даже шлюз."
-	item = /obj/item/ammo_box/magazine/m12g/breach
-	cost = 25
+	cost = 10
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/ammo/bull_XLbuck
-	name = "Расширенный барабан 12x70 — \"Картечь\""
-	desc = "Расширенный барабан на 24 патронов картечи калибра 12x70. Отлично подходит для ближней дистанции."
+	name = "Расширенный барабан 12x70 — \"Магнум Картечь\""
+	desc = "Расширенный барабан на 24 патронов магнум картечи калибра 12x70. Отлично подходит для ближней дистанции."
 	item = /obj/item/ammo_box/magazine/m12g/XtrLrg
 	cost = 20
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
@@ -1088,14 +1080,14 @@
 /datum/uplink_item/ammo/bull_XLflechette
 	name = "Расширенный барабан 12x70 — \"Флешетта\""
 	desc = "Расширенный барабан на 24 патронов \"Флешетта\" калибра 12x70. \
-			В отличие от картечи, у этих дробинок более узкая траектория полёта. Они обладают бронебойным действием."
+			В отличие от картечи, у этих флашетт более узкая траектория полёта. Они обладают бронебойным действием."
 	item = /obj/item/ammo_box/magazine/m12g/XtrLrg/flechette
 	cost = 20
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/ammo/bull_XLdragon
-	name = "Расширенный барабан 12x70 — \"Дыхание дракона\""
-	desc = "Расширенный барабан на 24 патронов \"Дыхание дракона\" калибра 12x70. Каждый снаряд содержит 4 поражающих элемента, которые при попадании поджигают цель."
+	name = "Расширенный барабан 12x70 — \"напалмовое Дыхание дракона\""
+	desc = "Расширенный барабан на 24 патронов \"напалмовое Дыхание дракона\" калибра 12x70. Каждый снаряд содержит 6 поражающих элементов, которые при попадании поджигают цель."
 	item = /obj/item/ammo_box/magazine/m12g/XtrLrg/dragon
 	cost = 20
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
@@ -1104,14 +1096,14 @@
 	name = "Барабан 12x70 — сумка"
 	desc = "Сумка, содержащая 8 барабанов на 12 патронов калибра 12x70 \"Картечь\" и 1 барабан \"Дыхание дракона\"."
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/shotgun
-	cost = 60 // normally 90
+	cost = 60
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/ammo/bulldog_XLmagsbag
 	name = "Расширенный барабан 12x70 — сумка"
 	desc = "Сумка, содержащая 3 расширенных барабана на 24 патронов калибра 12x70: \"Картечь\", \"Дыхание дракона\", \"Флешетта\"."
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/shotgunXLmags
-	cost = 45 // normally 90
+	cost = 45
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/ammo/smg

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -247,16 +247,6 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
-/datum/crafting_recipe/dragonsbreath
-	name = "Dragonsbreath Shell"
-	result = /obj/item/ammo_casing/shotgun/incendiary/dragonsbreath
-	reqs = list(/obj/item/ammo_casing/shotgun/techshell = 1,
-				/datum/reagent/phosphorus = 5,)
-	tools = list(TOOL_SCREWDRIVER)
-	time = 5
-	category = CAT_WEAPONRY
-	subcategory = CAT_AMMO
-
 /datum/crafting_recipe/frag12
 	name = "FRAG-12 Shell"
 	result = /obj/item/ammo_casing/shotgun/frag12

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -228,8 +228,8 @@
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
 
 /obj/item/ammo_casing/shotgun/buckshot
-	name = "buckshot shell"
-	desc = "A 12 gauge buckshot shell."
+	name = "magnum buckshot shell"
+	desc = "A 12 gauge magnum buckshot shell."
 	icon_state = "buckshotshell"
 	projectile_type = /obj/projectile/bullet/pellet
 	pellets = 6
@@ -253,8 +253,8 @@
 	pellets = 6
 	variance = 15
 
-/obj/item/ammo_casing/shotgun/buckshot/nuclear
-	projectile_type = /obj/projectile/bullet/pellet/nuclear
+/obj/item/ammo_casing/shotgun/buckshot/magnum
+	projectile_type = /obj/projectile/bullet/pellet/magnum
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubbershot shell"
@@ -348,8 +348,8 @@
 	variance = 25
 	muzzle_flash_color = LIGHT_COLOR_FIRE
 
-/obj/item/ammo_casing/shotgun/incendiary/dragonsbreath/nuclear
-	projectile_type = /obj/projectile/bullet/incendiary/shell/dragonsbreath/nuclear
+/obj/item/ammo_casing/shotgun/incendiary/dragonsbreath/napalm
+	projectile_type = /obj/projectile/bullet/incendiary/shell/dragonsbreath/napalm
 	pellets = 6
 	variance = 20
 

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -228,8 +228,8 @@
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
 
 /obj/item/ammo_casing/shotgun/buckshot
-	name = "magnum buckshot shell"
-	desc = "A 12 gauge magnum buckshot shell."
+	name = "buckshot shell"
+	desc = "A 12 gauge buckshot shell."
 	icon_state = "buckshotshell"
 	projectile_type = /obj/projectile/bullet/pellet
 	pellets = 6
@@ -254,6 +254,8 @@
 	variance = 15
 
 /obj/item/ammo_casing/shotgun/buckshot/magnum
+	name = "magnum buckshot shell"
+	desc = "A 12 gauge magnum buckshot shell."
 	projectile_type = /obj/projectile/bullet/pellet/magnum
 
 /obj/item/ammo_casing/shotgun/rubbershot

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -92,19 +92,19 @@
 		PREPOSITIONAL = "коробке патронов (шрапнель с глушащим токсином 12х70)"
 	)
 
-/obj/item/ammo_box/shotgun/buck/nuclear
+/obj/item/ammo_box/shotgun/buck/magnum
 	name = "elite ammunition box (buckshot)"
-	desc = "Коробка, содержащая патроны с крупной картечью калибра 12х70."
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot/nuclear
+	desc = "Коробка, содержащая патроны с магнум картечью калибра 12х70."
+	ammo_type = /obj/item/ammo_casing/shotgun/buckshot/magnum
 
-/obj/item/ammo_box/shotgun/buck/nuclear/get_ru_names()
+/obj/item/ammo_box/shotgun/buck/magnum/get_ru_names()
 	return list(
-		NOMINATIVE = "коробка патронов (крупная картечь 12х70)",
-		GENITIVE = "коробки патронов (крупная картечь 12х70)",
-		DATIVE = "коробке патронов (крупная картечь 12х70)",
-		ACCUSATIVE = "коробку патронов (крупная картечь 12х70)",
-		INSTRUMENTAL = "коробкой патронов (крупная картечь 12х70)",
-		PREPOSITIONAL = "коробке патронов (крупная картечь 12х70)"
+		NOMINATIVE = "коробка патронов (магнум картечь 12х70)",
+		GENITIVE = "коробки патронов (магнум картечь 12х70)",
+		DATIVE = "коробке патронов (магнум картечь 12х70)",
+		ACCUSATIVE = "коробку патронов (магнум картечь 12х70)",
+		INSTRUMENTAL = "коробкой патронов (магнум картечь 12х70)",
+		PREPOSITIONAL = "коробке патронов (магнум картечь 12х70)"
 	)
 
 /obj/item/ammo_box/shotgun/rubbershot
@@ -253,19 +253,19 @@
 		PREPOSITIONAL = "коробке патронов (дыхание дракона 12х70)"
 	)
 
-/obj/item/ammo_box/shotgun/dragonsbreath/nuclear
+/obj/item/ammo_box/shotgun/dragonsbreath/napalm
 	name = "elite ammunition box (dragonsbreath)"
 	desc = "Коробка, содержащая усиленные патроны \"Дыхание дракона\" калибра 12х70."
-	ammo_type = /obj/item/ammo_casing/shotgun/incendiary/dragonsbreath/nuclear
+	ammo_type = /obj/item/ammo_casing/shotgun/incendiary/dragonsbreath/napalm
 
-/obj/item/ammo_box/shotgun/dragonsbreath/nuclear/get_ru_names()
+/obj/item/ammo_box/shotgun/dragonsbreath/napalm/get_ru_names()
 	return list(
-		NOMINATIVE = "коробка патронов (усиленное дыхание дракона 12х70)",
-		GENITIVE = "коробки патронов (усиленное дыхание дракона 12х70)",
-		DATIVE = "коробке патронов (усиленное дыхание дракона 12х70)",
-		ACCUSATIVE = "коробку патронов (усиленное дыхание дракона 12х70)",
-		INSTRUMENTAL = "коробкой патронов (усиленное дыхание дракона 12х70)",
-		PREPOSITIONAL = "коробке патронов (усиленное дыхание дракона 12х70)"
+		NOMINATIVE = "коробка патронов (напалмовое дыхание дракона 12х70)",
+		GENITIVE = "коробки патронов (напалмовое дыхание дракона 12х70)",
+		DATIVE = "коробке патронов (напалмовое дыхание дракона 12х70)",
+		ACCUSATIVE = "коробку патронов (напалмовое дыхание дракона 12х70)",
+		INSTRUMENTAL = "коробкой патронов (напалмовое дыхание дракона 12х70)",
+		PREPOSITIONAL = "коробке патронов (напалмовое дыхание дракона 12х70)"
 	)
 
 /obj/item/ammo_box/shotgun/ion

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -839,10 +839,10 @@
 
 // this drum magazine uses for Buldog, Mastiff and AS-12 Minotaur shotguns
 /obj/item/ammo_box/magazine/m12g
-	name = "shotgun magazine (12g buckshot slugs)"
-	desc = "Барабанный магазин, предназначенный для патронов калибра 12х70."
+	name = "shotgun magazine (12g magnum buckshot)"
+	desc = "Барабанный магазин, предназначенный для картечных магнум патронов калибра 12х70."
 	icon_state = "m12gbc"
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot/nuclear
+	ammo_type = /obj/item/ammo_casing/shotgun/buckshot/magnum
 	caliber = ".12"
 	max_ammo = 12
 	multiple_sprites = 2
@@ -869,17 +869,17 @@
 
 /obj/item/ammo_box/magazine/cheap_m12g/get_ru_names()
 	return list(
-		NOMINATIVE = "барабанный магазин (кртечный 12х70)",
-		GENITIVE = "барабанного магазина (кртечный 12х70)",
-		DATIVE = "барабанному магазину (кртечный 12х70)",
-		ACCUSATIVE = "барабанный магазина (кртечный 12х70)",
-		INSTRUMENTAL = "барабанным магазином (кртечный 12х70)",
-		PREPOSITIONAL = "барабанном магазине (кртечный 12х70)"
+		NOMINATIVE = "барабанный магазин (картечный 12х70)",
+		GENITIVE = "барабанного магазина (картечный 12х70)",
+		DATIVE = "барабанному магазину (картечный 12х70)",
+		ACCUSATIVE = "барабанный магазина (картечный 12х70)",
+		INSTRUMENTAL = "барабанным магазином (картечный 12х70)",
+		PREPOSITIONAL = "барабанном магазине (картечный 12х70)"
 	)
 
 /obj/item/ammo_box/magazine/m12g/slug
 	name = "shotgun magazine (12g slugs)"
-	desc = "Барабанный магазин, предназначенный для различных патронов калибра 12х70."
+	desc = "Барабанный магазин, предназначенный для пулевых патронов калибра 12х70."
 	icon_state = "m12gb"
 	ammo_type = /obj/item/ammo_casing/shotgun
 
@@ -910,10 +910,10 @@
 	)
 
 /obj/item/ammo_box/magazine/m12g/dragon
-	name = "shotgun magazine (12g dragon's breath)"
-	desc = "Барабанный магазин, предназначенный для патронов \"Дыхание дракона\" калибра 12х70."
+	name = "shotgun magazine (12g napalm dragon's breath)"
+	desc = "Барабанный магазин, предназначенный для патронов \"напалмовое Дыхание дракона\" калибра 12х70."
 	icon_state = "m12gf"
-	ammo_type = /obj/item/ammo_casing/shotgun/incendiary/dragonsbreath/nuclear
+	ammo_type = /obj/item/ammo_casing/shotgun/incendiary/dragonsbreath/napalm
 
 /obj/item/ammo_box/magazine/m12g/dragon/get_ru_names()
 	return list(
@@ -975,10 +975,10 @@
 
 /obj/item/ammo_box/magazine/m12g/XtrLrg
 	name = "XL shotgun magazine (12g buckshot slugs)"
-	desc = "Увеличенный барабанный магазин, предназначенный для усиленных патронов калибра 12х70."
+	desc = "Увеличенный барабанный магазин, предназначенный для картечных магнум патронов калибра 12х70."
 	icon_state = "m12gXlBs"
 	w_class = WEIGHT_CLASS_NORMAL
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot/nuclear
+	ammo_type = /obj/item/ammo_casing/shotgun/buckshot/magnum
 	max_ammo = 24
 
 /obj/item/ammo_box/magazine/m12g/XtrLrg/get_ru_names()
@@ -1024,19 +1024,19 @@
 	)
 
 /obj/item/ammo_box/magazine/m12g/XtrLrg/dragon
-	name = "XL shotgun magazine (12g dragon's breath)"
-	desc = "Увеличенный барабанный магазин, предназначенный для патронов \"Дыхание дракона\" калибра 12х70."
+	name = "XL shotgun magazine (12g napalm dragon's breath)"
+	desc = "Увеличенный барабанный магазин, предназначенный для патронов \"напалмовое Дыхание дракона\" калибра 12х70."
 	icon_state = "m12gXlDb"
-	ammo_type = /obj/item/ammo_casing/shotgun/incendiary/dragonsbreath/nuclear
+	ammo_type = /obj/item/ammo_casing/shotgun/incendiary/dragonsbreath/napalm
 
 /obj/item/ammo_box/magazine/m12g/XtrLrg/dragon/get_ru_names()
 	return list(
-		NOMINATIVE = "увеличенный барабанный магазин (дыхание дракона 12х70)",
-		GENITIVE = "увеличенного барабанного магазина (дыхание дракона 12х70)",
-		DATIVE = "увеличенному барабанному магазину (дыхание дракона 12х70)",
-		ACCUSATIVE = "увеличенный барабанный магазин (дыхание дракона 12х70)",
-		INSTRUMENTAL = "увеличенным барабанным магазином (дыхание дракона 12х70)",
-		PREPOSITIONAL = "увеличенном барабанном магазине (дыхание дракона 12х70)"
+		NOMINATIVE = "увеличенный барабанный магазин (напалмовое дыхание дракона 12х70)",
+		GENITIVE = "увеличенного барабанного магазина (напалмовое дыхание дракона 12х70)",
+		DATIVE = "увеличенному барабанному магазину (напалмовое дыхание дракона 12х70)",
+		ACCUSATIVE = "увеличенный барабанный магазин (напалмовое дыхание дракона 12х70)",
+		INSTRUMENTAL = "увеличенным барабанным магазином (напалмовое дыхание дракона 12х70)",
+		PREPOSITIONAL = "увеличенном барабанном магазине (напалмовое дыхание дракона 12х70)"
 	)
 
 /obj/item/ammo_box/magazine/toy

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -187,9 +187,9 @@
 	tile_dropoff_s = 1.25
 	armour_penetration = -20
 
-/obj/projectile/bullet/pellet/nuclear
+/obj/projectile/bullet/pellet/magnum
 	damage = 15.5
-	tile_dropoff = 0
+	tile_dropoff = 0.4
 
 /obj/projectile/bullet/pellet/bioterror
 	damage = 9
@@ -344,6 +344,8 @@
 	if(location)
 		new /obj/effect/hotspot(location)
 		location.hotspot_expose(700, 50, 1)
+	if(prob(10))
+		do_sparks(1, TRUE, src)
 
 /obj/projectile/bullet/incendiary/shell/dragonsbreath
 	name = "dragonsbreath round"
@@ -355,10 +357,13 @@
 		INSTRUMENTAL = "пулей \"Дыхание дракона\"",
 		PREPOSITIONAL = "пуле \"Дыхание дракона\""
 	)
-	damage = 5
+	damage = 10
+	damage_type = BURN
+	range = 10
+	icon_state = "dragonbreath"
 
-/obj/projectile/bullet/incendiary/shell/dragonsbreath/nuclear
-	damage = 13.5
+/obj/projectile/bullet/incendiary/shell/dragonsbreath/napalm
+	damage = 14
 
 /obj/projectile/bullet/incendiary/shell/dragonsbreath/mecha
 	name = "liquidlava round"
@@ -371,6 +376,8 @@
 		PREPOSITIONAL = "пуле \"жидкая лава\""
 	)
 	damage = 20
+	damage_type = BRUTE
+	range = 50
 
 /obj/projectile/bullet/meteorshot
 	name = "meteor"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -357,7 +357,7 @@
 		INSTRUMENTAL = "пулей \"Дыхание дракона\"",
 		PREPOSITIONAL = "пуле \"Дыхание дракона\""
 	)
-	damage = 10
+	damage = 15
 	damage_type = BURN
 	range = 10
 	icon_state = "dragonbreath"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -842,6 +842,14 @@
 	build_path = /obj/item/ammo_casing/shotgun/buckshot
 	category = list("hacked", "Security")
 
+/datum/design/dragonsbreath
+	name = "Dragonsbreath shell"
+	id = "dragonsbreath_shell"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/incendiary/dragonsbreath
+	category = list("hacked", "Security")
+
 /datum/design/shotgun_dart
 	name = "Shotgun Dart"
 	id = "shotgun_dart"


### PR DESCRIPTION
## Что этот ПР делает

-Улучшены описания улучшенных патронов на дробовик у нюкеров для иммерсивности
-Удалены метеор слаги из аплинка нюкеров
-Магнум дробь нюкеров теперь обладает потерей урона в 0.4 за тайл(раньше было 0, у стандартной дроби это 0.75)
-Дыхание дракона "реворкнуто", теперь наносит урон бёрном, обновлены визуальные эффекты(стреляет искрами вместо пуль, в полёте пули с шансом искрят. Дальность полёта теперь ограничена 10 тайлами
-Удалён крафт патронов дыхание дракона, теперь они печатаются в автолате по цене обычной дроби
-Обычное дыхание дракона: 4 искринки по 15 урона(60)
-Напалмовое дыхание дракона нюкеров: 6 искринок по 14 урона(84)

## Почему это хорошо для игры

Теперь патроны нюкеров не волшебные а с лором
Теперь дыхание дракона ближе к реальной жизни
Теперь дыхание дракона вполне себе реально юзать против мажоров и оно выглядит красивее
Теперь нюкеры могут использовать дыхание дракона а не онли флашетты
Метеор слаги раковые и скучные, они лишние в аплинке

## Демонстрация изменений


https://github.com/user-attachments/assets/7b9eac40-c345-47d0-b80d-408075185b9c



## Тестирование

Да
