### PR TITLE
server/bugfix: Reworking the alphabetical order script and fix trait validaty

### DIFF
--- a/code/_globalvars/lists/names.dm
+++ b/code/_globalvars/lists/names.dm
@@ -1,4 +1,3 @@
-// START OF ALPHABETICAL SORTING
 GLOBAL_LIST_INIT(adjectives, world.file2list("strings/names/adjectives.txt"))
 GLOBAL_LIST_INIT(ai_names, world.file2list("strings/names/ai.txt"))
 GLOBAL_LIST_INIT(clown_names, world.file2list("strings/names/clown.txt"))
@@ -25,7 +24,6 @@ GLOBAL_LIST_INIT(nouns, world.file2list("strings/names/nouns.txt"))
 GLOBAL_LIST_INIT(verbs, world.file2list("strings/names/verbs.txt"))
 GLOBAL_LIST_INIT(wizard_first, world.file2list("strings/names/wizardfirst.txt"))
 GLOBAL_LIST_INIT(wizard_second, world.file2list("strings/names/wizardsecond.txt"))
-// END OF ALPHABETICAL SORTING
 
 GLOBAL_LIST_EMPTY(cached_ru_names)
 

--- a/code/tests/game_tests.dm
+++ b/code/tests/game_tests.dm
@@ -10,7 +10,6 @@
 #endif
 
 #ifdef GAME_TESTS
-// START OF ALPHABETICAL SORTING
 #include "test_announcements.dm"
 #include "test_components.dm"
 #include "test_elements.dm"
@@ -22,7 +21,6 @@
 #include "test_status_effect_ids.dm"
 #include "test_subsystem_init.dm"
 #include "test_timer_sanity.dm"
-// END OF ALPHABETICAL SORTING
 #endif
 
 #ifdef MAP_TESTS

--- a/tools/ci/alphabetical_check.py
+++ b/tools/ci/alphabetical_check.py
@@ -10,170 +10,74 @@ GREEN = "\033[0;32m"
 BLUE = "\033[0;34m"
 NC = "\033[0m"
 
