### PR TITLE
refactor: Beacons are no longer radios + init sanity unit test

### DIFF
--- a/_maps/map_files/Delta/Lavaland.dmm
+++ b/_maps/map_files/Delta/Lavaland.dmm
@@ -5921,7 +5921,7 @@
 	},
 /area/mine/laborcamp)
 "FQ" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -828,7 +828,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/effect/landmark/spawner/blob,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -4894,7 +4894,7 @@
 	},
 /area/hallway/secondary/entry/eastarrival)
 "aMn" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aMp" = (
@@ -48348,7 +48348,7 @@
 	},
 /area/crew_quarters/theatre)
 "fZm" = (
-/obj/item/radio/beacon/engine/tesling,
+/obj/item/beacon/engine/tesling,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "fZE" = (
@@ -64997,7 +64997,7 @@
 /area/crew_quarters/captain)
 "jXE" = (
 /obj/effect/decal/warning_stripes/west,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "jXH" = (
@@ -84589,7 +84589,7 @@
 	},
 /area/hallway/primary/central/south)
 "oFK" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/camera{
 	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
 	c_tag = "Research Toxins Test Chamber East";
@@ -85608,7 +85608,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -86043,7 +86043,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "oWK" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -97069,7 +97069,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -104583,7 +104583,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -111391,7 +111391,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "uEX" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -428,7 +428,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/powered/beach)
 "uA" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/beach/sand,
 /area/ruin/powered/beach)
 "uP" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandonedtele.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandonedtele.dmm
@@ -68,7 +68,7 @@
 /area/AIsattele)
 "q" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plating/airless,
 /area/AIsattele)
 "r" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -1064,7 +1064,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/item/radio/beacon{
+/obj/item/beacon{
 	emagged = 1
 	},
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -249,7 +249,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/ruin/powered/space_bar)
 "bt" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/ruin/powered/space_bar)
 "dw" = (

--- a/_maps/map_files/celestation/Lavaland.dmm
+++ b/_maps/map_files/celestation/Lavaland.dmm
@@ -4327,7 +4327,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/effect/baseturf_helper/lava_land/surface,
 /obj/structure/cable{
 	icon_state = "1-8"

--- a/_maps/map_files/celestation/celestation.dmm
+++ b/_maps/map_files/celestation/celestation.dmm
@@ -11865,7 +11865,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -20649,7 +20649,7 @@
 	},
 /area/bridge/meeting_room)
 "cMp" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -56577,7 +56577,7 @@
 	},
 /area/toxins/hallway)
 "jwo" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/camera{
 	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
@@ -97817,7 +97817,7 @@
 "ryB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -126283,7 +126283,7 @@
 "wVS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
 "wVW" = (

--- a/_maps/map_files/celestation/celestation.dmm
+++ b/_maps/map_files/celestation/celestation.dmm
@@ -80343,7 +80343,7 @@
 	},
 /area/teleporter/research)
 "ohb" = (
-/obj/item/book/random/triple,
+/obj/item/book/random,
 /turf/simulated/floor/grass,
 /area/crew_quarters/locker)
 "ohh" = (

--- a/_maps/map_files/cerestation/Lavaland.dmm
+++ b/_maps/map_files/cerestation/Lavaland.dmm
@@ -1637,7 +1637,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/mine/lobby)
 "gK" = (

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -7506,7 +7506,7 @@
 "bhm" = (
 /obj/structure/table,
 /obj/item/hand_tele,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
@@ -31631,7 +31631,7 @@
 /area/crew_quarters/bar)
 "fkO" = (
 /obj/effect/landmark/lightsout,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -46123,7 +46123,7 @@
 	},
 /area/hallway/secondary/exit)
 "jwo" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/camera{
 	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
@@ -78559,7 +78559,7 @@
 	},
 /area/storage/primary)
 "sCV" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -89506,7 +89506,7 @@
 /turf/simulated/floor/grass,
 /area/mine/unexplored/cere/orbiting)
 "vRR" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},

--- a/_maps/map_files/coldcolony/Lavaland.dmm
+++ b/_maps/map_files/coldcolony/Lavaland.dmm
@@ -300,7 +300,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "em" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -19053,7 +19053,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/effect/landmark/marauder_entry,
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -33132,7 +33132,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "cqZ" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -51427,7 +51427,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/north)
 "eZD" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
 "eZH" = (
@@ -61805,7 +61805,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/disposal)
 "jUp" = (
-/obj/item/radio/beacon/engine/tesling,
+/obj/item/beacon/engine/tesling,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "jUI" = (
@@ -62428,7 +62428,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/engineering/hardsuitstorage)
 "kix" = (
@@ -77015,7 +77015,7 @@
 /turf/simulated/floor/carpet,
 /area/ntrep)
 "qJB" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/camera{
 	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
@@ -78814,7 +78814,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -83845,7 +83845,7 @@
 	pixel_x = -27
 	},
 /obj/structure/table,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32

--- a/_maps/map_files/de_kerberos_2/de_kerberos_2.dmm
+++ b/_maps/map_files/de_kerberos_2/de_kerberos_2.dmm
@@ -867,7 +867,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/effect/landmark/spawner/blob,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -5012,7 +5012,7 @@
 	},
 /area/hallway/secondary/entry/eastarrival)
 "aMn" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aMp" = (
@@ -49179,7 +49179,7 @@
 	},
 /area/crew_quarters/theatre)
 "fZm" = (
-/obj/item/radio/beacon/engine/tesling,
+/obj/item/beacon/engine/tesling,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "fZE" = (
@@ -66373,7 +66373,7 @@
 /area/crew_quarters/captain)
 "jXE" = (
 /obj/effect/decal/warning_stripes/west,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "jXH" = (
@@ -86565,7 +86565,7 @@
 	},
 /area/hallway/primary/central/south)
 "oFK" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/camera{
 	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
 	c_tag = "Research Toxins Test Chamber East";
@@ -87601,7 +87601,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -88069,7 +88069,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "oWK" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -99486,7 +99486,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -107317,7 +107317,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -114312,7 +114312,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/structure/barricade/sandbags,
 /turf/simulated/floor/plasteel,
 /area/security/main)

--- a/_maps/map_files/event/Station/coldcolony.dmm
+++ b/_maps/map_files/event/Station/coldcolony.dmm
@@ -6956,7 +6956,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/coldcolony/malta/quartermaster/ore_production)
 "cym" = (
@@ -29122,7 +29122,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel/white,
 /area/coldcolony/malta/medical/sleeper)
 "kBE" = (
@@ -34079,7 +34079,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -42835,7 +42835,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -51033,7 +51033,7 @@
 /turf/simulated/floor/plating,
 /area/coldcolony/malta/maintenance/servicegen)
 "sAT" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/wood/fancy/light,
 /area/coldcolony/malta/bridge/hop)
 "sBl" = (

--- a/_maps/map_files/event/Station/delta_old.dmm
+++ b/_maps/map_files/event/Station/delta_old.dmm
@@ -411,7 +411,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/effect/landmark/spawner/blob,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -4269,7 +4269,7 @@
 	},
 /area/hallway/secondary/entry/eastarrival)
 "aMn" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aMp" = (
