### PR TITLE
balance: Воскрешающее прикосновение дьявола не воскрешает тех кто продал свою душу

### DIFF
--- a/code/datums/spells/devil_boons.dm
+++ b/code/datums/spells/devil_boons.dm
@@ -169,7 +169,7 @@
 
 	var/mob/living/mob = target
 
-	if(mob.stat != DEAD || !target.mind.is_revivable())
+	if(mob.stat != DEAD || !(mob.mind.is_revivable()))
 		return .
 
 	mob.revive()

--- a/code/datums/spells/devil_boons.dm
+++ b/code/datums/spells/devil_boons.dm
@@ -169,7 +169,7 @@
 
 	var/mob/living/mob = target
 
-	if(mob.stat != DEAD)
+	if(mob.stat != DEAD || !target.mind.is_revivable())
 		return .
 
 	mob.revive()


### PR DESCRIPTION
## Что этот ПР делает

То что написано

## Почему это хорошо для игры

Продажа души дьяволу обозначает финал игры. Ни один способ реанимации не должен работать на тех, кто решил продать свою душу.

## Тестирование
 Эшель сказал так работать будет
