### PR TITLE
bugfix: Исправление пустых крейтов если у них не указаны рунеймсы

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1146,15 +1146,23 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	)
 
 /datum/supply_packs/security/armory/m79
-	name = "M79 Grenade Launcher Crate"
+	name = "Гранатометы М79"
 	contains = list(/obj/item/gun/projectile/bombarda/secgl/m79,
 					/obj/item/gun/projectile/bombarda/secgl/m79)
 	cost = 80
-	containername = "m79 grenade launcher crate"
+	containername = "ящик с гранатометами М79"
+	container_ru_names = list(
+		NOMINATIVE = "ящик с гранатометами М79",
+		GENITIVE = "ящика с гранатометами М79",
+		DATIVE = "ящику с гранатометами М79",
+		ACCUSATIVE = "ящик с гранатометами М79",
+		INSTRUMENTAL = "ящиком с гранатометами М79",
+		PREPOSITIONAL = "ящике с гранатометами М79"
+	)
 	required_tech = list("combat" = 6, "materials" = 3)
 
 /datum/supply_packs/security/armory/grenades40mm_nonlethal
-	name = "40mm non-lethal grenade boxes crate"
+	name = "40-мм нелетальные гранаты"
 	contains = list(
 		/obj/item/ammo_box/secgl/solid,
 		/obj/item/ammo_box/secgl/flash,
@@ -1163,7 +1171,15 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 		/obj/item/ammo_box/secgl/paint
 	)
 	cost = 50
-	containername = "40mm non-lethal grenade boxes crate"
+	containername = "ящик с 40-мм нелетальными гранатами"
+	container_ru_names = list(
+		NOMINATIVE = "ящик с 40-мм нелетальными гранатами",
+		GENITIVE = "ящика с 40-мм нелетальными гранатами",
+		DATIVE = "ящику с 40-мм нелетальными гранатами",
+		ACCUSATIVE = "ящик с 40-мм нелетальными гранатами",
+		INSTRUMENTAL = "ящиком с 40-мм нелетальными гранатами",
+		PREPOSITIONAL = "ящике с 40-мм нелетальными гранатами"
+	)
 	required_tech = list("combat" = 5, "materials" = 3)
 
 /////// Implants & etc

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -321,7 +321,10 @@
 	Crate.name = "[object.containername] [comment ? "([comment])":"" ]"
 	Crate.ru_names = new /list(6)
 	for(var/i = 1; i <= 6; i++)
-		Crate.ru_names[i] = "[object.container_ru_names[i]] [comment ? "([comment])":"" ]"
+		if(i < length(object.container_ru_names))
+			Crate.ru_names[i] = "[object.container_ru_names[i]] [comment ? "([comment])":"" ]"
+		else
+			Crate.ru_names[i] = Crate.name
 
 	if(object.access)
 		Crate:req_access = list(text2num(object.access))


### PR DESCRIPTION
## Что этот ПР делает

Удаляет рантайм при попытке заспавнить крейт без прописанного рунеймса. Больше не будут приходит ьпустые крейты при заказе в карго.

## Почему это хорошо для игры

Исправление бага, фикс на всякий случай если кто забудет указать рунеймсы.

## Демонстрация изменений

<img width="303" height="301" alt="image" src="https://github.com/user-attachments/assets/7d954007-7644-4cab-9da3-85bef545cd8e" />


## Тестирование

Локалка.
