### PR TITLE
bugfix: Исправление спрайта магазина SP-91-RC

### DIFF
--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -540,7 +540,7 @@
 	)
 
 /obj/item/ammo_box/magazine/sp91rc/update_icon_state()
-	icon_state = "9mm-te-[round(ammo_count(),5)]"
+	icon_state = "[initial(icon_state)]-[round(ammo_count(), 5)]"
 
 /obj/item/ammo_box/magazine/uzim9mm
 	name = "uzi magazine (9mm)"


### PR DESCRIPTION
## Что этот ПР делает

Исправление `icon_state` у магазина от SP-91-RC (*горохострел в прошлом*).

[Багрепорт](https://discord.com/channels/617003227182792704/1418203396791468064/1418203396791468064)

## Почему это хорошо для игры
Баги плохо, багфиксы - хорошо.

## Тестирование
Запустил на локалке, взял шпик и достал магазин, магазин видно, пощелкал поразряжал пульки, все пять состояний спрайтов меняются корректно.
