### PR TITLE
fix map: замена noop на space в submape old_sm

### DIFF
--- a/_maps/map_files/Delta/submaps/old_sm_room.dmm
+++ b/_maps/map_files/Delta/submaps/old_sm_room.dmm
@@ -791,7 +791,7 @@
 /area/template_noop)
 "qP" = (
 /obj/structure/lattice/catwalk,
-/turf/template_noop,
+/turf/space,
 /area/template_noop)
 "rq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1073,7 +1073,7 @@
 /obj/structure/marker_beacon{
 	icon_state = "markerburgundy-on"
 	},
-/turf/template_noop,
+/turf/space,
 /area/template_noop)
 "xP" = (
 /obj/structure/barricade/wooden,
@@ -1241,7 +1241,7 @@
 /area/template_noop)
 "Ej" = (
 /obj/structure/lattice,
-/turf/template_noop,
+/turf/space,
 /area/template_noop)
 "Ew" = (
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION


закомпилил

на карте было изменено всего 5-7турфов за одно действие. Фикс необходим был чтобы убрать появление стен, перед воротами в версии сабмапы "подпилодская"