@@ -48138,7 +48138,7 @@
 	},
 /area/assembly/robotics)
 "fZm" = (
-/obj/item/radio/beacon/engine/tesling,
+/obj/item/beacon/engine/tesling,
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "fZr" = (
@@ -66147,7 +66147,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -67448,7 +67448,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -70534,7 +70534,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/warning_stripes/south,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "mkS" = (
@@ -79583,7 +79583,7 @@
 	},
 /area/hallway/primary/central/south)
 "oFK" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/camera{
 	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50);
 	c_tag = "Research Toxins Test Chamber East";
@@ -84473,7 +84473,7 @@
 	},
 /area/security/securehallway)
 "pQd" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -90182,7 +90182,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -96667,7 +96667,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -102136,7 +102136,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	dir = 1
 	},

--- a/_maps/map_files/event/Station/towerstation.dmm
+++ b/_maps/map_files/event/Station/towerstation.dmm
@@ -2607,8 +2607,8 @@
 "bKs" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/delivery,
-/obj/item/radio/beacon,
-/obj/item/radio/beacon,
+/obj/item/beacon,
+/obj/item/beacon,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -24
@@ -2863,7 +2863,7 @@
 	},
 /area/maintenance/auxsolarstarboard)
 "bQr" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/glass/reinforced,
 /area/crew_quarters/bar/atrium)
 "bQI" = (
@@ -6993,7 +6993,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -7329,7 +7329,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -7856,7 +7856,7 @@
 /turf/simulated/floor/wood,
 /area/bridge)
 "fmn" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/camera{
 	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
 	c_tag = "Research Toxins Test Chamber East";
@@ -11822,7 +11822,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/wood,
 /area/library)
 "hEh" = (
@@ -11917,7 +11917,7 @@
 /turf/simulated/floor/engine/co2,
 /area/atmos)
 "hHo" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/glass/reinforced,
 /area/engineering/break_room)
 "hHC" = (
@@ -12441,7 +12441,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "hXJ" = (
@@ -13683,7 +13683,7 @@
 /turf/simulated/floor/plating/airless,
 /area/toxins/test_area)
 "iMJ" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -15910,7 +15910,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -16974,7 +16974,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/medical/research)
 "kXl" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/primary/starboard)
 "kXS" = (
@@ -18574,7 +18574,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -18664,7 +18664,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -19629,7 +19629,7 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/dorms)
 "mDm" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/glass/reinforced,
 /area/medical/medbay)
 "mEs" = (
@@ -22064,7 +22064,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "ohA" = (
@@ -25550,7 +25550,7 @@
 	},
 /area/bridge)
 "quM" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/glass/reinforced,
 /area/medical/research)
 "qva" = (
@@ -28530,7 +28530,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "stS" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkgreenfull"
@@ -33044,7 +33044,7 @@
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "vlJ" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/glass/reinforced,
 /area/crew_quarters/dorms)
 "vlM" = (
@@ -34638,7 +34638,7 @@
 	},
 /area/crew_quarters/dorms)
 "wkb" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/secondary/entry)
 "wkN" = (
@@ -37365,7 +37365,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard)
 "xNX" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central)

--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -13853,7 +13853,7 @@
 	info = "<center><img src=\"https://cdn.discordapp.com/attachments/961279768249118750/1046826506741104830/unknown.png?width=604&height=604\"></center>";
 	name = "Супъективное мнение"
 	},
-/obj/item/book/random/triple,
+/obj/item/book/random,
 /turf/simulated/floor/plating,
 /area/centcom/zone2)
 "gAB" = (
@@ -22196,7 +22196,7 @@
 /area/centcom/supply)
 "kHS" = (
 /obj/structure/bookcase,
-/obj/item/book/random/triple,
+/obj/item/book/random,
 /turf/simulated/floor/plating,
 /area/centcom/zone2)
 "kHT" = (

--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -33429,11 +33429,11 @@
 /obj/item/grenade/syndieminibomb{
 	pixel_x = 8
 	},
-/obj/item/radio/beacon/syndicate/bomb{
+/obj/item/beacon/syndicate/bomb{
 	pixel_x = -5;
 	pixel_y = 12
 	},
-/obj/item/radio/beacon/syndicate/bomb{
+/obj/item/beacon/syndicate/bomb{
 	pixel_x = -5;
 	pixel_y = 12
 	},
@@ -34294,13 +34294,13 @@
 /area/syndicate_mothership/cargo)
 "pUu" = (
 /obj/structure/table/wood,
-/obj/item/radio/beacon/syndicate/bomb{
+/obj/item/beacon/syndicate/bomb{
 	pixel_y = 8
 	},
-/obj/item/radio/beacon/syndicate/bomb{
+/obj/item/beacon/syndicate/bomb{
 	pixel_y = 4
 	},
-/obj/item/radio/beacon/syndicate/bomb,
+/obj/item/beacon/syndicate/bomb,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -717,7 +717,7 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
 "bP" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purplecorner"

--- a/_maps/map_files/generic/z2_old.dmm
+++ b/_maps/map_files/generic/z2_old.dmm
@@ -3625,13 +3625,13 @@
 /area/centcom/bridge)
 "daV" = (
 /obj/structure/table/reinforced,
-/obj/item/radio/beacon/syndicate/bomb{
+/obj/item/beacon/syndicate/bomb{
 	pixel_y = 8
 	},
-/obj/item/radio/beacon/syndicate/bomb{
+/obj/item/beacon/syndicate/bomb{
 	pixel_y = 4
 	},
-/obj/item/radio/beacon/syndicate/bomb,
+/obj/item/beacon/syndicate/bomb,
 /obj/item/grenade/syndieminibomb{
 	pixel_x = 4;
 	pixel_y = 2

--- a/_maps/map_files/nova/Lavaland.dmm
+++ b/_maps/map_files/nova/Lavaland.dmm
@@ -8346,7 +8346,7 @@
 /turf/simulated/floor/indestructible/boss,
 /area/mine/necropolis)
 "WJ" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/hologram/holopad,
 /obj/effect/baseturf_helper/lava_land/surface,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{

--- a/_maps/map_files/nova/nova.dmm
+++ b/_maps/map_files/nova/nova.dmm
@@ -5070,7 +5070,7 @@
 	},
 /area/hallway/primary/central/north)
 "aMu" = (
-/obj/item/radio/beacon/engine/tesling,
+/obj/item/beacon/engine/tesling,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "aMv" = (
@@ -7901,7 +7901,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -22942,7 +22942,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/landmark/lightsout,
@@ -32567,7 +32567,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/maintenance/starboardaux)
 "eKG" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/camera{
 	armor = list("melee"=50,"bullet"=20,"laser"=20,"energy"=20,"bomb"=100,"bio"=0,"rad"=0,"fire"=90,"acid"=50);
@@ -51891,7 +51891,7 @@
 	},
 /area/toxins/xenobiology)
 "hDD" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -72386,7 +72386,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -85067,7 +85067,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -91389,7 +91389,7 @@
 	dir = 6
 	},
 /obj/effect/landmark/spawner/blob,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -116337,7 +116337,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -128831,7 +128831,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -138102,7 +138102,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/box,
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -144954,7 +144954,7 @@
 	},
 /area/crew_quarters/toilet)
 "vnb" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -162000,7 +162000,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	dir = 1
 	},

--- a/_maps/map_files/templates/medium_shuttle1.dmm
+++ b/_maps/map_files/templates/medium_shuttle1.dmm
@@ -239,7 +239,7 @@
 	},
 /area/ruin/powered/shuttle)
 "S" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark";
 	tag = "icon-dark"

