### PR TITLE
add: Режимы огня для WT-550

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -945,6 +945,9 @@
 #define COMSIG_LANG_PRE_ACT "check_language"
 	#define COMSIG_LANG_SECURED (1<<0)
 
+///from base of obj/gun/projectile/automatic/toggle_firemode(): (/mob/user, firemode)
+#define COMSIG_GUN_TOGGLE_FIREMODE "gun_firemode_toggle"
+
 /// Defib-specific signals
 
 /// Called when a defibrillator is first applied to someone. (mob/living/user, mob/living/target, harmful)

--- a/code/__DEFINES/gun.dm
+++ b/code/__DEFINES/gun.dm
@@ -32,3 +32,14 @@ GLOBAL_LIST_INIT(gun_module_slot_ru_name, list(
 	ATTACHMENT_SLOT_RAIL = "верхняя планка",
 	ATTACHMENT_SLOT_UNDER = "цевьё"
 ))
+
+/// Single shot firemode
+#define GUN_SINGLE_MODE 0
+/// Burst fire mode
+#define GUN_BURST_MODE 1
+/// Full auto friemode
+#define GUN_AUTO_MODE 2
+
+#define GUN_MODE_SINGLE_ONLY 1
+#define GUN_MODE_SINGLE_BURST 2
+#define GUN_MODE_SINGLE_BURST_AUTO 3

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -2,6 +2,7 @@
 #define AUTOFIRE_MOUSEDOWN 1
 
 /datum/component/automatic_fire
+	var/enable = TRUE
 	var/client/clicker
 	var/mob/living/shooter
 	var/atom/target
@@ -56,6 +57,8 @@
 
 
 /datum/component/automatic_fire/process(seconds_per_tick)
+	if(!enable)
+		return
 	if(autofire_stat != AUTOFIRE_STAT_FIRING)
 		STOP_PROCESSING(SSprojectiles, src)
 		return
@@ -126,6 +129,9 @@
 
 /datum/component/automatic_fire/proc/on_mouse_down(client/source, atom/_target, turf/location, control, params)
 	SIGNAL_HANDLER
+
+	if(!enable)
+		return
 
 	var/list/modifiers = params2list(params) //If they're shift+clicking, for example, let's not have them accidentally shoot.
 
@@ -204,6 +210,9 @@
 /datum/component/automatic_fire/proc/on_mouse_up(datum/source, atom/object, turf/location, control, params)
 	SIGNAL_HANDLER
 
+	if(!enable)
+		return
+
 	UnregisterSignal(clicker, COMSIG_CLIENT_MOUSEUP)
 	mouse_status = AUTOFIRE_MOUSEUP
 	if(autofire_stat == AUTOFIRE_STAT_FIRING)
@@ -232,6 +241,9 @@
 
 /datum/component/automatic_fire/proc/on_mouse_drag(client/source, atom/src_object, atom/over_object, turf/src_location, turf/over_location, src_control, over_control, params)
 	SIGNAL_HANDLER
+
+	if(!enable)
+		return
 
 	if(isnull(over_location)) //This happens when the mouse is over an inventory or screen object, or on entering deep darkness, for example.
 		var/list/modifiers = params2list(params)

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -38,6 +38,7 @@
 		return COMPONENT_INCOMPATIBLE
 	var/obj/item/gun = parent
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(wake_up))
+	RegisterSignal(parent, COMSIG_GUN_TOGGLE_FIREMODE, PROC_REF(toggle_firemode))
 	if(autofire_shot_delay)
 		src.autofire_shot_delay = autofire_shot_delay
 	src.allow_akimbo = allow_akimbo
@@ -76,6 +77,8 @@
 	if(user.is_in_hands(parent))
 		autofire_on(user.client)
 
+/datum/component/automatic_fire/proc/toggle_firemode(datum/source, mob/user, firemode)
+	enable = firemode == GUN_AUTO_MODE
 
 // There is a gun and there is a user wielding it. The component now waits for the mouse click.
 /datum/component/automatic_fire/proc/autofire_on(client/user_client)

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -1,16 +1,28 @@
-#define GPA_SINGLE_MODE 0
-#define GPA_BURST_MODE 1
-#define GPA_AUTO_MODE 2
-
 /obj/item/gun/projectile/automatic
 	w_class = WEIGHT_CLASS_NORMAL
 	var/alarmed = FALSE
