### PR TITLE
bugfix: Исправлено отображение имени морфа на скринтипе при мимикрии

### DIFF
--- a/code/datums/spells/mimic.dm
+++ b/code/datums/spells/mimic.dm
@@ -121,7 +121,7 @@
 
 /obj/effect/proc_holder/spell/mimic/proc/take_form(datum/mimic_form/form, mob/user)
 	var/old_name = "[user]"
-	user_ru_names = user.ru_names
+	user_ru_names = user.get_ru_names_cached() || user.ru_names
 	if(ishuman(user))
 		// Not fully finished yet
 		var/mob/living/carbon/human/H = user
@@ -226,11 +226,11 @@
 	examine_time = form.get_examine_time()
 	appearance = form.appearance
 	name = form.name
-	form_ru_names = form.get_ru_names() || form.ru_names
+	form_ru_names = form.get_ru_names_cached() || form.ru_names
 	// if no ru_names found, we just fill it with default name
 	if(!length(form_ru_names))
 		form_ru_names = new /list(6)
-		for(var/name in form_ru_names)
+		for(var/name in NOMINATIVE to PREPOSITIONAL)
 			form_ru_names[name] = form.declent_ru(name)
 	if(isliving(form))
 		var/mob/living/form_living = form

--- a/code/datums/spells/mimic.dm
+++ b/code/datums/spells/mimic.dm
@@ -19,6 +19,8 @@
 	var/next_override_index = 1
 	/// If a message is shown when somebody examines the user from close range
 	var/perfect_disguise = FALSE
+	/// Var to store user ru_names to restore them later when they stop mimicking
+	var/user_ru_names
 
 	var/static/list/black_listed_form_types = list(
 		/atom/movable/screen,
@@ -119,11 +121,13 @@
 
 /obj/effect/proc_holder/spell/mimic/proc/take_form(datum/mimic_form/form, mob/user)
 	var/old_name = "[user]"
+	user_ru_names = user.ru_names
 	if(ishuman(user))
 		// Not fully finished yet
 		var/mob/living/carbon/human/H = user
 		H.name_override = form.name
 	else
+		user.ru_names = form.form_ru_names
 		user.appearance = form.appearance
 		user.transform = initial(user.transform)
 		user.pixel_y = initial(user.pixel_y)
@@ -162,6 +166,10 @@
 		user.name = initial(user.name)
 		user.desc = initial(user.desc)
 		user.color = initial(user.color)
+		if(length(user_ru_names))
+			user.ru_names = user_ru_names
+		else
+			user.ru_names = null
 
 	playsound(user, SFX_BONEBREAK, 150, TRUE)
 	if(show_message)
@@ -208,6 +216,8 @@
 	var/appearance
 	/// What the name of the form is?
 	var/name
+	/// What the ru names of the form is?
+	var/list/form_ru_names
 
 
 /datum/mimic_form/New(atom/movable/form, mob/user)
@@ -216,6 +226,12 @@
 	examine_time = form.get_examine_time()
 	appearance = form.appearance
 	name = form.name
+	form_ru_names = form.get_ru_names() || form.ru_names
+	// if no ru_names found, we just fill it with default name
+	if(!length(form_ru_names))
+		form_ru_names = new /list(6)
+		for(var/name in form_ru_names)
+			form_ru_names[name] = form.declent_ru(name)
 	if(isliving(form))
 		var/mob/living/form_living = form
 		examine_species = form_living.get_visible_species()

--- a/code/datums/spells/mimic.dm
+++ b/code/datums/spells/mimic.dm
@@ -121,7 +121,7 @@
 
 /obj/effect/proc_holder/spell/mimic/proc/take_form(datum/mimic_form/form, mob/user)
 	var/old_name = "[user]"
-	user_ru_names = user.get_ru_names_cached() || user.ru_names
+	user_ru_names = user.ru_names
 	if(ishuman(user))
 		// Not fully finished yet
 		var/mob/living/carbon/human/H = user
@@ -226,7 +226,7 @@
 	examine_time = form.get_examine_time()
 	appearance = form.appearance
 	name = form.name
-	form_ru_names = form.get_ru_names_cached() || form.ru_names
+	form_ru_names = form.ru_names || form.get_ru_names_cached()
 	// if no ru_names found, we just fill it with default name
 	if(!length(form_ru_names))
 		form_ru_names = new /list(6)

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -57,6 +57,8 @@
 	var/obj/effect/proc_holder/spell/morph_spell/ambush/ambush_spell
 	/// The spell the morph uses to pass through airlocks
 	var/obj/effect/proc_holder/spell/morph_spell/pass_airlock/pass_airlock_spell
+	/// The spell the morph uses to open vent when crawling in them
+	var/obj/effect/proc_holder/spell/morph_spell/open_vent/open_vent_spell
 
 	/// How much the morph has gathered in terms of food. Used to reproduce and such
 	var/gathered_food = 20 // Start with a bit to use abilities
@@ -89,11 +91,24 @@
 	AddSpell(mimic_spell)
 	ambush_spell = new
 	AddSpell(ambush_spell)
-	AddSpell(new /obj/effect/proc_holder/spell/morph_spell/open_vent)
+	open_vent_spell = new
+	AddSpell(open_vent_spell)
 	pass_airlock_spell = new
 	AddSpell(pass_airlock_spell)
 	GLOB.morphs_alive_list += src
 	check_morphs()
+
+/mob/living/simple_animal/hostile/morph/Destroy()
+	RemoveSpell(mimic_spell)
+	mimic_spell = null
+	RemoveSpell(ambush_spell)
+	ambush_spell = null
+	RemoveSpell(open_vent_spell)
+	open_vent_spell = null
+	RemoveSpell(pass_airlock_spell)
+	pass_airlock_spell = null
+	return ..()
+
 
 /mob/living/simple_animal/hostile/morph/ComponentInitialize()
 	AddComponent( \


### PR DESCRIPTION
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

<!-- Вы можете совмещать до 2-х тэгов, например, balance/tweak:
Список возможных тэгов для пр-а:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map: Вы меняете только карту.
- image: Вы добавляете/удаляете спрайты.
- sound: Вы добавляете/удаляете звуки.
- spellcheck: Вы исправили опечатку.
- local: Вы добавляете новый текст на русском или переводите на русский.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает
Скринтип использует деклент для отображения имени объекта, так как у морфа есть рунеймы, при мимикрии всегда отображалось "морф"
<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2. В ином случае, опишите баг и его воспроизведение. -->

## Тестирование
Проверил на локалке на карпе кои с рунеймами, на mouse без рунеймов, на человеке, всё работает
<!-- Как Вы тестировали свои изменения? Ведь тестировали? -->