--- a/_maps/map_files/templates/medium_shuttle2.dmm
+++ b/_maps/map_files/templates/medium_shuttle2.dmm
@@ -152,7 +152,7 @@
 	},
 /area/ruin/powered/shuttle)
 "G" = (
-/obj/item/radio/beacon,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark";
 	tag = "icon-dark"

--- a/code/datums/rituals.dm
+++ b/code/datums/rituals.dm
@@ -283,7 +283,7 @@
 
 	var/list/destinations = list()
 
-	for(var/obj/item/beacon/beacon in GLOB.global_radios)
+	for(var/obj/item/beacon/beacon in GLOB.beacons)
 		LAZYADD(destinations, get_turf(beacon))
 
 	human.forceMove(safepick(destinations))

--- a/code/datums/rituals.dm
+++ b/code/datums/rituals.dm
@@ -283,7 +283,7 @@
 
 	var/list/destinations = list()
 
-	for(var/obj/item/beacon/beacon in GLOB.beacons)
+	for(var/obj/item/beacon/beacon as anything in GLOB.beacons)
 		LAZYADD(destinations, get_turf(beacon))
 
 	human.forceMove(safepick(destinations))

--- a/code/datums/rituals.dm
+++ b/code/datums/rituals.dm
@@ -283,7 +283,7 @@
 
 	var/list/destinations = list()
 
-	for(var/obj/item/radio/beacon/beacon in GLOB.global_radios)
+	for(var/obj/item/beacon/beacon in GLOB.global_radios)
 		LAZYADD(destinations, get_turf(beacon))
 
 	human.forceMove(safepick(destinations))

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1460,7 +1460,7 @@
 			который телепортирует бомбу к вам при активации. Бомбу можно прикрутить к полу гаечным ключом. После того как таймер будет запущен, \
 			она начнёт издавать громкий звук, который будет усиливаться по мере приближения взрыва. Если бомбу обнаружат вовремя, её можно будет обезвредить. \
 			Взрыв нанесёт серьёзный ущерб окружению."
-	item = /obj/item/radio/beacon/syndicate/bomb
+	item = /obj/item/beacon/syndicate/bomb
 	cost = 40
 	surplus = 0
 	can_discount = FALSE
@@ -1479,7 +1479,7 @@
 			который телепортирует бомбу к вам при активации. Бомбу можно прикрутить к полу гаечным ключом. После того как таймер будет запущен, \
 			она начнёт издавать громкий звук, который будет усиливаться по мере приближения взрыва. Если бомбу обнаружат вовремя, её можно будет обезвредить. \
 			На 2-3 минуты все электронные устройства в радиусе 36 тайлов будут полностью отключены."
-	item = /obj/item/radio/beacon/syndicate/bomb/emp
+	item = /obj/item/beacon/syndicate/bomb/emp
 	cost = 40
 	surplus = 0
 	can_discount = FALSE
@@ -1944,7 +1944,7 @@
 	name = "Силовой маяк"
 	desc = "Устройство, притягивающее к себе сингулярность и тесла-шар после того, как они покинут зону содержания. \
 			Чтобы его подключить, необходимо установить его на узел и закрепить с помощью отвёртки, а затем включить."
-	item = /obj/item/radio/beacon/syndicate
+	item = /obj/item/beacon/syndicate
 	cost = 30
 	surplus = 0
 	hijack_only = TRUE //This is an item only useful for a hijack traitor, as such, it should only be available in those scenarios.
@@ -2364,7 +2364,7 @@
 /datum/uplink_item/bundles_TC/badass
 	name = "Набор Синдиката"
 	desc = "Предлагает вам выбрать один из трёх наборов или получить случайный набор. Общая стоимость предметов в наборах превышает 100 телекристаллов."
-	item = /obj/item/radio/beacon/syndicate/bundle
+	item = /obj/item/beacon/syndicate/bundle
 	cost = 100
 	refundable = TRUE
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)

--- a/code/game/machinery/Beacon.dm
+++ b/code/game/machinery/Beacon.dm
@@ -10,7 +10,7 @@
 	anchored = TRUE
 	var/syndicate = 0
 	var/area_bypass = FALSE
-	var/obj/item/radio/beacon/Beacon
+	var/obj/item/beacon/Beacon
 	var/enabled = TRUE
 	var/cc_beacon = FALSE //can be teleported to even if on zlevel2
 
@@ -20,7 +20,7 @@
 
 /obj/machinery/bluespace_beacon/proc/create_beacon()
 	var/turf/T = loc
-	Beacon = new /obj/item/radio/beacon
+	Beacon = new /obj/item/beacon
 	Beacon.invisibility = INVISIBILITY_MAXIMUM
 	Beacon.loc = T
 	Beacon.syndicate = syndicate

--- a/code/game/machinery/computer/depot.dm
+++ b/code/game/machinery/computer/depot.dm
@@ -456,7 +456,7 @@
 	last_opener = usr
 	is_cooldown = TRUE
 	blocked = TRUE
-	for(var/obj/item/radio/beacon/R in GLOB.beacons)
+	for(var/obj/item/beacon/R in GLOB.beacons)
 		var/turf/T = get_turf(R)
 		if(!T)
 			continue

--- a/code/game/machinery/computer/depot.dm
+++ b/code/game/machinery/computer/depot.dm
@@ -456,7 +456,7 @@
 	last_opener = usr
 	is_cooldown = TRUE
 	blocked = TRUE
-	for(var/obj/item/beacon/R in GLOB.beacons)
+	for(var/obj/item/beacon/R as anything in GLOB.beacons)
 		var/turf/T = get_turf(R)
 		if(!T)
 			continue

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -214,7 +214,7 @@
 	var/list/areaindex = list()
 	var/turf/teleporter_turf = get_turf(src)
 	var/is_station_teleport = is_station_level(teleporter_turf.z)
