### PR TITLE
add: Снаряжание магазинов по одному патрону с коробок и с пола

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -94,33 +94,38 @@
 	return ..()
 
 
-/obj/item/ammo_casing/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/ammo_box) && can_be_box_inserted)
-		add_fingerprint(user)
-		var/obj/item/ammo_box/box = I
-		if(!isturf(loc))
-			to_chat(user, span_warning("Вы можете собирать гильзы только с пола."))
-			return ATTACK_CHAIN_PROCEED
+/obj/item/ammo_casing/attackby(obj/item/item, mob/user, params)
+	if(!istype(item, /obj/item/ammo_box) || !can_be_box_inserted)
+		return ..()
+	add_fingerprint(user)
+	var/obj/item/ammo_box/box = item
+	if(!isturf(loc))
+		to_chat(user, span_warning("Вы можете собирать гильзы только с пола."))
+		return ATTACK_CHAIN_PROCEED
+	if(length(box.stored_ammo) >= box.max_ammo)
+		to_chat(user, span_warning("[box.declent_ru(NOMINATIVE)] переполнена."))
+		return ATTACK_CHAIN_PROCEED
+	var/boolets = 0
+	for(var/obj/item/ammo_casing/bullet in loc)
 		if(length(box.stored_ammo) >= box.max_ammo)
-			to_chat(user, span_warning("[box.declent_ru(NOMINATIVE)] переполнена."))
-			return ATTACK_CHAIN_PROCEED
-		var/boolets = 0
-		for(var/obj/item/ammo_casing/bullet in loc)
-			if(length(box.stored_ammo) >= box.max_ammo)
+			break
+		if(!bullet.BB)
+			continue
+		if(!box.can_fast_load)
+			playsound(box, box.insert_sound, 50, TRUE)
+			if(!do_after(user, box.bullet_load_duration, box, max_interact_count = 1))
 				break
-			if(!bullet.BB)
-				continue
-			if(box.give_round(bullet, FALSE))
-				boolets++
-		if(!boolets)
-			to_chat(user, span_warning("Вам не удалось ничего собрать."))
-			return ATTACK_CHAIN_PROCEED
-		box.update_appearance(UPDATE_ICON|UPDATE_DESC)
-		to_chat(user, span_notice("Вы собрали [boolets] гильз[declension_ru(boolets,"у","ы","")]. Теперь в [box.declent_ru(GENITIVE)] [length(box.stored_ammo)] гильз[declension_ru(length(box.stored_ammo),"а","ы","")]."))
+			box.update_appearance(UPDATE_ICON|UPDATE_DESC)
+		if(box.give_round(bullet, FALSE))
+			boolets++
+	if(!boolets)
+		to_chat(user, span_warning("Вам не удалось ничего собрать."))
+		return ATTACK_CHAIN_PROCEED
+	box.update_appearance(UPDATE_ICON|UPDATE_DESC)
+	to_chat(user, span_notice("Вы собрали [boolets] гильз[declension_ru(boolets,"у","ы","")]. Теперь в [box.declent_ru(GENITIVE)] [length(box.stored_ammo)] гильз[declension_ru(length(box.stored_ammo),"а","ы","")]."))
+	if(box.can_fast_load)
 		playsound(src, 'sound/weapons/gun_interactions/bulletinsert.ogg', 50, TRUE)
-		return ATTACK_CHAIN_PROCEED_SUCCESS
-
-	return ..()
+	return ATTACK_CHAIN_PROCEED_SUCCESS
 
 
 /obj/item/ammo_casing/screwdriver_act(mob/living/user, obj/item/I)
@@ -193,6 +198,10 @@
 	var/remove_sound = 'sound/weapons/gun_interactions/remove_bullet.ogg'
 	var/insert_sound = 'sound/weapons/gun_interactions/bulletinsert.ogg'
 	var/load_sound = 'sound/weapons/gun_interactions/shotguninsert.ogg'
+	/// Reload ammo box without progress bar
+	var/can_fast_load = TRUE
+	/// One bullet load duration
+	var/bullet_load_duration = 0.4 SECONDS
 
 
 /obj/item/ammo_box/Initialize(mapload)
