### PR TITLE
balance: Добавление knockdown при передозе кофе с 5 процентным шансом

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -707,13 +707,17 @@
 		K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount)
 	return K
 
+
 /mob/living/proc/unbuckle_if_not_cuffed()
 	if(!buckled)
 		return
+
 	var/mob/living/carbon/carbon = src
 	if(!istype(carbon) || carbon.handcuffed)
 		return
+
 	buckled.unbuckle_mob(src, force = TRUE)
+
 
 // MARK: IMMOBILIZED
 

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -707,6 +707,14 @@
 		K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount)
 	return K
 
+/mob/living/proc/unbuckle_if_not_cuffed()
+	if(!buckled)
+		return
+	var/mob/living/carbon/carbon = src
+	if(!istype(carbon) || carbon.handcuffed)
+		return
+	buckled.unbuckle_mob(src, force = TRUE)
+
 // MARK: IMMOBILIZED
 
 /mob/living/proc/IsImmobilized()

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -310,10 +310,9 @@
 /datum/reagent/consumable/drink/coffee/overdose_process(mob/living/target, severity)
 	if(volume > 45)
 		target.Jitter(10 SECONDS)
-	if(volume > 50)
-		if(prob(10)) //10% to knockdown
-			target.unbuckle_if_not_cuffed()
-			target.Knockdown(2 SECONDS)
+	if(volume > 50 && prob(10)) //10% to knockdown
+		target.unbuckle_if_not_cuffed()
+		target.Knockdown(2 SECONDS)
 	return list(0, STATUS_UPDATE_NONE)
 
 /datum/reagent/consumable/drink/coffee/icecoffee

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -307,9 +307,13 @@
 		holder.remove_reagent("frostoil", 5)
 	return ..() | update_flags
 
-/datum/reagent/consumable/drink/coffee/overdose_process(mob/living/M, severity)
+/datum/reagent/consumable/drink/coffee/overdose_process(mob/living/target, severity)
 	if(volume > 45)
-		M.Jitter(10 SECONDS)
+		target.Jitter(10 SECONDS)
+	if(volume > 50)
+		if(prob(10)) //10% to knockdown
+			target.unbuckle_if_not_cuffed()
+			target.Knockdown(2 SECONDS)
 	return list(0, STATUS_UPDATE_NONE)
 
 /datum/reagent/consumable/drink/coffee/icecoffee

--- a/code/modules/vehicle/wheelchair.dm
+++ b/code/modules/vehicle/wheelchair.dm
@@ -31,6 +31,7 @@
 	chair_overlay = mutable_appearance(icon, "wheelchair_overlay", ABOVE_MOB_LAYER)
 	update_icon(UPDATE_OVERLAYS)
 	bell_action = new /datum/action/innate/wheelchair/bell(callback = CALLBACK(src, PROC_REF(on_bell_action)))
+	// wheelchair can not give speed bonus
 
 /obj/vehicle/ridden/wheelchair/Destroy()
 	chair_overlay = null


### PR DESCRIPTION
## Что этот ПР делает
Если в крови больше 50 юнитов кофе будет 5% шанс на кнокдаун. Если сидит на стуле и не связан наручами - упадет со стула тоже (*фикс чтобы не абузили через инвалидную коляску*).


## Почему это хорошо для игры
Убиваем мету заливания кофе в вены при тенях. Да и 100 юнитов кофе это пиздец.

## Тестирование
Локалка