-START_MARKER = "// START OF ALPHABETICAL SORTING"
-END_MARKER = "// END OF ALPHABETICAL SORTING"
-
-REQUIRED_FILES = [
-    'code/tests/game_tests.dm',
-    'code/_globalvars/lists/names.dm',
+DIRECTORIES_TO_CHECK = [
+    'strings/',
 ]
-
-def find_txt_files(directory):
-    """Find all .txt files in directory and subdirectories using pathlib."""
-    if not os.path.exists(directory):
-        return []
-    return [str(p) for p in Path(directory).rglob("*.txt")]
 
 def print_error(message, filename=None, line_number=None):
     """Print error with GitHub Actions formatting support."""
     if os.getenv("GITHUB_ACTIONS") == "true":
-        location = f"file={filename},line={line_number}" if filename and line_number else f"file={filename}" if filename else ""
+        location_parts = []
+        if filename:
+            location_parts.append(f"file={filename}")
+        if line_number:
+            location_parts.append(f"line={line_number}")
+        location = ",".join(location_parts)
         print(f"::error {location},title=Alphabetical Sort Check::{message}")
     else:
         location = f"{filename}:{line_number}:" if filename and line_number else f"{filename}:" if filename else ""
         print(f"{location} {RED}{message}{NC}")
 
-def get_file_content_lines(filename):
-    """Read file and return lines with error handling."""
-    if not os.path.isfile(filename):
-        return None, [Failure(filename, 0, f"File not found: {filename}")]
+def find_txt_files():
+    """Find all .txt files in specified directories and subdirectories."""
+    txt_files = []
+    for directory in DIRECTORIES_TO_CHECK:
+        path = Path(directory)
+        if path.exists():
+            txt_files.extend(path.rglob("*.txt"))
+        else:
+            print(f"{RED}Directory not found: '{directory}'.{NC}")
+    return txt_files
 
+def check_alphabetical_sort(filename):
+    """Check if all non-empty lines are alphabetically sorted."""
     try:
         with open(filename, 'r', encoding='utf-8') as file:
-            return file.readlines(), []
+            lines = [line.strip() for line in file if line.strip()]
     except Exception as e:
-        return None, [Failure(filename, 0, f"Error reading file: {e}")]
+        return [Failure(str(filename), None, f"Error reading file: {e}")]
 
-def extract_marker_block(lines):
-    """Extract lines between START and END markers."""
-    inside_block = False
-    block_lines = []
-    block_line_numbers = []
-    failures = []
-
-    for i, line in enumerate(lines, 1):
-        stripped_line = line.strip()
-
-        if START_MARKER in stripped_line:
-            if inside_block:
-                failures.append(Failure(None, i, "Found nested start marker"))
-            inside_block = True
-            continue
-
-        if END_MARKER in stripped_line:
-            if not inside_block:
-                failures.append(Failure(None, i, "Found end marker without start marker"))
-            else:
-                inside_block = False
-            continue
-
-        if inside_block and stripped_line and not stripped_line.startswith("//"):
-            block_lines.append(stripped_line)
-            block_line_numbers.append(i)
-
-    if inside_block:
-        failures.append(Failure(None, len(lines), "Unclosed alphabetical sorting block"))
-
-    return block_lines, block_line_numbers, failures
-
-def extract_all_content(lines):
-    """Extract all non-empty, non-comment lines."""
-    content_lines = []
-    content_line_numbers = []
-
-    for i, line in enumerate(lines, 1):
-        stripped_line = line.strip()
-        if stripped_line and not stripped_line.startswith(("//", "#")):
-            content_lines.append(stripped_line)
-            content_line_numbers.append(i)
-
-    return content_lines, content_line_numbers
-
-def check_sorting(block_lines, line_numbers, filename):
-    """Check if lines are alphabetically sorted."""
-    if not block_lines:
+    # Early return for empty files or single line files
+    if len(lines) <= 1:
         return []
 
-    sorted_lines = sorted(block_lines, key=str.lower)
-    if block_lines == sorted_lines:
-        return []
+    # Check sorting in single pass
+    for i in range(1, len(lines)):
+        if lines[i].lower() < lines[i-1].lower():
+            return [Failure(str(filename), None, f"File is not sorted alphabetically.")]
 
-    # Find first mismatch
-    for i, (current, expected) in enumerate(zip(block_lines, sorted_lines)):
-        if current.lower() != expected.lower():
-            prev_line = sorted_lines[i-1] if i > 0 else '...'
-            return [Failure(
-                filename,
-                line_numbers[i],
-                f"Alphabetical ordering violation: '{current}' should come after '{prev_line}'"
-            )]
-
-    return [Failure(filename, line_numbers[len(sorted_lines)], "Extra line at end of block")]
-
-def check_file_alphabetical(filename, use_markers=True):
-    """Check alphabetical sorting of file content."""
-    lines, failures = get_file_content_lines(filename)
-    if failures:
-        return failures
-
-    if use_markers:
-        block_lines, line_numbers, marker_failures = extract_marker_block(lines)
-        failures.extend(f for f in marker_failures if f.filename is not None)
-        # Update filename for marker failures
-        marker_failures = [Failure(filename, f.lineno, f.message) for f in marker_failures if f.filename is None]
-        failures.extend(marker_failures)
-    else:
-        block_lines, line_numbers = extract_all_content(lines)
-
-    if not failures:
-        failures.extend(check_sorting(block_lines, line_numbers, filename))
-
-    return failures
+    return []
 
 def main():
-    strings_dir = "strings/"
-    strings_txt_files = find_txt_files(strings_dir)
+    txt_files = find_txt_files()
 
-    if not strings_txt_files:
-        print(f"{BLUE}Note: No .txt files found in '{strings_dir}'{NC}")
+    if not txt_files:
+        print(f"{BLUE}No .txt files found in specified directories.{NC}")
+        return
 
-    # Determine files to check
-    files_to_check = sys.argv[1:] if len(sys.argv) > 1 else REQUIRED_FILES + strings_txt_files
+    print(f"{BLUE}Checking {len(txt_files)} files...{NC}")
 
     all_failures = []
-    checked_files = []
+    for file_path in txt_files:
+        all_failures.extend(check_alphabetical_sort(file_path))
 
-    for file_to_check in files_to_check:
-        if not os.path.isfile(file_to_check):
-            all_failures.append(Failure(file_to_check, 0, f"File not found: {file_to_check}"))
-            continue
-
-        checked_files.append(file_to_check)
-
-        # Use markerless check for .txt files in strings directory
-        use_markers = file_to_check not in strings_txt_files
-        failures = check_file_alphabetical(file_to_check, use_markers)
-        all_failures.extend(failures)
-
-    # Report results
     if all_failures:
         for failure in all_failures:
             print_error(failure.message, failure.filename, failure.lineno)
-
-        print_error(f"Found {len(all_failures)} alphabetical sorting violation(s)!")
-
-        if any(f.filename in strings_txt_files for f in all_failures):
-            print_error("Please ensure all .txt files in strings/ directory are properly sorted!")
-        if any(f.filename not in strings_txt_files for f in all_failures):
-            print_error("Please ensure all lines between sort markers are properly sorted!")
-
+        print(f"{RED}Alphabetical sorting check failed!{NC}")
         sys.exit(1)
-    else:
-        print(f"{GREEN}All files are properly sorted!{NC}")
-        print(f"{BLUE}Checked {len(checked_files)} files.{NC}")
-        #for checked_file in checked_files:
-        #    check_type = "full file" if checked_file in strings_txt_files else "marker-based"
-        #    print(f"  - {checked_file} ({check_type} check)")
+
+    print(f"{GREEN}All files are properly sorted alphabetically!{NC}")
 
 if __name__ == "__main__":
     main()

--- a/tools/ci/trait_validity.py
+++ b/tools/ci/trait_validity.py
@@ -97,11 +97,24 @@ def check_alphabetical_sort_in_global_list(filename: str) -> list[Failure]:
                         lines_before_trait = list_content[:trait_start_in_list].count('\n')
                         trait_line_num = list_line_num + lines_before_trait
 
-                        failures.append(Failure(
-                            filename,
-                            trait_line_num,
-                            f"Alphabetical ordering violation in {type_path} list: '{trait_names[i]}' should come after '{sorted_trait_names[i-1] if i > 0 else '...'}'"
-                        ))
+                        # Find where this trait should be located in the sorted list
+                        correct_position = sorted_trait_names.index(trait_names[i])
+
+                        if correct_position > 0:
+                            # Should come after the previous element in sorted list
+                            expected_previous = sorted_trait_names[correct_position - 1]
+                            failures.append(Failure(
+                                filename,
+                                trait_line_num,
+                                f"Alphabetical ordering violation in {type_path} list: '{trait_names[i]}' should come after '{expected_previous}'."
+                            ))
+                        else:
+                            # Should be first in the list
+                            failures.append(Failure(
+                                filename,
+                                trait_line_num,
+                                f"Alphabetical ordering violation in {type_path} list: '{trait_names[i]}' should be first in the list."
+                            ))
                         break
 
     return failures


### PR DESCRIPTION
## Что этот ПР делает

- Убрал проклятую идею с маркерами в алфавит чеке. Она казалась мне крутой, но на деле bruh.
- Упростил вывод ошибки в алфавит чеке до "нарушение алфавитного порядка в файле". Не вижу смысла подробного вывода ошибки в этих файлах.
- Теперь алфавит чек работает только на .txt по указанным путям. Сейчас только всё в 'strings/'.
- Починил вывод ошибки в трейт валидити, поскольку там был копипаст с ошибкой из алфавит чека :/ Теперь при ошибке корректно выводится, после какой строки на самом деле должна идти не отсортированная строка.

## Демонстрация изменений
<details><summary>Ошибка</summary>
<p>

<img width="652" height="94" alt="image" src="https://github.com/user-attachments/assets/47c5243c-6a2f-4949-af43-8f0a50cf00c2" />

</p>
</details> 
