### PR TITLE
add: Добавить в вендор билетиков в дормах спрей для автозагара

### DIFF
--- a/code/modules/arcade/prize_datums.dm
+++ b/code/modules/arcade/prize_datums.dm
@@ -179,6 +179,12 @@ GLOBAL_DATUM_INIT(global_prizes, /datum/prizes, new())
 	typepath = /obj/item/storage/box/fakesyndiesuit
 	cost = 90
 
+/datum/prize_item/spraytan
+	name = "Spray Tan"
+	desc = "Спрей-автозагар. Не попадите в глаза!"
+	typepath = /obj/item/reagent_containers/spray/spraytan
+	cost = 100
+
 /datum/prize_item/owl
 	name = "Owl Action Figure"
 	desc = "Помните: герои не становятся ГРИФонами!"


### PR DESCRIPTION
## Что этот ПР делает

Добавляет в Prize Counter, в дормах, спрей для автозагара (/obj/item/reagent_containers/spray/spraytan) за 100 билетиков, сам спрей и реагент в нем уже есть в игре, локализован, но находится только на лаве у пляжников.
Реагент "Спрей-загар" в спрее при пшике на гуманоида устанавливает ему цвет кожи на #9B7653 и тон кожи на -30
При передозировке в 11 юнитов людям убирает бороду и ставит прическу на Spiky черного цвета и с 7 процентной вероятностью в тик выведет сообщение что человек играет своими бицепсами.
Для всех рас при передозировке с 10 процентным шансом в тик выкрикнет фразу в районе:
"Это было ПРОСТО ОХУИТЕЛЬНО."
"Вы - зло этого мира."
"Не стесняйтесь, покажите мне на что вы способны."

## Почему это хорошо для игры

Забавный гиммик в вендор для забавных гиммиков.

## Демонстрация изменений

Созданный кнопками хуман, слева - до пшика, справа - после пшика
<img width="137" height="74" alt="spraytan" src="https://github.com/user-attachments/assets/98b8ac8f-1cd3-4333-9900-c13168b4dff8" />

## Тестирование

Локалка
