### PR TITLE
qol: Уменьшение громкости топанья берц и звука сирен от одежды

### DIFF
--- a/code/datums/components/jackboots.dm
+++ b/code/datums/components/jackboots.dm
@@ -30,4 +30,4 @@
 		var/mob/M = parent
 		if(M.stat == DEAD)
 			return
-	playsound(parent, pickweight(step_sounds), 50, TRUE, 0, falloff_exponent = sound_falloff_exponent)
+	playsound(parent, pickweight(step_sounds), 20, TRUE, 0, falloff_exponent = sound_falloff_exponent)

--- a/code/datums/looping_sounds/item_sounds.dm
+++ b/code/datums/looping_sounds/item_sounds.dm
@@ -5,7 +5,9 @@
 
 /datum/looping_sound/ambulance_alarm/justice
 	mid_length = 1.5 SECONDS
+	falloff_distance = 4
 	falloff_exponent = 4
+	volume = 40
 
 /datum/looping_sound/chainsaw
 	start_sound = list('sound/weapons/chainsaw_start.ogg')

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -44,6 +44,7 @@
 	var/toggle_on_message
 	var/toggle_off_message
 	var/active_sound
+	var/active_sound_volume = 100
 	var/toggle_sound
 	var/toggle_cooldown = 0
 	var/cooldown = 0
@@ -592,7 +593,7 @@ BLIND     // can't see anything
 	set waitfor = FALSE
 
 	while(up)
-		playsound(loc, active_sound, 100, FALSE, 4)
+		playsound(loc, active_sound, active_sound_volume, FALSE, 4)
 		sleep(1.5 SECONDS)
 
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -152,6 +152,7 @@
 	can_toggle = TRUE
 	toggle_cooldown = 20
 	active_sound = 'sound/items/weeoo1.ogg'
+	active_sound_volume = 50
 	dog_fashion = null
 
 /obj/item/clothing/head/helmet/justice/escape


### PR DESCRIPTION
## Что этот ПР делает
Уменьшение громкости топота в jackboots с 50% до 20%.
Уменьшение громкости звука сирены от сумки и шлема 40% и 50%.

## Почему это хорошо для игры
Громкость звука топота берц в игре кринж, тупо минус уши. Поэтому все (*ну почти все*) офицеры цепляют изоленту чтобы тупо не оглохнуть. Даем возможность игрокам аутентично топать ерцами по техам без потери слуха.
Ну и сирены заодно.


## Тестирование
Локалка, звук стал заметно тише.
