### PR TITLE
balance: нерф крав маг

### DIFF
--- a/code/modules/martial_arts/combos/krav_maga/leg_sweep.dm
+++ b/code/modules/martial_arts/combos/krav_maga/leg_sweep.dm
@@ -11,8 +11,9 @@
 	)
 	playsound(get_turf(user), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
 	target.apply_damage(5, BRUTE)
+	target.apply_damage(45, STAMINA)
 	objective_damage(user, target, 5, BRUTE)
-	target.Weaken(4 SECONDS)
+	target.Knockdown(4 SECONDS)
 	add_attack_logs(user, target, "Melee attacked with martial-art [src] :  Leg Sweep", ATKLOG_ALL)
 	user.mind.martial_art.in_stance = FALSE
 	return MARTIAL_COMBO_DONE_CLEAR_COMBOS


### PR DESCRIPTION
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

<!-- Вы можете совмещать до 2-х тэгов, например, balance/tweak:
Список возможных тэгов для пр-а:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map: Вы меняете только карту.
- image: Вы добавляете/удаляете спрайты.
- sound: Вы добавляете/удаляете звуки.
- spellcheck: Вы исправили опечатку.
- local: Вы добавляете новый текст на русском или переводите на русский.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает
Заменяет у кравмаг пермастан на 4 секунды, меняя его на кнокдаун.
В обмен на ослабление, теперь удар кравмагами наносит 40 урона по стамине, делая данный удар по эффективности как удар телескопичкой.
<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2. В ином случае, опишите баг и его воспроизведение. -->

## Почему это хорошо для игры
Стан на 4 секунды, который откатывается быстрее, чем человек собственно находится в стане. Стан, который в виду особенностей БИ игнорирует любую защиту, включая любые виды щитов (включая энергощиты у нюки или культа). В эпоху, когда мы уходим от однокнопочной боевки, у нас все еще есть предмет, который станит куклу на достаточное время, чтобы по этой самой кукле можно было бы выпустить весь магазин. Стан, который по своей сути является бесплатным, бесконечным с эффектом антидропа, который без проблем биндится на условный пробел и который не сбрасывается в принципе (к примеру, там есть условие, при котором стан не сработает на лежащую куклу, в связи с чем можно просто бить эту самую куклу в хелпе или харме, пока человек не решит подняться, и сразу после поднятия прокает новый стан во время атаки)
<!-- Опишите, почему, по вашему, следует добавить эти изменения в билд. -->

