### PR TITLE
tweak: Легкий нерф молота Ратвара

### DIFF
--- a/code/game/gamemodes/clockwork/clockwork_items.dm
+++ b/code/game/gamemodes/clockwork/clockwork_items.dm
@@ -380,14 +380,14 @@
 	icon = 'icons/obj/clockwork.dmi'
 	icon_state = "clock_hammer0"
 	slot_flags = ITEM_SLOT_BACK
-	force = 15
-	force_unwielded = 15
-	force_wielded = 35
-	armour_penetration = 40
-	throwforce = 45
+	force = 10
+	force_unwielded = 10
+	force_wielded = 30
+	armour_penetration = 35
+	throwforce = 40
 	w_class = WEIGHT_CLASS_HUGE
 	needs_permit = TRUE
-	block_chance = 40
+	block_chance = 30
 
 /obj/item/twohanded/clock_hammer/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## Что этот ПР делает

Легкий нерф молота Ратвара

Урон в одной руке понижен до 10
Урон в двух руках понижен до 30
Пробивание брони понижено до 35
Шанс блока понижен до 30%

## Почему это хорошо для игры

Игроки жалуются что молот слишком сильный, движение в сторону баланса