-	var/select = 1
+	var/select = GUN_BURST_MODE
 	can_tactical = TRUE
 	can_holster = FALSE
 	burst_size = 3
 	fire_delay = 2
 	actions_types = list(/datum/action/item_action/toggle_firemode)
+	var/fire_modes = GUN_MODE_SINGLE_BURST
+	var/autofire_delay = 0.2 SECONDS
+
+/obj/item/gun/projectile/automatic/Initialize(mapload)
+	if(fire_modes == GUN_MODE_SINGLE_ONLY)
+		actions_types = null
+	. = ..()
+
+
+/obj/item/gun/projectile/automatic/ComponentInitialize()
+	. = ..()
+	if(fire_modes != GUN_MODE_SINGLE_BURST_AUTO)
+		return
+	select = GUN_AUTO_MODE
+	burst_size = 1
+	AddComponent(/datum/component/automatic_fire, autofire_delay)
 
 
 /obj/item/gun/projectile/automatic/update_icon_state()
@@ -19,10 +31,11 @@
 
 /obj/item/gun/projectile/automatic/update_overlays()
 	. = ..()
-	if(!select)
-		. += "[initial(icon_state)]semi"
-	if(select == 1)
-		. += "[initial(icon_state)]burst"
+	switch(select)
+		if(GUN_SINGLE_MODE)
+			. += "[initial(icon_state)]semi"
+		if(GUN_BURST_MODE)
+			. += "[initial(icon_state)]burst"
 
 
 /obj/item/gun/projectile/automatic/attackby(obj/item/I, mob/user, params)
@@ -55,32 +68,28 @@
 	. = ..()
 
 /obj/item/gun/projectile/automatic/proc/toggle_firemode()
+	if(fire_modes == GUN_MODE_SINGLE_ONLY)
+		return // not available change modes
 	var/mob/living/carbon/human/user = usr
-	var/datum/component/automatic_fire/full_auto_mode = GetComponent(/datum/component/automatic_fire)
-	var/available_modes = GPA_BURST_MODE + 1
-	if(full_auto_mode)
-		available_modes = GPA_AUTO_MODE + 1
-	select = (select + 1) % available_modes
+	select++
+	if(select >= fire_modes)
+		select = GUN_SINGLE_MODE
+	if(select == GUN_BURST_MODE && initial(burst_size) == 1)
+		select = GUN_AUTO_MODE //skip burst mode if not configured burst size
 	switch(select)
-		if(GPA_SINGLE_MODE)
+		if(GUN_SINGLE_MODE)
 			burst_size = 1
 			fire_delay = 0
 			balloon_alert(user, "полуавтомат")
-			if(full_auto_mode)
-				full_auto_mode.enable = FALSE
-		if(GPA_BURST_MODE)
+		if(GUN_BURST_MODE)
 			burst_size = initial(burst_size) == 1 ? 2 : initial(burst_size)
 			fire_delay = initial(fire_delay)
-			balloon_alert(user, "отсечка по [burst_size] [declension_ru(burst_size, "патрону",  "патрона",  "патронов")]")
-			if(full_auto_mode)
-				full_auto_mode.enable = FALSE
-		if(GPA_AUTO_MODE)
-			burst_size = initial(burst_size)
+			balloon_alert(user, "отсечка по [burst_size] [declension_ru(burst_size, "патрону", "патрона", "патронов")]")
+		if(GUN_AUTO_MODE)
+			burst_size = 1
 			fire_delay = initial(fire_delay)
 			balloon_alert(user, "автоматический")
-			if(full_auto_mode)
-				full_auto_mode.enable = TRUE
-
+	SEND_SIGNAL(src, COMSIG_GUN_TOGGLE_FIREMODE, user, select)
 	playsound(user, 'sound/weapons/gun_interactions/selector.ogg', 100, TRUE)
 	update_icon()
 	for(var/X in actions)