-	for(var/obj/item/beacon/R in GLOB.beacons)
+	for(var/obj/item/beacon/R as anything in GLOB.beacons)
 		var/turf/T = get_turf(R)
 		if(!T)
 			continue

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -214,7 +214,7 @@
 	var/list/areaindex = list()
 	var/turf/teleporter_turf = get_turf(src)
 	var/is_station_teleport = is_station_level(teleporter_turf.z)
-	for(var/obj/item/radio/beacon/R in GLOB.beacons)
+	for(var/obj/item/beacon/R in GLOB.beacons)
 		var/turf/T = get_turf(R)
 		if(!T)
 			continue
@@ -295,8 +295,8 @@
 /obj/machinery/computer/teleporter/proc/teleport_helper()
 	area_bypass = FALSE
 	for(var/item in target.contents)
-		if(istype(item, /obj/item/radio/beacon))
-			var/obj/item/radio/beacon/B = item
+		if(istype(item, /obj/item/beacon))
+			var/obj/item/beacon/B = item
 			if(B.area_bypass)
 				area_bypass = TRUE
 			cc_beacon = B.cc_beacon

--- a/code/game/objects/items/devices/enginepicker.dm
+++ b/code/game/objects/items/devices/enginepicker.dm
@@ -41,12 +41,12 @@
 //This proc re-assigns all of engine beacons in the global list to a local list.
 /obj/item/enginepicker/proc/locatebeacons()
 	LAZYCLEARLIST(list_enginebeacons)
-	for(var/obj/item/radio/beacon/engine/B in GLOB.engine_beacon_list)
+	for(var/obj/item/beacon/engine/B in GLOB.engine_beacon_list)
 		if(B && !QDELETED(B))	//This ensures that the input pop-up won't have any qdeleted beacons
 			LAZYADD(list_enginebeacons, B)
 
 //Spawns and logs / announces the appropriate engine based on the choice made
-/obj/item/enginepicker/proc/processchoice(obj/item/radio/beacon/engine/choice, mob/living/carbon/user)
+/obj/item/enginepicker/proc/processchoice(obj/item/beacon/engine/choice, mob/living/carbon/user)
 	var/issuccessful = FALSE	//Check for a successful choice
 	var/engtype					//Engine type
 	var/G						//Generator that will be spawned

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -1,73 +1,63 @@
-/obj/item/radio/beacon
-	name = "Tracking Beacon"
+/obj/item/beacon
+	name = "tracking beacon"
 	desc = "A beacon used by a teleporter."
+	icon = 'icons/obj/radio.dmi'
 	icon_state = "beacon"
 	item_state = "signaler"
-	var/code = "Beacon"
 	origin_tech = "bluespace=1"
-	var/emagged = 0
-	var/syndicate = 0
+	flags = CONDUCT
+	slot_flags = ITEM_SLOT_BELT
+	throw_range = 9
+	w_class = WEIGHT_CLASS_SMALL
+	materials = list(MAT_METAL = 200, MAT_GLASS = 100)
+
+	var/emagged = FALSE
+	var/syndicate = FALSE
 	var/area_bypass = FALSE
-	var/cc_beacon = FALSE //set if allowed to teleport to even if on zlevel2
+	/// Set if allowed to teleport to even if on zlevel2
+	var/cc_beacon = FALSE
 
-/obj/item/radio/beacon/Initialize(mapload)
-	..()
-	code = "[code] ([GLOB.beacons.len + 1])"
-	GLOB.beacons += src
+/obj/item/beacon/Initialize(mapload)
+	. = ..()
+	GLOB.beacons |= src
 
-/obj/item/radio/beacon/Destroy()
+/obj/item/beacon/Destroy()
 	GLOB.beacons -= src
 	return ..()
 
-/obj/item/radio/beacon/emag_act(mob/user)
+/obj/item/beacon/emag_act(mob/user)
 	if(!emagged)
-		emagged = 1
-		syndicate = 1
+		emagged = TRUE
+		syndicate = TRUE
 		if(user)
 			to_chat(user, span_notice("The This beacon now only be locked on to by emagged teleporters!"))
 
-/obj/item/radio/beacon/hear_talk()
+/obj/item/beacon/hear_talk()
 	return
 
-/obj/item/radio/beacon/talk_into()
+/obj/item/beacon/talk_into()
 	return FALSE
 
-/obj/item/radio/beacon/send_hear()
-	return null
+/// Probably a better way of doing this, I'm lazy.
+/obj/item/beacon/bacon
 
-/obj/item/radio/beacon/verb/alter_signal(t as text)
-	set name = "Изменить сигнал маяка"
-	set category = STATPANEL_OBJECT
-	set src in usr
-
-	if(usr.incapacitated() || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
-		return
-
-	code = t
-	if(isnull(code))
-		code = initial(code)
-	src.add_fingerprint(usr)
-	return
-
-/obj/item/radio/beacon/bacon //Probably a better way of doing this, I'm lazy.
-
-/obj/item/radio/beacon/bacon/proc/digest_delay()
-	QDEL_IN(src, 600)
+/obj/item/beacon/bacon/proc/digest_delay()
+	QDEL_IN(src, 60 SECONDS)
 
 // SINGULO BEACON SPAWNER
-/obj/item/radio/beacon/syndicate
+/obj/item/beacon/syndicate
 	name = "suspicious beacon"
 	desc = "A label on it reads: <i>Activate to have a singularity beacon teleported to your location</i>."
 	origin_tech = "bluespace=6;syndicate=5"
 	syndicate = TRUE
 	var/obj/machinery/computer/syndicate_depot/teleporter/mycomputer
 
-/obj/item/radio/beacon/syndicate/Destroy()
+/obj/item/beacon/syndicate/Destroy()
 	if(mycomputer)
 		mycomputer.mybeacon = null
 	return ..()
 
-/obj/item/radio/beacon/syndicate/attack_self(mob/user)
+/obj/item/beacon/syndicate/attack_self(mob/user)
 	if(!user)
 		return
 	if(!isturf(user.loc))
@@ -79,12 +69,12 @@
 	user.temporarily_remove_item_from_inventory(src)
 	qdel(src)
 
-/obj/item/radio/beacon/syndicate/bomb
+/obj/item/beacon/syndicate/bomb
 	desc = "A label on it reads: <i>Warning: Activating this device will send a high-ordinance explosive to your location</i>."
 	origin_tech = "bluespace=5;syndicate=5"
 	var/bomb = /obj/machinery/syndicatebomb
 
-/obj/item/radio/beacon/syndicate/bomb/attack_self(mob/user)
+/obj/item/beacon/syndicate/bomb/attack_self(mob/user)
 	if(!user)
 		return
 	if(!isturf(user.loc))
@@ -96,11 +86,11 @@
 	user.temporarily_remove_item_from_inventory(src)
 	qdel(src)
 
-/obj/item/radio/beacon/syndicate/bomb/emp
+/obj/item/beacon/syndicate/bomb/emp
 	desc = "A label on it reads: <i>Warning: Activating this device will send a high-ordinance EMP explosive to your location</i>."
 	bomb = /obj/machinery/syndicatebomb/emp
 
-/obj/item/radio/beacon/syndicate/bundle
+/obj/item/beacon/syndicate/bundle
 	desc = "A label on it reads: <i>Activate to select a bundle</i>."
 	var/used = FALSE
 	var/list/selected = list()
@@ -294,19 +284,19 @@
 	)
 
 
