### PR TITLE
tweak: Гравитация делает Knockdown вместо урона стамине

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -240,7 +240,7 @@
 		return
 
 	to_chat(src, span_userdanger("Gravity exhausts you!"))
-	apply_damage(35, STAMINA)
+	Knockdown(1 SECONDS)
 
 
 /mob/living/carbon/human/slip(weaken, obj/slipped_on, lube_flags, tilesSlipped)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -239,7 +239,7 @@
 	if(m_intent != MOVE_INTENT_RUN)
 		return
 
-	to_chat(src, span_userdanger("Gravity exhausts you!"))
+	to_chat(src, span_userdanger("Гравитация впечатывает вас в пол!"))
 	Knockdown(1 SECONDS)
 
 


### PR DESCRIPTION
## Что этот ПР делает

Заменяет урон стамине, при входе в тайл с гравитацией из тайла без нее, на 1 секунду кнокдауна, переводит сообщение о падении от гравитации

## Почему это хорошо для игры

Текущая гравитация планировалась как безобидный стамино урон но в итоге из за выталкивающей куклу атмосферы любит делать мгновенный стаминокрит. В таком виде эффект от гравитации все еще ощутим, но не заставляет лежать и смирно смотреть как тебя расстреливают из дробовика в упор

## Тестирование

Протестировано на локалке