@@ -166,7 +175,7 @@
 	magin_sound = 'sound/weapons/gun_interactions/batrifle_magin.ogg'
 	magout_sound = 'sound/weapons/gun_interactions/batrifle_magout.ogg'
 	fire_delay = 2
-	burst_size = 1
+	burst_size = 2
 	can_bayonet = TRUE
 	bayonet_x_offset = 25
 	bayonet_y_offset = 12
@@ -179,12 +188,8 @@
 	)
 	recoil = GUN_RECOIL_MEDIUM
 	weapon_weight = WEAPON_HEAVY
-
-/obj/item/gun/projectile/automatic/wt550/ComponentInitialize()
-	AddComponent( \
-		/datum/component/automatic_fire, \
-		 0.2 SECONDS \
-		 )
+	fire_modes = GUN_MODE_SINGLE_BURST_AUTO
+	autofire_delay = 0.2 SECONDS
 
 /obj/item/gun/projectile/automatic/wt550/update_icon_state()
 	icon_state = "wt550[magazine ? "-[CEILING(get_ammo(FALSE)/6, 1)*6]" : ""]"
@@ -201,10 +206,9 @@
 	magin_sound = 'sound/weapons/gun_interactions/batrifle_magin.ogg'
 	magout_sound = 'sound/weapons/gun_interactions/batrifle_magout.ogg'
 	fire_delay = 2
-	burst_size = 1
+	burst_size = 3
 	can_bayonet = FALSE
 	accuracy = new /datum/gun_accuracy/rifle/extend_spread()
-	actions_types = null
 	attachable_allowed = GUN_MODULE_CLASS_RIFLE_MUZZLE | GUN_MODULE_CLASS_RIFLE_RAIL | GUN_MODULE_CLASS_RIFLE_UNDER
 	attachable_offset = list(
 		ATTACHMENT_SLOT_MUZZLE = list("x" = 19, "y" = 3),
@@ -213,12 +217,8 @@
 	)
 	recoil = GUN_RECOIL_MEDIUM
 	weapon_weight = WEAPON_HEAVY
-
-/obj/item/gun/projectile/automatic/sp91rc/ComponentInitialize()
-	AddComponent( \
-		/datum/component/automatic_fire, \
-		 0.2 SECONDS \
-		 )
+	fire_modes = GUN_MODE_SINGLE_BURST_AUTO
+	autofire_delay = 0.2 SECONDS
 
 /obj/item/gun/projectile/automatic/sp91rc/update_icon_state()
 	icon_state = "SP-91-RC[magazine ? "-[CEILING(get_ammo(FALSE)/5, 1)*5]" : ""]"
@@ -238,7 +238,7 @@ TODO Use this name and desc for localisation*/
 	origin_tech = "combat=4;materials=2;syndicate=4"
 	mag_type = /obj/item/ammo_box/magazine/uzim9mm
 	fire_sound = 'sound/weapons/gunshots/1uzi.ogg'
-	burst_size = 1
+	burst_size = 3
 	attachable_allowed = GUN_MODULE_CLASS_PISTOL_MUZZLE | GUN_MODULE_CLASS_PISTOL_RAIL
 	attachable_offset = list(
 		ATTACHMENT_SLOT_MUZZLE = list("x" = 14, "y" = 7),
@@ -246,13 +246,8 @@ TODO Use this name and desc for localisation*/
 	)
 	accuracy = GUN_ACCURACY_PISTOL
 	recoil = GUN_RECOIL_LOW
-	actions_types = null
-
-/obj/item/gun/projectile/automatic/mini_uzi/ComponentInitialize()
-	AddComponent( \
-		/datum/component/automatic_fire, \
-		 0.2 SECONDS \
-		 )
+	fire_modes = GUN_MODE_SINGLE_BURST_AUTO
+	autofire_delay = 0.2 SECONDS
 
 
 //M-90gl Carbine//
@@ -317,22 +312,22 @@ TODO Use this name and desc for localisation*/
 	if(magazine)
 		. += image(icon = icon, icon_state = "m90-[CEILING(get_ammo(FALSE)/6, 1)*6]")
 	switch(select)
