### PR TITLE
bugfix: Исправление бага с портативным смесом

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -123,37 +123,37 @@
 	add_fingerprint(user)
 	if(terminal)	//is there already a terminal ?
 		to_chat(user, span_warning("This SMES already has a power terminal."))
-		return
+		return FALSE
 	var/terminal_dir = get_dir(user, src)
 	if(ISDIAGONALDIR(terminal_dir))	//we don't want diagonal click
 		to_chat(user, span_warning("You should face the SMES from any cardinal direction."))
-		return
+		return FALSE
 	if(panel_check && !panel_open)	//is the panel open ?
 		to_chat(user, span_warning("You should open the maintenance panel first."))
-		return
+		return FALSE
 	var/turf/terminal_turf = get_step(src, REVERSE_DIR(terminal_dir))
 	if(!terminal_turf.can_have_cabling() || terminal_turf.intact)	//is the floor plating removed or is it a spaceturf ?
 		to_chat(user, span_warning("You should remove or change the floor plating beneath you."))
-		return
+		return FALSE
 	if(user.loc == loc)	// somehow???
 		to_chat(user, span_warning("You must not be on the same tile as the SMES."))
-		return
+		return FALSE
 	if(coil.get_amount() < 10)
 		to_chat(user, span_warning("You need at least ten length of cable to construct a power terminal."))
-		return
+		return FALSE
 	user.visible_message(
 		span_notice("[user] starts to construct the cable terminal for the SMES."),
 		span_notice("You start to construct the cable terminal for the SMES..."),
 	)
 	coil.play_tool_sound(src)
 	if(!do_after(user, 5 SECONDS * coil.toolspeed, src, category = DA_CAT_TOOL) || (panel_check && !panel_open) || !terminal_turf.can_have_cabling() || terminal_turf.intact || QDELETED(coil))
-		return
+		return FALSE
 	var/obj/structure/cable/node = terminal_turf.get_cable_node()
 	if(check_electrocute(user, node, node))
-		return
+		return FALSE
 	if(!coil.use(10))
 		to_chat(user, span_warning("At some point during construction you lost some cable. Make sure you have ten lengths before trying again."))
-		return
+		return FALSE
 	user.visible_message(
 		span_notice("[user] has finished the construction of the cable terminal for the SMES."),
 		span_notice("You have finished the construction of the cable terminal for the SMES."),
@@ -161,6 +161,7 @@
 	make_terminal(terminal_dir, terminal_turf)
 	terminal.add_fingerprint(user)
 	terminal.connect_to_network()
+	return TRUE
 
 /obj/machinery/power/smes/proc/check_electrocute(mob/user, power_source, obj/source)
 	if(prob(50) && electrocute_mob(user, power_source, source, 1, TRUE))


### PR DESCRIPTION

## Что этот ПР делает

Фикс бага с установкой портитвного смеса. Теперь корректно ставится и нельзя перетащить после установки терминала.

## Почему это хорошо для игры

Исправление бага по репорту: https://discord.com/channels/617003227182792704/1422842354234167356/1422842354234167356

## Тестирование

Проверил на локалке, смес корректно становится `anchored = 1` после установки терминала.