### PR TITLE
balance: Дали возможность стрелять SP-91 с одной руки

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -217,7 +217,6 @@
 		ATTACHMENT_SLOT_UNDER = list("x" = 8, "y" = -5)
 	)
 	recoil = GUN_RECOIL_MEDIUM
-	weapon_weight = WEAPON_HEAVY
 	fire_modes = GUN_MODE_SINGLE_BURST_AUTO
 	autofire_delay = 0.2 SECONDS
 


### PR DESCRIPTION
## Что этот ПР делает

Убирает необходимость в второй руке для стрельбы с *компактного* пистолета-пулемета

## Почему это хорошо для игры

После серьезного улучшения WT-550 и добавления необходимости в второй руке для "горохострела" он стал никому не нужен. С добавлением случайной оружейной у офицеров забрали выбор, SP-91 во всем хуже WT-550, но банальный бафф характеристик сделал бы эти два оружия очень похожими, что плохо для геймдизайна. Поэтому добавляем пушке свою нишу и делаем их разными.

## Демонстрация изменений



## Тестирование

Зашли на локалку, постреляли с одной руки одним. Постреляли с двух рук с двух , но попали мало.
