### PR TITLE
server: New auto comment blocks extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,14 @@
 {
-    "recommendations": [
-        "gbasood.byond-dm-language-support",
+	"recommendations": [
+		"gbasood.byond-dm-language-support",
 		"platymuus.dm-langclient",
-		"editorconfig.editorconfig",
+		"EditorConfig.EditorConfig",
 		"dbaeumer.vscode-eslint",
 		"anturk.dmi-editor",
 		"eamodio.gitlens",
 		"oderwat.indent-rainbow",
 		"esbenp.prettier-vscode",
-		"stylemistake.auto-comment-blocks"
-    ]
+		"kevinkyang.auto-comment-blocks",
+		"arcanis.vscode-zipfs"
+	]
 }


### PR DESCRIPTION
## Что этот ПР делает
Старое расширение на авто-комментирование было удалено из VSC, заменил на полный аналог `kevinkyang.auto-comment-blocks`. Также прописал `arcanis.vscode-zipfs`.
Малютки больше не страдают?