### PR TITLE
bugfix: Исправление черных тайлов пола при постройке на лаве и тайлах ковров

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -25,6 +25,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	icon_state = "dont_use_this_tile"
 	plane = FLOOR_PLANE
 	var/icon_regular_floor = "floor" //used to remember what icon the tile should have by default
+	var/icon_regular_floor_dmi = 'icons/turf/floors.dmi' //used to remember what icon the tile should have by default (fix bug for change dmi)
 	var/floor_regular_dir = SOUTH  //used to remember what dir the tile should have by default
 	var/icon_plating = "plating"
 	thermal_conductivity = 0.040
@@ -48,8 +49,10 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	. = ..()
 	if(icon_state in GLOB.icons_to_ignore_at_floor_init) //so damaged/burned tiles or plating icons aren't saved as the default
 		icon_regular_floor = "floor"
+		icon_regular_floor_dmi = 'icons/turf/floors.dmi'
 	else
 		icon_regular_floor = icon_state
+		icon_regular_floor_dmi = icon
 		floor_regular_dir = dir
 
 
@@ -156,6 +159,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	if(!ispath(T, /turf/simulated/floor))
 		return ..()
 
+	var/old_dmi = icon_regular_floor_dmi
 	var/old_icon = icon_regular_floor
 	var/old_plating = icon_plating
 	var/old_dir = dir
@@ -163,6 +167,9 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	var/old_transparent_floor = transparent_floor
 
 	var/turf/simulated/floor/W = ..()
+
+	if(old_dmi != W.icon_regular_floor_dmi) //bugfix for dark tiles
+		keep_icon = FALSE
 
 	var/obj/machinery/atmospherics/R
 	var/obj/machinery/power/terminal/term


### PR DESCRIPTION

## Что этот ПР делает

Исправлен баг с черными тайлами при постройке пола на лазисе и на тайлах ковров и паркета.

## Почему это хорошо для игры

Меньше багов в игре.

## Демонстрация изменений
До фикса:
<img width="1254" height="805" alt="image" src="https://github.com/user-attachments/assets/b948196e-5bc5-4ef0-9e5b-be2e6f8f9907" />

После фикса:
<img width="584" height="527" alt="image" src="https://github.com/user-attachments/assets/31e8dffd-a884-46b2-890c-343a3ae7f8a4" />

## Тестирование

Проверил на локалке, проверил тайлы лавы, ковры возле тстауи станции, паркет в атриуме.