-		if(0)
+		if(GUN_SINGLE_MODE)
 			. += "[initial(icon_state)]gren"
-		if(1)
+		if(GUN_BURST_MODE)
 			.  += "[initial(icon_state)]burst"
 
 
 /obj/item/gun/projectile/automatic/m90/toggle_firemode()
 	var/mob/living/carbon/human/user = usr
 	switch(select)
-		if(0)
-			select = 1
+		if(GUN_SINGLE_MODE)
+			select = GUN_BURST_MODE
 			burst_size = initial(burst_size)
 			fire_delay = initial(fire_delay)
 			balloon_alert(user, "отсечка по [burst_size] [declension_ru(burst_size, "патрону",  "патрона",  "патронов")]")
-		if(1)
-			select = 0
+		if(GUN_BURST_MODE)
+			select = GUN_SINGLE_MODE
 			balloon_alert(user, "подствольный гранатомёт")
 	playsound(user, 'sound/weapons/gun_interactions/selector.ogg', 100, TRUE)
 	update_icon()
@@ -419,7 +414,6 @@ TODO Use this name and desc for localisation*/
 	can_suppress = 0
 	burst_size = 1
 	fire_delay = 0
-	actions_types = null
 	accuracy = GUN_ACCURACY_SHOTGUN
 	attachable_allowed = GUN_MODULE_CLASS_SHOTGUN_MUZZLE | GUN_MODULE_CLASS_SHOTGUN_RAIL | GUN_MODULE_CLASS_SHOTGUN_UNDER
 	attachable_offset = list(
@@ -428,6 +422,7 @@ TODO Use this name and desc for localisation*/
 		ATTACHMENT_SLOT_UNDER = list("x" = 10, "y" = -6)
 	)
 	recoil = GUN_RECOIL_HIGH
+	fire_modes = GUN_MODE_SINGLE_ONLY
 
 
 /obj/item/gun/projectile/automatic/shotgun/bulldog/mastiff
@@ -495,6 +490,7 @@ TODO Use this name and desc for localisation*/
 		ATTACHMENT_SLOT_UNDER = list("x" = 7, "y" = -5)
 	)
 	recoil = GUN_RECOIL_HIGH
+	fire_modes = GUN_MODE_SINGLE_BURST
 
 /obj/item/gun/projectile/automatic/shotgun/minotaur/New()
 	magazine = new/obj/item/ammo_box/magazine/m12g/XtrLrg
@@ -524,6 +520,7 @@ TODO Use this name and desc for localisation*/
 		ATTACHMENT_SLOT_RAIL = list("x" = 6, "y" = 6)
 	)
 	recoil = GUN_RECOIL_HIGH
+	fire_modes = GUN_MODE_SINGLE_BURST
 
 
 /obj/item/gun/projectile/automatic/cats/update_icon_state()
@@ -576,7 +573,6 @@ TODO Use this name and desc for localisation*/
 	magout_sound = 'sound/weapons/gun_interactions/batrifle_magout.ogg'
 	can_suppress = 0
 	burst_size = 1
-	actions_types = null
 	accuracy = GUN_ACCURACY_RIFLE_LASER
 	attachable_allowed = GUN_MODULE_CLASS_RIFLE_RAIL | GUN_MODULE_CLASS_RIFLE_UNDER
 	attachable_offset = list(
@@ -584,6 +580,7 @@ TODO Use this name and desc for localisation*/
 		ATTACHMENT_SLOT_UNDER = list("x" = 10, "y" = -2)
 	)
 	recoil = GUN_RECOIL_MIN
+	fire_modes = GUN_MODE_SINGLE_ONLY
 
 /obj/item/gun/projectile/automatic/lr30/update_icon_state()
 	icon_state = "lr30[magazine ? "-[CEILING(get_ammo(FALSE)/4, 1)*4]" : ""]"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -1,3 +1,7 @@
+#define GPA_SINGLE_MODE 0
+#define GPA_BURST_MODE 1
+#define GPA_AUTO_MODE 2
+
 /obj/item/gun/projectile/automatic
 	w_class = WEIGHT_CLASS_NORMAL
 	var/alarmed = FALSE
