### PR TITLE
balance: изменения для слотов сб боргов

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -446,9 +446,9 @@
 			if(silicon.stat != DEAD && silicon.module && istype(silicon.module, /obj/item/robot_module/security))
 				count_secborgs++
 
-		var/max_secborgs = 2
-		if(SSsecurity_level.get_current_level_as_number() == SEC_LEVEL_GREEN)
-			max_secborgs = 1
+		var/max_secborgs = 1
+		if(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_GAMMA)
+			max_secborgs = 3
 
 		if(count_secborgs >= max_secborgs)
 			to_chat(robot, span_warning("There are too many Security cyborgs active. Please choose another module."))


### PR DESCRIPTION


## Что этот ПР делает

Теперь можно пикнуть только 1 СБ борга вплоть до гамма кода
Если гамма код = ГАММА или выше, можно пикнуть до трёх сб боргов

## Почему это хорошо для игры

СБ борги известны своей душностью, это литералли ходячая станпалка без каких-либо возможных интересных интеракций. + Два слота сбухи перманентно когда у нас и так по 12+ офиков на хайпопе, чет не очень весело. С этим изменения СБ боргов будет много тогда, когда они НУЖНЫ. Гамма код и выше.

## Демонстрация изменений

<img width="1582" height="816" alt="Screenshot_1" src="https://github.com/user-attachments/assets/230dd207-6955-405f-8113-9491fa0aa4bb" />
<img width="1383" height="848" alt="Screenshot_2" src="https://github.com/user-attachments/assets/210558d1-89cc-4608-86a3-0c09cf532eda" />


## Тестирование

Скрины приложил