-/obj/item/radio/beacon/syndicate/bundle/magical //for d20 dice of fate
+/obj/item/beacon/syndicate/bundle/magical //for d20 dice of fate
 	used = TRUE
 	name = "suspicious 'magical' beacon"
 	desc = "It looks battered and old, as if someone tried to crack it with brute force."
 
-/obj/item/radio/beacon/syndicate/bundle/Initialize(mapload)
+/obj/item/beacon/syndicate/bundle/Initialize(mapload)
 	. = ..()
 	unselected = bundles.Copy()
 	while(length(selected) < 3)
 		selected |= pick_n_take(unselected)
 	selected += "Random"
 
-/obj/item/radio/beacon/syndicate/bundle/attack_self(mob/user)
+/obj/item/beacon/syndicate/bundle/attack_self(mob/user)
 	if(!user)
 		return
 	used = TRUE
@@ -321,30 +311,30 @@
 	qdel(src)
 	user.put_in_hands(your_bundle)
 
-/obj/item/radio/beacon/syndicate/bundle/check_uplink_validity()
+/obj/item/beacon/syndicate/bundle/check_uplink_validity()
 	return !used
 
-/obj/item/radio/beacon/engine
+/obj/item/beacon/engine
 	desc = "A label on it reads: <i>Warning: This device is used for transportation of high-density objects used for high-yield power generation. Stay away!</i>."
-	anchored = TRUE		//Let's not move these around. Some folk might get the idea to use these for assassinations
+	anchored = TRUE //Let's not move these around. Some folk might get the idea to use these for assassinations
 	var/list/enginetype = list()
 
-/obj/item/radio/beacon/engine/Initialize(mapload)
+/obj/item/beacon/engine/Initialize(mapload)
 	LAZYADD(GLOB.engine_beacon_list, src)
 	return ..()
 
-/obj/item/radio/beacon/engine/Destroy()
+/obj/item/beacon/engine/Destroy()
 	GLOB.engine_beacon_list -= src
 	return ..()
 
-/obj/item/radio/beacon/engine/tesling
+/obj/item/beacon/engine/tesling
 	name = "Engine Beacon for Tesla and Singularity"
 	enginetype = list(ENGTYPE_TESLA, ENGTYPE_SING)
 
-/obj/item/radio/beacon/engine/tesla
+/obj/item/beacon/engine/tesla
 	name = "Engine Beacon for Tesla"
 	enginetype = list(ENGTYPE_TESLA)
 
-/obj/item/radio/beacon/engine/sing
+/obj/item/beacon/engine/sing
 	name = "Engine Beacon for Singularity"
 	enginetype = list(ENGTYPE_SING)

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -32,12 +32,6 @@
 		if(user)
 			to_chat(user, span_notice("The This beacon now only be locked on to by emagged teleporters!"))
 