@@ -46,21 +50,36 @@
 
 /obj/item/gun/projectile/automatic/ui_action_click(mob/user, datum/action/action, leftclick)
 	if(istype(action, /datum/action/item_action/toggle_firemode))
-		burst_select()
+		toggle_firemode()
 		return TRUE
 	. = ..()
 
-/obj/item/gun/projectile/automatic/proc/burst_select()
+/obj/item/gun/projectile/automatic/proc/toggle_firemode()
 	var/mob/living/carbon/human/user = usr
-	select = !select
-	if(!select)
-		burst_size = 1
-		fire_delay = 0
-		balloon_alert(user, "полуавтомат")
-	else
-		burst_size = initial(burst_size)
-		fire_delay = initial(fire_delay)
-		balloon_alert(user, "отсечка по [burst_size] [declension_ru(burst_size, "патрону",  "патрона",  "патронов")]")
+	var/datum/component/automatic_fire/full_auto_mode = GetComponent(/datum/component/automatic_fire)
+	var/available_modes = GPA_BURST_MODE + 1
+	if(full_auto_mode)
+		available_modes = GPA_AUTO_MODE + 1
+	select = (select + 1) % available_modes
+	switch(select)
+		if(GPA_SINGLE_MODE)
+			burst_size = 1
+			fire_delay = 0
+			balloon_alert(user, "полуавтомат")
+			if(full_auto_mode)
+				full_auto_mode.enable = FALSE
+		if(GPA_BURST_MODE)
+			burst_size = initial(burst_size) == 1 ? 2 : initial(burst_size)
+			fire_delay = initial(fire_delay)
+			balloon_alert(user, "отсечка по [burst_size] [declension_ru(burst_size, "патрону",  "патрона",  "патронов")]")
+			if(full_auto_mode)
+				full_auto_mode.enable = FALSE
+		if(GPA_AUTO_MODE)
+			burst_size = initial(burst_size)
+			fire_delay = initial(fire_delay)
+			balloon_alert(user, "автоматический")
+			if(full_auto_mode)
+				full_auto_mode.enable = TRUE
 
 	playsound(user, 'sound/weapons/gun_interactions/selector.ogg', 100, TRUE)
 	update_icon()
@@ -152,7 +171,6 @@
 	bayonet_x_offset = 25
 	bayonet_y_offset = 12
 	accuracy = new /datum/gun_accuracy/rifle/extend_spread()
-	actions_types = null
 	attachable_allowed = GUN_MODULE_CLASS_RIFLE_MUZZLE | GUN_MODULE_CLASS_RIFLE_RAIL | GUN_MODULE_CLASS_RIFLE_UNDER
 	attachable_offset = list(
 		ATTACHMENT_SLOT_MUZZLE = list("x" = 20, "y" = 1),
@@ -305,7 +323,7 @@ TODO Use this name and desc for localisation*/
 			.  += "[initial(icon_state)]burst"
 
 
-/obj/item/gun/projectile/automatic/m90/burst_select()
+/obj/item/gun/projectile/automatic/m90/toggle_firemode()
 	var/mob/living/carbon/human/user = usr
 	switch(select)
 		if(0)

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -45,6 +45,8 @@
 	actions_types = null
 	accuracy = GUN_ACCURACY_MINIMAL
 	attachable_allowed = GUN_MODULE_CLASS_NONE
+	fire_modes = GUN_MODE_SINGLE_ONLY
+
 
 
 /obj/item/gun/projectile/automatic/gyropistol/process_chamber(eject_casing = 0, empty_chamber = 1)
@@ -72,6 +74,7 @@
 	accuracy = GUN_ACCURACY_DEFAULT
 	attachable_allowed = GUN_MODULE_CLASS_NONE
 	recoil = null
+	fire_modes = GUN_MODE_SINGLE_ONLY
 
 
 /obj/item/gun/projectile/automatic/speargun/update_icon_state()

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -12,7 +12,6 @@
 	magout_sound = 'sound/weapons/gun_interactions/pistol_magout.ogg'
 	burst_size = 1
 	fire_delay = 0
-	actions_types = null
 	accuracy = GUN_ACCURACY_PISTOL_UPLINK
 	recoil = GUN_RECOIL_LOW
 	attachable_allowed = GUN_MODULE_CLASS_PISTOL_MUZZLE | GUN_MODULE_CLASS_PISTOL_RAIL
@@ -20,6 +19,7 @@
 		ATTACHMENT_SLOT_MUZZLE = list("x" = 16, "y" = 3),
 		ATTACHMENT_SLOT_RAIL = list("x" = 1, "y" = 7)
 	)
