### PR TITLE
bugfix: У культа ратвара снова светятся руки

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -678,7 +678,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		if(blood_DNA || clock_hands)
 			var/mutable_appearance/standing = mutable_appearance(layer = -GLOVES_LAYER, appearance_flags = KEEP_TOGETHER)
 			if(clock_hands)
-				standing.overlays += mutable_appearance(dna.species.blood_mask, "clockedhands")
+				standing.overlays += mutable_appearance(dna.species.blood_mask, "clockedhands", color = COLOR_LIGHT_ORANGE)
 			else if(blood_DNA)
 				standing.overlays += mutable_appearance(dna.species.blood_mask, "bloodyhands", color = blood_color)
 


### PR DESCRIPTION
<!-- **ВАЖНО!!!** Если Ваш ПР содержит много .dmi файлов, которые могут создать излишнюю нагрузку на IconDiffBot2, тогда добавьте в название ПРа тэг [IDB IGNORE] -->
<!-- Например, "Добавил 1kk новых спрайтов [IDB IGNORE]" -->

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- Список тегов для ПРа:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map Вы меняете только карту.
- local Вы делаете добавляете новый текст на русском или переводите на русский.
- imageadd:  Вы добавили новый спрайт.
- imagedel:  Вы удалили старый спрайт.
- soundadd: Вы добавили новый звук.
- sounddel: Вы удалили старый звук.
- spellcheck: Вы исправили опечатку.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает
При выполнении целей у ратвара должны визуально начинать светиться руки, но кто-то забыл указать цвет для оверлея
<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2 или issue в репозитории. В ином случае, опишите баг и ступени для его воспроизведения. -->

## Демонстрация изменений
<img width="75" height="86" alt="image" src="https://github.com/user-attachments/assets/a0d4dfda-73a5-4b5b-88fb-29a181f64b70" />

<!-- Заполните, если Вы меняли спрайты, карту или ваши изменения требуют визуальной демонстрации изменений. -->
