### PR TITLE
del: Временно отключает втыкание ножей через дизарм пока пельмень не сделает нормально

### DIFF
--- a/code/datums/components/stick_it_in.dm
+++ b/code/datums/components/stick_it_in.dm
@@ -1,9 +1,11 @@
+// DO NOT USE: not exists armor check!
+
 /datum/component/stick_it_in
 
 /datum/component/stick_it_in/Initialize(...)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
-	
+
 /datum/component/stick_it_in/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK, PROC_REF(HarmAct))
 
@@ -22,6 +24,6 @@
 	if(!(prob(40) || isthrowingmatart(target_human?.mind?.martial_art)))
 		return NONE
 	target_human.embed_item_inside(parent, user.zone_selected)
-	
+
 	return COMPONENT_CANCEL_ATTACK_CHAIN
-	
+

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -241,8 +241,9 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	if(!move_resist)
 		determine_move_resist()
 
-	if(embed_disarm)
-		AddComponent(/datum/component/stick_it_in)
+	// temp disable reason: pelmen
+	//if(embed_disarm)
+		//AddComponent(/datum/component/stick_it_in)
 
 	add_eatable_component()
 	scatter_item()


### PR DESCRIPTION
## Что этот ПР делает
Просто убирает компонент втыкания ножей через дизарм.

## Почему это хорошо для игры
Втыкание ножей сырые, неизвестно почему попали в игру в таком виде.
1. Можно втыкать через любую броню.
2. Можно втыкать после грина.
3. Доставание застравшего предмета сломано.
4. Шансы на втыкание тупо 40% на всех ножах.


## Тестирование
Локалка