### PR TITLE
bugfix: Убирает дюп стаков ресурсов

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -352,13 +352,13 @@
 /obj/item/stack/proc/change_stack(mob/user, amount)
 	var/obj/item/stack/material = new type(user, amount, FALSE)
 	. = material
+	use(amount)
 	material.copy_evidences(src)
 	if(!user.put_in_hands(material, merge_stacks = FALSE))
 		material.forceMove(user.drop_location())
 	add_fingerprint(user)
 	material.add_fingerprint(user)
 	do_pickup_animation(user)
-	use(amount)
 	SStgui.update_uis(src)
 
 /**


### PR DESCRIPTION
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

<!-- Вы можете совмещать до 2-х тэгов, например, balance/tweak:
Список возможных тэгов для пр-а:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map: Вы меняете только карту.
- image: Вы добавляете/удаляете спрайты.
- sound: Вы добавляете/удаляете звуки.
- spellcheck: Вы исправили опечатку.
- local: Вы добавляете новый текст на русском или переводите на русский.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает
[Репорт](https://discord.com/channels/617003227182792704/1424346040399564850)
Если с обеими занятыми руками брать лежащий под собой стак ресурса в количестве 1, то он дюпался из-за того что forceMove происходил раньше, чем тратился старый стак
<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2. В ином случае, опишите баг и его воспроизведение. -->

## Тестирование
Проверял на локалке, остальное поведение стаков вроде не изменилось
<!-- Как Вы тестировали свои изменения? Ведь тестировали? -->
