### PR TITLE
balance/bugfix: худы прячут глаза

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -3,6 +3,7 @@
 	desc = "A heads-up display that provides important info in (almost) real time."
 	origin_tech = "magnets=3;biotech=2"
 	prescription_upgradable = TRUE
+	flags_cover = parent_type::flags_cover|GLASSESCOVERSEYES
 	/// The visual icons granted by wearing these glasses.
 	var/HUDType = null
 


### PR DESCRIPTION
## Что этот ПР делает

Очки-худы прячут глаза.
Что это за собой влечет: глаза не просвечивают сквозь худы https://discord.com/channels/617003227182792704/1421618531694411898/1421618531694411898
Глаза защищены от лукового сока, бумажного самолетика, песка, вонзание вещей в глаза и фонарика

Хотел сделать умнее, но такая обработка требовала нового дефайна, и большого количества операций с вычитанием иконок, что показалось излишним для механики сияния глаз

## Почему это хорошо для игры

Нет кривого отображения сияния глаз над худами

## Тестирование

Да
