### PR TITLE
server/bugfix: Check bitwise operator order

### DIFF
--- a/code/controllers/failsafe.dm
+++ b/code/controllers/failsafe.dm
@@ -172,7 +172,7 @@ GLOBAL_REAL(Failsafe, /datum/controller/failsafe)
 	if(. == 1) //We were able to create a new master
 		SSticker.Recover() //Recover the ticket system so the Masters runlevel gets set
 		Master.Initialize(10, FALSE, FALSE) //Need to manually start the MC, normally world.new would do this
-		to_chat(GLOB.admins, "<span class='boldnotice'>MC successfully recreated after deleting and recreating all subsystems!")
+		to_chat(GLOB.admins, span_boldnotice("MC successfully recreated after deleting and recreating all subsystems!"))
 	else
 		message_admins(span_boldannounceooc("Failed to create new MC!"))
 

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -317,7 +317,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		SS_INIT_NO_MESSAGE,
 	)
 
-	if(subsystem.flags & SS_NO_INIT || subsystem.initialized) //Don't init SSs with the corresponding flag or if they already are initialized
+	if((subsystem.flags & SS_NO_INIT) || subsystem.initialized) //Don't init SSs with the corresponding flag or if they already are initialized
+		subsystem.initialized = TRUE // set initialized to TRUE, because the value of initialized may still be checked on SS_NO_INIT subsystems as an "is this ready" check
 		return
 
 	current_initializing_subsystem = subsystem

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -168,7 +168,7 @@
 
 ///Resume our loop after being paused by pause_loop()
 /datum/move_loop/proc/resume_loop()
-	if(!controller || (status & MOVELOOP_STATUS_RUNNING|MOVELOOP_STATUS_PAUSED) != (MOVELOOP_STATUS_RUNNING|MOVELOOP_STATUS_PAUSED))
+	if(!controller || (status & (MOVELOOP_STATUS_RUNNING|MOVELOOP_STATUS_PAUSED)) != (MOVELOOP_STATUS_RUNNING|MOVELOOP_STATUS_PAUSED))
 		return
 
 	timer = world.time

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -193,7 +193,7 @@
 	implanted = BIOCHIP_IMPLANTED
 
 	if(trigger_emotes)
-		if(!(trigger_causes & BIOCHIP_EMOTE_TRIGGER_INTENTIONAL|BIOCHIP_EMOTE_TRIGGER_UNINTENTIONAL))
+		if(!(trigger_causes & (BIOCHIP_EMOTE_TRIGGER_INTENTIONAL|BIOCHIP_EMOTE_TRIGGER_UNINTENTIONAL)))
 			CRASH("Bio-chip [src] has trigger emotes defined but no trigger cause with which to use them!")
 		if(activated == BIOCHIP_ACTIVATED_PASSIVE && (trigger_causes & BIOCHIP_EMOTE_TRIGGER_INTENTIONAL))
 			CRASH("Bio-chip [src] has intentional emote triggers on a passive bio-chip")

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -1181,7 +1181,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 
 		else if(char == "'")
 			if(word != "")
-				to_chat(usr, "\red SDQL2: You have an error in your SDQL syntax, unexpected ' in query: \"<span style='color: gray;'>[query_text]</span>\" following \"<span style='color: gray;'>[word]</span>\". Please check your syntax, and try again.", confidential=TRUE)
+				to_chat(usr, span_red(" SDQL2: You have an error in your SDQL syntax, unexpected ' in query: \"<span style='color: gray;'>[query_text]</span>\" following \"<span style='color: gray;'>[word]</span>\". Please check your syntax, and try again."), confidential=TRUE)
 				return null
 
 			word = "'"
@@ -1201,7 +1201,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 					word += char
 
 			if(i > len)
-				to_chat(usr, "\red SDQL2: You have an error in your SDQL syntax, unmatched ' in query: \"<span style='color: gray;'>[query_text]</span>\". Please check your syntax, and try again.", confidential=TRUE)
+				to_chat(usr, span_red(" SDQL2: You have an error in your SDQL syntax, unmatched ' in query: \"<span style='color: gray;'>[query_text]</span>\". Please check your syntax, and try again."), confidential=TRUE)
 				return null
 
 			query_list += "[word]'"