+	fire_modes = GUN_MODE_SINGLE_ONLY
 
 
 /obj/item/gun/projectile/automatic/pistol/update_icon_state()
@@ -258,7 +258,6 @@
 	mag_type = /obj/item/ammo_box/magazine/pistolm9mm
 	burst_size = 3
 	fire_delay = 2
-	actions_types = list(/datum/action/item_action/toggle_firemode)
 	accuracy = GUN_ACCURACY_PISTOL_UPLINK
 	recoil = GUN_RECOIL_MEDIUM
 	attachable_allowed = GUN_MODULE_CLASS_PISTOL_MUZZLE | GUN_MODULE_CLASS_PISTOL_RAIL
@@ -266,3 +265,4 @@
 		ATTACHMENT_SLOT_MUZZLE = list("x" = 18, "y" = 5),
 		ATTACHMENT_SLOT_RAIL = list("x" = 3, "y" = 8)
 	)
+	fire_modes = GUN_MODE_SINGLE_BURST_AUTO

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -13,8 +13,7 @@
 	magout_sound = 'sound/weapons/gun_interactions/lmg_magout.ogg'
 	var/cover_open = 0
 	fire_delay = 1
-	burst_size = 1
-	actions_types = null
+	burst_size = 3
 	accuracy = GUN_ACCURACY_RIFLE
 	recoil = GUN_RECOIL_HIGH
 	attachable_allowed = GUN_MODULE_CLASS_RIFLE_MUZZLE | GUN_MODULE_CLASS_RIFLE_RAIL | GUN_MODULE_CLASS_RIFLE_UNDER
@@ -23,12 +22,8 @@
 		ATTACHMENT_SLOT_RAIL = list("x" = 1, "y" = 7),
 		ATTACHMENT_SLOT_UNDER = list("x" = 7, "y" = -7)
 	)
-
-/obj/item/gun/projectile/automatic/l6_saw/ComponentInitialize()
-	AddComponent( \
-		/datum/component/automatic_fire, \
-		 0.2 SECONDS \
-		 )
+	fire_modes = GUN_MODE_SINGLE_BURST_AUTO
+	autofire_delay = 0.2 SECONDS
 
 /obj/item/gun/projectile/automatic/l6_saw/attack_self(mob/user)
 	cover_open = !cover_open

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -20,6 +20,7 @@
 	accuracy = GUN_ACCURACY_SNIPER
 	attachable_allowed = GUN_MODULE_CLASS_NONE
 	recoil = GUN_RECOIL_MEGA
+	fire_modes = GUN_MODE_SINGLE_ONLY
 
 /obj/item/gun/projectile/automatic/sniper_rifle/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/gun_module/muzzle/suppressor))

--- a/code/modules/projectiles/guns/projectile/toy.dm
+++ b/code/modules/projectiles/guns/projectile/toy.dm
@@ -29,6 +29,7 @@
 	fire_delay = 0
 	actions_types = null
 	accuracy = GUN_ACCURACY_PISTOL
+	fire_modes = GUN_MODE_SINGLE_ONLY
 
 
 /obj/item/gun/projectile/automatic/toy/pistol/update_icon_state()


### PR DESCRIPTION
## Что этот ПР делает
Вернул кнопку режимов стрельбы для втшки. Три режима стрельбы: одиночный, очередь 2 патрона и полностью автоматический.

Отрефакторил чутка режимы стрельбы, теперь у `/gun/projectile/automatic` есть поля `fire_modes` и `autofire_delay` для настройки режимов стрельбы. Компонент автоогня автоматически добавляется если в поле настройки режимов указать данный режим.

## Почему это хорошо для игры
Зюзя попросил.

## Тестирование
Локалка