-/obj/item/beacon/hear_talk()
-	return
-
-/obj/item/beacon/talk_into()
-	return FALSE
-
 /// Probably a better way of doing this, I'm lazy.
 /obj/item/beacon/bacon
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -741,12 +741,11 @@ GLOBAL_LIST_INIT(default_pirate_channels, list(
 		return
 	user.set_machine(src)
 	b_stat = !b_stat
-	if(!istype(src, /obj/item/radio/beacon))
-		if(b_stat)
-			balloon_alert(user, "модификация возможна!")
-		else
-			balloon_alert(user, "модификация невозможна!")
-		updateDialog()
+	if(b_stat)
+		balloon_alert(user, "модификация возможна!")
+	else
+		balloon_alert(user, "модификация невозможна!")
+	updateDialog()
 
 /obj/item/radio/wirecutter_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -407,7 +407,7 @@
 		if(17)
 			//Choose from 1 of 3 random syndie bundles
 			T.visible_message(span_userdanger("A suspicious radio beacon appears!"))
-			new /obj/item/radio/beacon/syndicate/bundle/magical(drop_location())
+			new /obj/item/beacon/syndicate/bundle/magical(drop_location())
 			create_smoke(2)
 		if(18)
 			//Captain ID

--- a/code/modules/anomalies/anomaly_generator.dm
+++ b/code/modules/anomalies/anomaly_generator.dm
@@ -184,7 +184,7 @@
 
 		if("beakon")
 			var/list/options = list()
-			for(var/obj/item/beacon/possible_beacon in GLOB.beacons)
+			for(var/obj/item/beacon/possible_beacon as anything in GLOB.beacons)
 				var/turf/T = get_turf(possible_beacon)
 				if(!T)
 					continue

--- a/code/modules/anomalies/anomaly_generator.dm
+++ b/code/modules/anomalies/anomaly_generator.dm
@@ -34,9 +34,9 @@
 	var/speed = 1e4
 
 	/// A beacon located inside the anomaly generator.
-	var/obj/item/radio/beacon/beacon
+	var/obj/item/beacon/beacon
 	/// The beacon selected as a place for generating anomalies.
-	var/obj/item/radio/beacon/selected_beacon
+	var/obj/item/beacon/selected_beacon
 	/// Current anomaly generator datum.
 	var/datum/anomaly_gen_datum/cur_anomaly
 
@@ -184,7 +184,7 @@
 
 		if("beakon")
 			var/list/options = list()
-			for(var/obj/item/radio/beacon/possible_beacon in GLOB.beacons)
+			for(var/obj/item/beacon/possible_beacon in GLOB.beacons)
 				var/turf/T = get_turf(possible_beacon)
 				if(!T)
 					continue
@@ -197,7 +197,7 @@
 
 				options["[T.loc.name]"] = possible_beacon
 
-			var/obj/item/radio/beacon/choice = options[tgui_input_list(ui.user, "Выберите маячок для создания аномалии.", "Выбор маячка", options)]
+			var/obj/item/beacon/choice = options[tgui_input_list(ui.user, "Выберите маячок для создания аномалии.", "Выбор маячка", options)]
 			if(choice == null)
 				choice = beacon;
 

--- a/code/modules/anomalies/gen_datums.dm
+++ b/code/modules/anomalies/gen_datums.dm
@@ -42,7 +42,7 @@
 /datum/anomaly_gen_datum/proc/is_possible_turf(turf/T)
 	return !is_ok_in_range(T, 2)
 
-/datum/anomaly_gen_datum/proc/generate(list/containment, obj/item/radio/beacon/beacon, range = 100, use_items = TRUE)
+/datum/anomaly_gen_datum/proc/generate(list/containment, obj/item/beacon/beacon, range = 100, use_items = TRUE)
 	var/list/used = list()
 	if(use_items)
 		used = get_used(containment)

--- a/code/modules/anomalies/items/anomaly_beacon.dm
+++ b/code/modules/anomalies/items/anomaly_beacon.dm
@@ -69,7 +69,7 @@
 	result = /obj/item/assembly/anomaly_beacon
 	tools = list(TOOL_SCREWDRIVER)
 	reqs = list(/obj/item/relict_production/rapid_dupe = 1,
-				/obj/item/radio/beacon = 1,
+				/obj/item/beacon = 1,
 				/obj/item/stack/cable_coil = 5)
 	time = 10 SECONDS
 	category = CAT_WEAPONRY

--- a/code/modules/anomalies/old.dm
+++ b/code/modules/anomalies/old.dm
@@ -245,9 +245,9 @@
 	var/turf/turf = pick(get_area_turfs(impact_area))
 	if(turf)
 		// Calculate new position (searches through beacons in world)
-		var/obj/item/radio/beacon/chosen
+		var/obj/item/beacon/chosen
 		var/list/possible = list()
-		for(var/obj/item/radio/beacon/W in GLOB.beacons)
+		for(var/obj/item/beacon/W in GLOB.beacons)
 			if(!is_station_level(W.z))
 				continue
 			possible += W
@@ -274,7 +274,7 @@
 			var/y_distance = turf_to.y - turf_from.y
 			var/x_distance = turf_to.x - turf_from.x
 			for(var/atom/movable/movable_atom in urange(12, turf_from)) // iterate thru list of mobs in the area
-				if(istype(movable_atom, /obj/item/radio/beacon))
+				if(istype(movable_atom, /obj/item/beacon))
 					continue // don't teleport beacons because that's just insanely stupid
 				if(movable_atom.anchored || movable_atom.move_resist == INFINITY)
 					continue

--- a/code/modules/anomalies/old.dm
+++ b/code/modules/anomalies/old.dm
@@ -247,7 +247,7 @@
 		// Calculate new position (searches through beacons in world)
 		var/obj/item/beacon/chosen
 		var/list/possible = list()
-		for(var/obj/item/beacon/W in GLOB.beacons)
+		for(var/obj/item/beacon/W as anything in GLOB.beacons)
 			if(!is_station_level(W.z))
 				continue
 			possible += W

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -694,14 +694,14 @@
 	name = "tele bacon"
 	desc = "It tastes a little odd but it's still delicious."
 	icon_state = "bacon"
-	var/obj/item/radio/beacon/bacon/baconbeacon
+	var/obj/item/beacon/bacon/baconbeacon
 	list_reagents = list("nutriment" = 4, "porktonium" = 10)
 	tastes = list("bacon" = 1)
 	foodtype = MEAT
 
 /obj/item/reagent_containers/food/snacks/telebacon/New()
 	..()
-	baconbeacon = new /obj/item/radio/beacon/bacon(src)
+	baconbeacon = new /obj/item/beacon/bacon(src)
 
 /obj/item/reagent_containers/food/snacks/telebacon/On_Consume(mob/M, mob/user)
 	if(!reagents.total_volume)

--- a/code/modules/food_and_drinks/item_food/eat_item_list_tech.dm
+++ b/code/modules/food_and_drinks/item_food/eat_item_list_tech.dm
@@ -315,7 +315,7 @@
 	nutritional_value = 15, \
 	)
 
-/obj/item/radio/beacon/add_eatable_component()
+/obj/item/beacon/add_eatable_component()
 	AddComponent( \
 	/datum/component/eatable, \
 	material_type = MATERIAL_CLASS_TECH, \
@@ -419,56 +419,56 @@
 	/datum/component/eatable, \
 	material_type = MATERIAL_CLASS_TECH, \
 	nutritional_value = 30, \
-	)	
+	)
 
 /obj/item/stock_parts/scanning_module/phasic/add_eatable_component()
 	AddComponent( \
 	/datum/component/eatable, \
 	material_type = MATERIAL_CLASS_TECH, \
 	nutritional_value = 30, \
-	)	
+	)
 
 /obj/item/stock_parts/manipulator/pico/add_eatable_component()
 	AddComponent( \
 	/datum/component/eatable, \
 	material_type = MATERIAL_CLASS_TECH, \
 	nutritional_value = 30, \
-	)	
+	)
 
 /obj/item/stock_parts/micro_laser/ultra/add_eatable_component()
 	AddComponent( \
 	/datum/component/eatable, \
 	material_type = MATERIAL_CLASS_TECH, \
 	nutritional_value = 30, \
-	)	
+	)
 
 /obj/item/stock_parts/matter_bin/super/add_eatable_component()
 	AddComponent( \
 	/datum/component/eatable, \
 	material_type = MATERIAL_CLASS_TECH, \
 	nutritional_value = 30, \
-	)	
+	)
 
 /obj/item/stock_parts/capacitor/quadratic/add_eatable_component()
 	AddComponent( \
 	/datum/component/eatable, \
 	material_type = MATERIAL_CLASS_TECH, \
 	nutritional_value = 60, \
-	)	
+	)
 
 /obj/item/stock_parts/scanning_module/triphasic/add_eatable_component()
 	AddComponent( \
 	/datum/component/eatable, \
 	material_type = MATERIAL_CLASS_TECH, \
 	nutritional_value = 60, \
-	)	
-	
+	)
+
 /obj/item/stock_parts/manipulator/femto/add_eatable_component()
 	AddComponent( \
 	/datum/component/eatable, \
 	material_type = MATERIAL_CLASS_TECH, \
 	nutritional_value = 60, \
-	)	
+	)
 
 /obj/item/stock_parts/micro_laser/quadultra/add_eatable_component()
 	AddComponent( \

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -25,6 +25,12 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 0)
 	/// Typecache of the things allowed in the bookcase. Populated in [/proc/generate_allowed_books()] on Initialize.
 	var/list/allowed_books
