### PR TITLE
bugfix: Абдукторский Мультиметр имел неправильный путь к иконке

### DIFF
--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -178,7 +178,6 @@
 	name = "alien multimeter"
 	desc = "Прибор из неизвестного сплава с голографическим интерфейсом. Похоже, что он  предназначен для измерения показателей электрических объектов."
 	icon = 'icons/obj/abductor.dmi'
-	icon_state = "multitool"
 	toolspeed = 0.1
 	origin_tech = "magnets=5;engineering=5;abductor=3"
 	shows_wire_information = TRUE

--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -178,8 +178,7 @@
 	name = "alien multimeter"
 	desc = "Прибор из неизвестного сплава с голографическим интерфейсом. Похоже, что он  предназначен для измерения показателей электрических объектов."
 	icon = 'icons/obj/abductor.dmi'
-	icon_state = "alien_multitool"
-	belt_icon = "alien_multitool"
+	icon_state = "multitool"
 	toolspeed = 0.1
 	origin_tech = "magnets=5;engineering=5;abductor=3"
 	shows_wire_information = TRUE


### PR DESCRIPTION

## Что этот ПР делает

Исправляет баг абдукторского мультитула

У него не было белт иконки. в файлах называется просто мультитул.

## Почему это хорошо для игры

Исправляет баг

## Демонстрация изменений

<img width="264" height="48" alt="изображение" src="https://github.com/user-attachments/assets/bf9c2b46-9500-4f01-931d-2ba3a32108ed" />

## Тестирование

Посмотрел правильные названия в иконках
