### PR TITLE
bugfix: возвращает звуки зарядки магазинов, убирает накладывания звуков дропа и поднятия предметов при перезарядках

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -90,7 +90,7 @@
 
 
 /obj/item/gun/projectile/proc/reload(obj/item/ammo_box/magazine/new_magazine, mob/user)
-	if(user && magazine.loc == user && !user.drop_transfer_item_to_loc(new_magazine, src))
+	if(user && magazine.loc == user && !user.drop_transfer_item_to_loc(new_magazine, src, silent = TRUE))
 		return FALSE
 	. = TRUE
 	magazine = new_magazine
@@ -135,7 +135,7 @@
 	var/obj/item/ammo_casing/AC = chambered //Find chambered round
 	if(magazine)
 		magazine.forceMove(drop_location())
-		user.put_in_hands(magazine)
+		user.put_in_hands(magazine, silent = TRUE)
 		magazine.update_appearance()
 		magazine = null
 		update_weight()

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -45,11 +45,12 @@
 		if(!istype(new_magazine, mag_type))
 			balloon_alert(user, "не совместимо!")
 			return ATTACK_CHAIN_PROCEED
-		if(!user.drop_transfer_item_to_loc(new_magazine, src))
+		if(!user.drop_transfer_item_to_loc(new_magazine, src, silent = TRUE))
 			return ..()
 		if(magazine)
 			magazine.forceMove(get_turf(src))
 			magazine.update_appearance()
+		playsound(loc, magin_sound, 50, TRUE)
 		balloon_alert(user, "заряжено")
 		alarmed = FALSE	// Reset the alarm once a magazine is loaded
 		magazine = new_magazine

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -54,7 +54,7 @@
 		//drop the mag
 		magazine.update_appearance(UPDATE_ICON | UPDATE_DESC)
 		magazine.forceMove(drop_location())
-		user.put_in_hands(magazine)
+		user.put_in_hands(magazine, silent = TRUE)
 		magazine = null
 		playsound(src, magout_sound, 50, TRUE)
 		update_icon()


### PR DESCRIPTION

## Что этот ПР делает

Теперь слышно звуки вставляения магазинов, а не звук бумажки, теперь звуки дроп и поднятия не накладываются на звуки перезарядки 

## Почему это хорошо для игры

Лучше слышать звуки перезарядки чем звуки бумажек?


## Демонстрация изменений


https://github.com/user-attachments/assets/6350c090-be96-4cd9-a0f0-20931d4dbea7



## Тестирование

Да