+	/// When enabled, books_to_load number of random books will be generated for this bookcase when first interacted with.
+	var/load_random_books = FALSE
+	/// The category of books to pick from when populating random books.
+	var/random_category = null
+	/// How many random books to generate.
+	var/books_to_load = 0
 
 /obj/structure/bookcase/get_ru_names()
 	return list(
@@ -42,7 +48,6 @@
 	if(mapload)
 		addtimer(CALLBACK(src, PROC_REF(take_contents)), 0)
 
-
 /obj/structure/bookcase/examine(mob/user)
 	if(length(contents) > 0)
 		desc = "Большой книжный шкаф. На его полках стоят книги."
@@ -54,7 +59,6 @@
 /obj/structure/bookcase/add_debris_element()
 	AddElement(/datum/element/debris, DEBRIS_WOOD, -40, 5)
 
-
 /// Populates typecache with the things allowed to store
 /obj/structure/bookcase/proc/generate_allowed_books()
 	allowed_books = typecacheof(list(
@@ -63,7 +67,6 @@
 		/obj/item/storage/bible,
 		/obj/item/tome,
 	))
-
 
 /// This is called on Initialize to add contents on the tile
 /obj/structure/bookcase/proc/take_contents()
@@ -85,8 +88,6 @@
 	balloon_alert(user, "поставлено на полку")
 	add_fingerprint(user)
 	update_icon(UPDATE_ICON_STATE)
-
-
 
 /obj/structure/bookcase/attackby(obj/item/I, mob/user, params)
 	if(user.a_intent == INTENT_HARM)
@@ -122,7 +123,6 @@
 
 	return ..()
 
-
 /obj/structure/bookcase/screwdriver_act(mob/user, obj/item/I)
 	if(obj_flags & NODECONSTRUCT)
 		return FALSE
@@ -135,10 +135,8 @@
 	TOOL_DISMANTLE_SUCCESS_MESSAGE
 	deconstruct(TRUE)
 
-
 /obj/structure/bookcase/wrench_act(mob/user, obj/item/I)
 	return default_unfasten_wrench(user, I, 0)
-
 
 /obj/structure/bookcase/attack_hand(mob/user)
 	if(!length(contents))
@@ -164,8 +162,7 @@
 	for(var/atom/movable/thing as anything in contents)
 		if(is_type_in_typecache(thing, allowed_books))
 			thing.forceMove(drop_loc)
-	..()
-
+	return ..()
 
 /obj/structure/bookcase/update_icon_state()
 	icon_state = "book-[min(length(contents), 5)]"
@@ -185,7 +182,6 @@
 		ru_names[INSTRUMENTAL] += manual_name_ru
 		ru_names[PREPOSITIONAL] += manual_name_ru
 
-
 /obj/structure/bookcase/manuals/medical
 	manual_name = "Medical Manuals "
 	manual_name_ru = " с учебниками по медицине"
@@ -195,12 +191,9 @@
 	new /obj/item/book/manual/medical_cloning(src)
 	update_icon(UPDATE_ICON_STATE)
 
-
 /obj/structure/bookcase/manuals/engineering
 	manual_name = "Engineering Manuals "
 	manual_name_ru = " с руководствами по инженерному делу"
-
-
 
 /obj/structure/bookcase/manuals/engineering/Initialize(mapload)
 	. = ..()
@@ -212,18 +205,14 @@
 	new /obj/item/book/manual/robotics_cyborgs(src)
 	update_icon(UPDATE_ICON_STATE)
 
-
 /obj/structure/bookcase/manuals/research_and_development
 	manual_name = "R&D Manuals "
 	manual_name_ru = " с учебниками по научной деятельности"
-
-
 
 /obj/structure/bookcase/manuals/research_and_development/Initialize(mapload)
 	. = ..()
 	new /obj/item/book/manual/research_and_development(src)
 	update_icon(UPDATE_ICON_STATE)
-
 
 /*
  * Book

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -1,98 +1,100 @@
 /obj/item/book/manual/random
 	icon_state = "random_book"
 
-/obj/item/book/manual/random/New()
-	..()
+/obj/item/book/manual/random/Initialize(mapload)
+	. = ..()
 	var/static/banned_books = list(/obj/item/book/manual/random, /obj/item/book/manual/nuclear)
 	var/newtype = pick(subtypesof(/obj/item/book/manual) - banned_books)
 	new newtype(loc)
-
-/obj/item/book/manual/random/Initialize(mapload)
-	. = ..()
 	return INITIALIZE_HINT_QDEL
 
 /obj/item/book/random
 	icon_state = "random_book"
-	var/amount = 1
-	var/category = null
+	/// The category of books to pick from when creating this book.
+	var/random_category = null
+	/// If this book has already been 'generated' yet.
+	var/random_loaded = FALSE
 
 /obj/item/book/random/Initialize(mapload)
 	. = ..()
-	create_random_books(amount, src.loc, TRUE, category)
-	return INITIALIZE_HINT_QDEL
+	icon_state = "book[rand(1,8)]"
 
-/obj/item/book/random/triple
-	amount = 3
+/obj/item/book/random/attack_self()
+	if(!random_loaded)
+		create_random_books(1, loc, TRUE, random_category, src)
+		random_loaded = TRUE
+	return ..()
 
 /obj/structure/bookcase/random
-	var/category = null
-	var/book_count = 2
+	load_random_books = TRUE
+	books_to_load = 2
 	icon_state = "random_bookcase"
 
 /obj/structure/bookcase/random/Initialize(mapload)
 	. = ..()
-	if(!book_count || !isnum(book_count))
-		update_icon()
-		return
-	book_count += pick(-1,-1,0,1,1)
-	create_random_books(book_count, src, FALSE, category)
-	update_icon()
+	if(books_to_load && isnum(books_to_load))
+		books_to_load += pick(-1,-1,0,1,1)
+	update_appearance()
 
-// why is this a global proc
-/proc/create_random_books(amount = 2, location, fail_loud = FALSE, category = null)
+/proc/create_random_books(amount, location, fail_loud = FALSE, category = null, obj/item/book/existing_book)
 	. = list()
 	if(!isnum(amount) || amount<1)
 		return
 	if(!SSdbcore.IsConnected())
-		if(fail_loud || prob(5))
-			var/obj/item/paper/P = new(location)
-			P.info = "There once was a book from Nantucket<br>But the database failed us, so f*$! it.<br>I tried to be good to you<br>Now this is an I.O.U<br>If you're feeling entitled, well, stuff it!<br><br><font color='gray'>~</font>"
-			P.update_icon()
+		if(existing_book && (fail_loud || prob(5)))
+			existing_book.author = "???"
+			existing_book.title = "Strange book"
+			existing_book.name = "Strange book"
+			existing_book.dat = "There once was a book from Nantucket<br>But the database failed us, so f*$! it.<br>I tried to be good to you<br>Now this is an I.O.U<br>If you're feeling entitled, well, stuff it!<br><br><font color='gray'>~</font>"
 		return
 	if(prob(25))
 		category = null
-	var/c = ""
+	var/sql_category = ""
 	var/list/sql_params = list()
 	if(category)
-		c = " AND category=:category"
+		sql_category = " AND category=:category"
 		sql_params["category"] = category
 
 	sql_params["amount"] = amount
-	var/datum/db_query/query_get_random_books = SSdbcore.NewQuery("SELECT author, title, content FROM [format_table_name("library")] WHERE (isnull(flagged) OR flagged = 0)[c] GROUP BY title ORDER BY rand() LIMIT :amount", sql_params)
+	var/datum/db_query/query_get_random_books = SSdbcore.NewQuery("SELECT author, title, content FROM [format_table_name("library")] WHERE (isnull(flagged) OR flagged = 0)[sql_category] ORDER BY rand() LIMIT :amount", sql_params)
 	if(!query_get_random_books.warn_execute())
 		qdel(query_get_random_books)
 		return
 
 	while(query_get_random_books.NextRow())
-		var/obj/item/book/B = new(location)
-		. += B
-		B.author	=	query_get_random_books.item[1]
-		B.title		=	query_get_random_books.item[2]
-		B.dat		=	query_get_random_books.item[3]
-		B.name		=	"Book: [B.title]"
-		B.icon_state=	"book[rand(1,8)]"
+		var/obj/item/book/book
+		book = existing_book ? existing_book : new(location)
+		book.author = query_get_random_books.item[1]
+		book.title = query_get_random_books.item[2]
+		book.dat =	query_get_random_books.item[3]
+		book.name = "Book: [book.title]"
+		if(!existing_book)
+			book.icon_state = "book[rand(1,8)]"
 	qdel(query_get_random_books)
 
 /obj/structure/bookcase/random/fiction
 	name = "bookcase (Fiction)"
-	category = "Fiction"
+	random_category = "Fiction"
+
 /obj/structure/bookcase/random/nonfiction
 	name = "bookcase (Non-Fiction)"
-	category = "Non-fiction"
+	random_category = "Non-fiction"
+
 /obj/structure/bookcase/random/religion
 	name = "bookcase (Religion)"
-	category = "Religion"
+	random_category = "Religion"
+
 /obj/structure/bookcase/random/adult
 	name = "bookcase (Adult)"
-	category = "Adult"
+	random_category = "Adult"
 
 /obj/structure/bookcase/random/reference
 	name = "bookcase (Reference)"
-	category = "Reference"
+	random_category = "Reference"
 	var/ref_book_prob = 20
 
 /obj/structure/bookcase/random/reference/Initialize(mapload)
 	. = ..()
-	while(book_count > 0 && prob(ref_book_prob))
-		book_count--
+	while(books_to_load > 0 && prob(ref_book_prob))
+		books_to_load--
 		new /obj/item/book/manual/random(src)

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -41,7 +41,7 @@
 
 /obj/item/wormhole_jaunter/proc/get_destinations()
 	. = list()
-	for(var/obj/item/beacon/beacon in GLOB.beacons)
+	for(var/obj/item/beacon/beacon as anything in GLOB.beacons)
 		var/turf/beacon_turf = get_turf(beacon)
 		if(is_station_level(beacon_turf.z))
 			. += beacon
@@ -164,7 +164,7 @@
 	update_mob()
 
 	var/list/destinations = list()
-	for(var/obj/item/beacon/beacon in GLOB.beacons)
+	for(var/obj/item/beacon/beacon as anything in GLOB.beacons)
 		var/turf/beacon_turf = get_turf(beacon)
 		if(is_station_level(beacon_turf.z))
 			destinations += beacon_turf

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -41,7 +41,7 @@
 
 /obj/item/wormhole_jaunter/proc/get_destinations()
 	. = list()
-	for(var/obj/item/radio/beacon/beacon in GLOB.global_radios)
+	for(var/obj/item/beacon/beacon in GLOB.beacons)
 		var/turf/beacon_turf = get_turf(beacon)
 		if(is_station_level(beacon_turf.z))
 			. += beacon
@@ -164,7 +164,7 @@
 	update_mob()
 
 	var/list/destinations = list()
-	for(var/obj/item/radio/beacon/beacon in GLOB.global_radios)
+	for(var/obj/item/beacon/beacon in GLOB.beacons)
 		var/turf/beacon_turf = get_turf(beacon)
 		if(is_station_level(beacon_turf.z))
 			destinations += beacon_turf

--- a/code/modules/projectiles/guns/energy/telegun.dm
+++ b/code/modules/projectiles/guns/energy/telegun.dm
@@ -30,7 +30,7 @@
 	var/list/L = list()
 	var/list/areaindex = list()
 
-	for(var/obj/item/beacon/R in GLOB.beacons)
+	for(var/obj/item/beacon/R as anything in GLOB.beacons)
 		var/turf/T = get_turf(R)
 		if(!T)
 			continue

--- a/code/modules/projectiles/guns/energy/telegun.dm
+++ b/code/modules/projectiles/guns/energy/telegun.dm
@@ -30,7 +30,7 @@
 	var/list/L = list()
 	var/list/areaindex = list()
 
-	for(var/obj/item/radio/beacon/R in GLOB.beacons)
+	for(var/obj/item/beacon/R in GLOB.beacons)
 		var/turf/T = get_turf(R)
 		if(!T)
 			continue

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -88,7 +88,7 @@
 	req_tech = list("bluespace" = 1)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 150, MAT_GLASS = 100)
-	build_path = /obj/item/radio/beacon
+	build_path = /obj/item/beacon
 	category = list("Bluespace")
 
 /datum/design/brpd

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -31,7 +31,7 @@
 		/obj/structure/spider/spiderling,
 		/obj/item/disk/nuclear,
 		/obj/machinery/nuclearbomb,
-		/obj/item/radio/beacon,
+		/obj/item/beacon,
 		/obj/machinery/the_singularitygen,
 		/obj/singularity,
 		/obj/machinery/teleport/station,

--- a/code/tests/game_tests.dm
+++ b/code/tests/game_tests.dm
@@ -14,6 +14,7 @@
 #include "test_announcements.dm"
 #include "test_components.dm"
 #include "test_elements.dm"
+#include "test_init_sanity.dm"
 #include "test_map_templates.dm"
 #include "test_reagent_id_typos.dm"
 #include "test_spawn_humans.dm"

--- a/code/tests/test_init_sanity.dm
+++ b/code/tests/test_init_sanity.dm
@@ -1,0 +1,11 @@
+/datum/game_test/initialize_sanity/Run()
+	if(length(SSatoms.BadInitializeCalls))
+		TEST_FAIL("Bad Initialize() calls detected. Please read logs.")
+		var/list/init_failures_to_text = list(
+			"[BAD_INIT_QDEL_BEFORE]" = "Qdeleted Before Initialized",
+			"[BAD_INIT_DIDNT_INIT]" = "Did Not Initialize",
+			"[BAD_INIT_SLEPT]" = "Initialize() Slept",
+			"[BAD_INIT_NO_HINT]" = "No Initialize() Hint Returned",
+		)
+		for(var/failure in SSatoms.BadInitializeCalls)
+			TEST_FAIL("[failure]: [init_failures_to_text["[SSatoms.BadInitializeCalls[failure]]"]]") // You like stacked brackets?


### PR DESCRIPTION
## Что этот ПР делает
https://github.com/ParadiseSS13/Paradise/pull/25559
Это мало того, что легаси, так ещё и вызывает бэд иниты со слапами.
Имплементирован инит санити юнит тест.

Из-за плохих спящих инитов, пришлось портировать рефактор инита буков с ТГ 2020 +50 -50.

## Тестирование
Бомбы взрываются, тесла вызывается.