@@ -296,6 +305,16 @@
 	if(ammo_box)
 		var/obj/item/ammo_box/box = I
 		for(var/obj/item/ammo_casing/casing in box.stored_ammo)
+			if(!can_fast_load)
+				playsound(src, insert_sound, 50, TRUE)
+				if(!do_after(user, bullet_load_duration, src, DA_IGNORE_USER_LOC_CHANGE, max_interact_count = 1))
+					break
+				box.update_appearance()
+				box.update_equipped_item()
+				update_appearance()
+				update_equipped_item()
+				if(!user.Adjacent(src))
+					break
 			var/did_load = give_round(casing, replace_spent, count_chambered, user)
 			if(did_load)
 				box.stored_ammo -= casing

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -103,7 +103,7 @@
 		balloon_alert(user, "не получилось собрать")
 		return ATTACK_CHAIN_PROCEED
 	if(length(box.stored_ammo) >= box.max_ammo)
-		balloon_alert(user, "уже полный")
+		balloon_alert(user, "магазин заполнен")
 		return ATTACK_CHAIN_PROCEED
 	var/boolets = 0
 	for(var/obj/item/ammo_casing/bullet in loc)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -103,7 +103,7 @@
 		balloon_alert(user, "не получилось собрать")
 		return ATTACK_CHAIN_PROCEED
 	if(length(box.stored_ammo) >= box.max_ammo)
-		balloon_alert(user, "магазин заполнен")
+		balloon_alert(user, "уже заполнено")
 		return ATTACK_CHAIN_PROCEED
 	var/boolets = 0
 	for(var/obj/item/ammo_casing/bullet in loc)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -100,10 +100,10 @@
 	add_fingerprint(user)
 	var/obj/item/ammo_box/box = item
 	if(!isturf(loc))
-		to_chat(user, span_warning("Вы можете собирать гильзы только с пола."))
+		balloon_alert(user, "не получилось собрать")
 		return ATTACK_CHAIN_PROCEED
 	if(length(box.stored_ammo) >= box.max_ammo)
-		to_chat(user, span_warning("[box.declent_ru(NOMINATIVE)] переполнена."))
+		balloon_alert(user, "уже полный")
 		return ATTACK_CHAIN_PROCEED
 	var/boolets = 0
 	for(var/obj/item/ammo_casing/bullet in loc)
@@ -119,7 +119,7 @@
 		if(box.give_round(bullet, FALSE))
 			boolets++
 	if(!boolets)
-		to_chat(user, span_warning("Вам не удалось ничего собрать."))
+		balloon_alert(user, "не получилось собрать")
 		return ATTACK_CHAIN_PROCEED
 	box.update_appearance(UPDATE_ICON|UPDATE_DESC)
 	to_chat(user, span_notice("Вы собрали [boolets] гильз[declension_ru(boolets,"у","ы","")]. Теперь в [box.declent_ru(GENITIVE)] [length(box.stored_ammo)] гильз[declension_ru(length(box.stored_ammo),"а","ы","")]."))

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -1,6 +1,7 @@
 // MARK: Internal magazines
 /obj/item/ammo_box/magazine/internal
 	desc = "Oh god, this shouldn't be here!"
+	can_fast_load = TRUE
 
 
 //internals magazines are accessible, so replace spent ammo if full when trying to put a live one in
@@ -260,6 +261,7 @@
 // MARK: External magazines
 /obj/item/ammo_box/magazine
 	materials = list(MAT_METAL = 2000)
+	can_fast_load = FALSE
 
 /obj/item/ammo_box/magazine/m10mm
 	name = "pistol magazine (10mm)"


### PR DESCRIPTION
## Что этот ПР делает
Каждый патрон занимет 0.4 секунды для добавления в магазин.
Работает при ударе коробкой по магазину и ударом магазина по патронам на полу.

## Почему это хорошо для игры
1. Удаляем мету таскания коробок с патронами для быстрой перезарядки и мешков с пульками
2. Увеличиваем важность магаинов в игре.

## Демонстрация изменений
На демонстрации 0.3 секунды, в пре уже 0.4 секунды

https://github.com/user-attachments/assets/382fb02c-bab4-453c-a323-a60378354c66

## Тестирование
Локалка.