@@ -1209,7 +1209,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 
 		else if(char == "\"")
 			if(word != "")
-				to_chat(usr, "\red SDQL2: You have an error in your SDQL syntax, unexpected \" in query: \"<span style='color: gray;'>[query_text]</span>\" following \"<span style='color: gray;'>[word]</span>\". Please check your syntax, and try again.", confidential=TRUE)
+				to_chat(usr, span_red(" SDQL2: You have an error in your SDQL syntax, unexpected \" in query: \"<span style='color: gray;'>[query_text]</span>\" following \"<span style='color: gray;'>[word]</span>\". Please check your syntax, and try again."), confidential=TRUE)
 				return null
 
 			word = "\""
@@ -1229,7 +1229,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 					word += char
 
 			if(i > len)
-				to_chat(usr, "\red SDQL2: You have an error in your SDQL syntax, unmatched \" in query: \"<span style='color: gray;'>[query_text]</span>\". Please check your syntax, and try again.", confidential=TRUE)
+				to_chat(usr, span_red(" SDQL2: You have an error in your SDQL syntax, unmatched \" in query: \"<span style='color: gray;'>[query_text]</span>\". Please check your syntax, and try again."), confidential=TRUE)
 				return null
 
 			query_list += "[word]\""

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -181,7 +181,7 @@
 		. += span_notice("К цевью прикреплен [attachments_by_slot[ATTACHMENT_SLOT_UNDER].declent_ru(NOMINATIVE)].")
 	else if(attachable_allowed & GUN_MODULE_CLASS_PISTOL_UNDER)
 		. += span_notice("Имеет маленькую планку на цевье для крепление пистолетного фонаря.")
-	else if(attachable_allowed & GUN_MODULE_CLASS_RIFLE_UNDER | attachable_allowed & GUN_MODULE_CLASS_SHOTGUN_UNDER)
+	else if(attachable_allowed & (GUN_MODULE_CLASS_RIFLE_UNDER|GUN_MODULE_CLASS_SHOTGUN_UNDER))
 		. += span_notice("Имеет большую планку на цевье для крепление большого фонаря или рукоятки.")
 
 	if(unique_reskin)

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -88,7 +88,7 @@
 	var/maxdam = 0
 	var/obj/item/organ/external/damaged_organ = null
 	for(var/obj/item/organ/external/bodypart as anything in bodyparts)
-		if((bodypart.status & ORGAN_DEAD|ORGAN_ROBOT) || bodypart.hidden_pain)
+		if((bodypart.status & (ORGAN_DEAD|ORGAN_ROBOT)) || bodypart.hidden_pain)
 			continue
 
 		var/dam = bodypart.get_damage()

--- a/tools/ci/check_grep.py
+++ b/tools/ci/check_grep.py
@@ -53,11 +53,17 @@ def check_html_tags_case(idx, line):
     if match := HTML_TAGS_UPPERCASE_RE.search(line):
         return [(idx + 1, f"HTML tag '{match.group(0)}' should be in lowercase, not uppercase.")]
 
+SUSPICIOUS_SYMBOLS = re.compile(r'[<>]')
+def check_suspicious_symbols_in_maps(idx, line):
+    if SUSPICIOUS_SYMBOLS.search(line):
+        return [(idx + 1, f"HTML code in maps detected.")]
+
 CODE_CHECKS = [
     check_non_tgm_map_format,
     check_nanotrasen_style,
     check_dash_usage,
     check_html_tags_case,
+#    check_suspicious_symbols_in_maps,
 ]
 
 def lint_file(code_filepath: str) -> list[Failure]:

--- a/tools/ci/check_grep2.py
+++ b/tools/ci/check_grep2.py
@@ -28,24 +28,26 @@ def check_515_proc_syntax(idx, line):
 CHECK_SPACE_INDENTATION_RE = re.compile(r"^( {2})|(^ [^ *])|(^ {4,})")
 def check_space_indentation(idx, line):
     """
-    Check specifically for space-significant indentation.
+    Check specifically for space-significant indentation. Excludes dmdoc
+    block comment lines so long as there is an asterisk immediately after the
+    leading spaces.
 
     >>> bool(check_space_indentation(["  foo"]))
     True
-    >>> bool(check_space_indentation(["  * foo"])) # 2 spaces + asterisk
+    >>> bool(check_space_indentation(["  * foo"]))
     True
-    >>> bool(check_space_indentation([" x"])) # 1 space + letter
+    >>> bool(check_space_indentation([" x"]))
     True
-    >>> bool(check_space_indentation(["    foo"])) # 4+ spaces
+    >>> bool(check_space_indentation(["    foo"]))
     True
-    >>> bool(check_space_indentation(["  "])) # 2 spaces only
+    >>> bool(check_space_indentation(["  "]))
     True
 
-    >>> bool(check_space_indentation(["\\tfoo"])) # tabs are fine
+    >>> bool(check_space_indentation(["\\tfoo"]))
     False
-    >>> bool(check_space_indentation([" * foo"])) # 1 space + asterisk
+    >>> bool(check_space_indentation([" * foo"]))
     False
-    >>> bool(check_space_indentation(["   foo"])) # 3 spaces (not matched)
+    >>> bool(check_space_indentation(["   foo"]))
     False
     """
     if CHECK_SPACE_INDENTATION_RE.match(line):
@@ -310,7 +312,7 @@ def check_rand_floating_point(idx, line):
 BITWISE_AMBIGUOUS_RE = re.compile(r'&[ \t]*\w+[ \t]*\|[ \t]*\w+')
 def check_bitwise_operator_order(idx, line):
     if BITWISE_AMBIGUOUS_RE.search(line):
-        return [(idx + 1, "Likely operator order mistake with bitwise OR. Use parentheses to specify intention.")]
+        return [(idx + 1, "Error in operator order when using bitwise OR. Use parentheses to indicate intent.")]
 
 CODE_CHECKS = [
     check_space_indentation,

--- a/tools/ci/check_grep2.py
+++ b/tools/ci/check_grep2.py
@@ -307,6 +307,11 @@ def check_rand_floating_point(idx, line):
     if RAND_FLOATING_POINT_NUMBERS.search(line):
         return [(idx + 1, "rand() does not support floating point numbers, use randfloat() instead.")]
 
+BITWISE_AMBIGUOUS_RE = re.compile(r'&[ \t]*\w+[ \t]*\|[ \t]*\w+')
+def check_bitwise_operator_order(idx, line):
+    if BITWISE_AMBIGUOUS_RE.search(line):
+        return [(idx + 1, "Likely operator order mistake with bitwise OR. Use parentheses to specify intention.")]
+
 CODE_CHECKS = [
     check_space_indentation,
     check_mixed_indentation,
@@ -341,6 +346,7 @@ CODE_CHECKS = [
     check_playsound_improper_call,
     check_apostrophe_name,
     check_rand_floating_point,
+    check_bitwise_operator_order,
 ]
 
 def check_updatepaths_validity():


### PR DESCRIPTION
## Что этот ПР делает
1. Пофикшено добавление ту чата в очередь, ссылка на пр в описании коммита. +1 -1
2. Добавлена проверка, чтобы избежать проблемы с битовыми операторами. `A & B|C` Можно было бы с помощью проверки поправить все выражения с операторами И/ИЛИ логическими и битовыми, поскольку порой такое нагородят без скобок, что приходится тратить ВРЕМЯ на то, чтобы вникнуть. Но mehhh..
3. Добавлена закомменченная проверка для dmm на вычищение html, когда и если у меня или кого-то дойдут руки до вычищения бумажек из кода карт.

Это, наверное, последнее изменение в грепе, поскольку я высосал отовсюду всё, что было можно. В нём остались закомменченными 2 проверки, на верблюд_кейс и istype на src. В обоих случаях мне нереально лень их внедрять + в случае камал кейса нужен будет мерж от Азиза :/
