### PR TITLE
balance/add: Рикошет и баланс дальнего оружия

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -51,6 +51,8 @@
 #define RICOCHET_SHINY (1<<0)
 /// If the thing can reflect matter (bullets/bomb shrapnel)
 #define RICOCHET_HARD (1<<1)
+/// If the thing can reflect ballistic bullets with low chance
+#define RICOCHET_BALLISTIC (1<<2)
 
 //Reagent flags
 #define REAGENT_NOREACT 1

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1662,7 +1662,7 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	var/turf/p_turf = get_turf(ricocheting_projectile)
 	var/face_direction = get_dir(src, p_turf) || get_dir(src, ricocheting_projectile)
 	var/face_angle = dir2angle(face_direction)
-	var/incidence_s = GET_ANGLE_OF_INCIDENCE(face_angle, (ricocheting_projectile.Angle + 180))
+	var/incidence_s = GET_ANGLE_OF_INCIDENCE(face_angle, (ricocheting_projectile.Angle + 180 + rand(-30, 30)))
 	var/a_incidence_s = abs(incidence_s)
 	if(a_incidence_s > 90 && a_incidence_s < 270)
 		return FALSE

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -22,6 +22,8 @@
 	explosion_block = 1
 	explosion_vertical_block = 1
 
+	flags_ricochet = RICOCHET_BALLISTIC
+
 	thermal_conductivity = WALL_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 312500 //a little over 5 cm thick , 312500 for 1 m by 2.5 m by 0.25 m plasteel wall
 

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -237,7 +237,7 @@
 	icon_state = "shuttle-0"
 	base_icon_state = "shuttle"
 	explosion_block = 3
-	flags_ricochet = RICOCHET_SHINY | RICOCHET_HARD
+	flags_ricochet = RICOCHET_SHINY | RICOCHET_HARD | RICOCHET_BALLISTIC
 	sheet_type = /obj/item/stack/sheet/mineral/titanium
 	smooth = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	canSmoothWith = SMOOTH_GROUP_TITANIUM_WALLS + SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE + SMOOTH_GROUP_AIRLOCK

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -74,6 +74,7 @@
 
 /obj/projectile/bullet/saw/weak
 	damage = 30
+	ricochet_chance = 10
 
 /obj/projectile/bullet/saw/bleeding
 	damage = 20
@@ -88,6 +89,7 @@
 /obj/projectile/bullet/saw/hollow
 	damage = 60
 	armour_penetration = -10
+	ricochets_max = 0
 
 /obj/projectile/bullet/saw/ap
 	damage = 40

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -391,7 +391,6 @@
 	icon_state = ".50exp"
 
 /obj/projectile/bullet/sniper/explosive/a338
-	ricochets_max = 0
 
 //hemorrhage ammo
 /obj/item/ammo_box/magazine/a338/haemorrhage

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -163,6 +163,7 @@
 	stun = 6 SECONDS
 	dismemberment = 0
 	weaken = 6 SECONDS
+	ricochets_max = 0
 
 /obj/projectile/bullet/sniper/explosive/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && (!ismob(target, /mob/living) && breakthings))
@@ -390,6 +391,7 @@
 	icon_state = ".50exp"
 
 /obj/projectile/bullet/sniper/explosive/a338
+	ricochets_max = 0
 
 //hemorrhage ammo
 /obj/item/ammo_box/magazine/a338/haemorrhage

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -500,6 +500,9 @@
 	if((flag == BOMB || flag == BULLET) && (A.flags_ricochet & RICOCHET_HARD))
 		return TRUE
 
+	if(flag == BULLET && (A.flags_ricochet & RICOCHET_BALLISTIC))
+		return TRUE
+
 	return FALSE
 
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -2,7 +2,7 @@
 	name = "laser"
 	icon_state = "laser"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	damage = 20
+	damage = 23
 	damage_type = BURN
 	hitsound = 'sound/weapons/sear.ogg'
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'
@@ -29,7 +29,7 @@
 /obj/projectile/beam/laser
 
 /obj/projectile/beam/laser/light
-	damage = 15
+	damage = 18
 
 /obj/projectile/beam/laser/heavylaser
 	name = "heavy laser"
@@ -210,7 +210,7 @@
 /obj/projectile/beam/emitter
 	name = "emitter beam"
 	icon_state = "emitter"
-	damage = 30
+	damage = 33
 	hitsound = 'sound/weapons/resonator_blast.ogg'
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -17,10 +17,10 @@
 
 /obj/projectile/bullet/slug
 	armour_penetration = 40
-	damage = 30
+	damage = 33
 
 /obj/projectile/bullet/desert_eagle
-	stamina = 30
+	stamina = 33
 
 /obj/projectile/bullet/weakbullet //beanbag, heavy stamina damage
 	name = "beanbag slug"
@@ -106,9 +106,11 @@
 	nodamage = TRUE
 	log_override = TRUE
 
+//9mm bullet casing
 /obj/projectile/bullet/weakbullet3
-	damage = 20
+	damage = 23
 
+//4.6x30mm bullet casing
 /obj/projectile/bullet/weakbullet3/foursix
 	damage = 15
 
@@ -121,8 +123,9 @@
 	damage_type = TOX
 	armour_penetration = 10
 
+//40nr bullet casing
 /obj/projectile/bullet/weakbullet3/fortynr
-	damage = 25
+	damage = 28
 	stamina = 20
 
 /obj/projectile/bullet/weakbullet3/fortynr/get_ru_names()
@@ -151,9 +154,10 @@
 		PREPOSITIONAL = "резиновой пуле"
 	)
 
+//45 N&R bullet casing
 /obj/projectile/bullet/weakbullet4/c45nr
 	name = "45 N&R"
-	damage = 10
+	damage = 12
 	stamina = 15
 
 /obj/projectile/bullet/toxinbullet
@@ -177,7 +181,7 @@
 	armour_penetration = 10
 
 /obj/projectile/bullet/armourpiercing
-	damage = 17
+	damage = 18
 	armour_penetration = 10
 
 /obj/projectile/bullet/pellet
@@ -281,23 +285,27 @@
 	do_sparks(3, TRUE, src)
 	..()
 
+//.45 bullet casing
 /obj/projectile/bullet/midbullet
-	damage = 20
+	damage = 23
 	stamina = 33 //four rounds from the c20r knocks people down
 
 /obj/projectile/bullet/midbullet_AC2S
-	damage = 20
+	damage = 23
 	stamina = 40 //three rounds from the AC 2 Special knocks people down
 
+//.45 rubber bullet casing
 /obj/projectile/bullet/midbullet_r
 	damage = 5
 	stamina = 33 //Still four rounds to knock people down
 
+//.36 bullet casing
 /obj/projectile/bullet/midbullet2
 	damage = 25
 
+//10mm bullet casing
 /obj/projectile/bullet/midbullet3
-	damage = 30
+	damage = 33
 
 /obj/projectile/bullet/midbullet3/hp
 	damage = 50
@@ -318,8 +326,9 @@
 		M.adjust_fire_stacks(1)
 		M.IgniteMob()
 
+//5.56mm bullet casing
 /obj/projectile/bullet/heavybullet
-	damage = 35
+	damage = 36
 
 /obj/projectile/bullet/stunshot	//taser slugs for shotguns, nothing special
 	name = "stunshot"
@@ -562,7 +571,7 @@
 
 /obj/projectile/bullet/f545 // Rusted AK
 	name = "Fusty FMJ 5.45 bullet"
-	damage = 18
+	damage = 20
 	stamina = 6
 
 /obj/projectile/bullet/f545/get_ru_names()
@@ -577,7 +586,7 @@
 
 /obj/projectile/bullet/ftt762 // Rusted PPSh
 	name = "Fusty FMJ 7.62 TT bullet"
-	damage = 8
+	damage = 9
 	stamina = 1
 	armour_penetration = 5
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -4,6 +4,8 @@
 	hitsound = SFX_BULLET
 	hitsound_wall = SFX_RICOCHET
 	impact_effect_type = /obj/effect/temp_visual/impact_effect
+	ricochets_max = 1
+	ricochet_chance = 5
 
 /obj/projectile/bullet/get_ru_names()
 	return list(
@@ -15,17 +17,24 @@
 		PREPOSITIONAL = "пуле"
 	)
 
+/obj/projectile/bullet/on_ricochet(atom/A)
+	. = ..()
+	damage = damage / 2
+	stamina = stamina / 2
+
 /obj/projectile/bullet/slug
 	armour_penetration = 40
 	damage = 33
 
 /obj/projectile/bullet/desert_eagle
 	stamina = 33
+	ricochet_chance = 10
 
 /obj/projectile/bullet/weakbullet //beanbag, heavy stamina damage
 	name = "beanbag slug"
 	damage = 5
 	stamina = 55
+	ricochet_chance = 20 //rubber bullets - high ricochet chance
 
 /obj/projectile/bullet/weakbullet/get_ru_names()
 	return list(
@@ -62,6 +71,7 @@
 	damage = 5
 	stamina = 35
 	icon_state = "bullet-r"
+	ricochet_chance = 20
 
 /obj/projectile/bullet/weakbullet2/get_ru_names()
 	return list(
@@ -76,6 +86,7 @@
 /obj/projectile/bullet/hp38 //Detective hollow-point
 	damage = 33
 	armour_penetration = -50
+	ricochets_max = 0 //no ricochets for HP
 
 /obj/projectile/bullet/hp38/on_hit(atom/target, blocked, hit_zone)
 	if(..(target, blocked))
@@ -109,6 +120,7 @@
 //9mm bullet casing
 /obj/projectile/bullet/weakbullet3
 	damage = 23
+	ricochet_chance = 10
 
 //4.6x30mm bullet casing
 /obj/projectile/bullet/weakbullet3/foursix
@@ -127,6 +139,7 @@
 /obj/projectile/bullet/weakbullet3/fortynr
 	damage = 28
 	stamina = 20
+	ricochet_chance = 10
 
 /obj/projectile/bullet/weakbullet3/fortynr/get_ru_names()
 	return list(
@@ -143,6 +156,7 @@
 	damage = 5
 	stamina = 30
 	icon_state = "bullet-r"
+	ricochet_chance = 20
 
 /obj/projectile/bullet/weakbullet4/get_ru_names()
 	return list(
@@ -159,6 +173,7 @@
 	name = "45 N&R"
 	damage = 12
 	stamina = 15
+	ricochet_chance = 10
 
 /obj/projectile/bullet/toxinbullet
 	damage = 15
@@ -190,6 +205,7 @@
 	tile_dropoff = 0.75
 	tile_dropoff_s = 1.25
 	armour_penetration = -20
+	ricochets_max = 0
 
 /obj/projectile/bullet/pellet/get_ru_names()
 	return list(
@@ -237,6 +253,8 @@
 	damage = 3
 	stamina = 15
 	icon_state = "bullet-r"
+	ricochets_max = 1
+	ricochet_chance = 20
 
 /obj/projectile/bullet/pellet/rubber/get_ru_names()
 	return list(
@@ -298,18 +316,22 @@
 /obj/projectile/bullet/midbullet_r
 	damage = 5
 	stamina = 33 //Still four rounds to knock people down
+	ricochet_chance = 20
 
 //.36 bullet casing
 /obj/projectile/bullet/midbullet2
 	damage = 25
+	ricochet_chance = 10
 
 //10mm bullet casing
 /obj/projectile/bullet/midbullet3
 	damage = 33
+	ricochet_chance = 10
 
 /obj/projectile/bullet/midbullet3/hp
 	damage = 50
 	armour_penetration = -50
+	ricochets_max = 0
 
 /obj/projectile/bullet/midbullet3/hp/on_hit(atom/target, blocked, hit_zone)
 	if(..(target, blocked))
@@ -340,6 +362,7 @@
 	range = 7
 	icon_state = "spark"
 	color = "#FFFF00"
+	ricochets_max = 0
 
 /obj/projectile/bullet/stunshot/get_ru_names()
 	return list(
@@ -417,6 +440,7 @@
 	damage = 30
 	weaken = 4 SECONDS
 	hitsound = 'sound/effects/meteorimpact.ogg'
+	ricochets_max = 0
 
 /obj/projectile/bullet/meteorshot/get_ru_names()
 	return list(
@@ -470,6 +494,7 @@
 	damage = 6
 	var/volume = 50
 	var/piercing = FALSE
+	ricochets_max = 0
 
 /obj/projectile/bullet/dart/get_ru_names()
 	return list(
@@ -589,6 +614,7 @@
 	damage = 9
 	stamina = 1
 	armour_penetration = 5
+	ricochet_chance = 10
 
 /obj/projectile/bullet/ftt762/get_ru_names()
 	return list(

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -150,7 +150,6 @@
 /obj/projectile/bullet/weakbullet3/fortynr
 	damage = 28
 	stamina = 20
-	ricochet_chance = 10
 
 /obj/projectile/bullet/weakbullet3/fortynr/get_ru_names()
 	return list(

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -22,6 +22,17 @@
 	damage = damage / 2
 	stamina = stamina / 2
 
+/obj/projectile/bullet/on_hit(atom/target, blocked = 0)
+	. = ..()
+	if(!.)
+		return
+	if(!ismob(target))
+		return
+	var/datum/gun_recoil/recoil = GLOB.mob_hit_recoil
+	var/shot_angle = get_angle(firer, target)
+	var/rand_angle = (rand() - 0.5) * recoil.angle + shot_angle
+	recoil_camera(target, recoil.strength, recoil.in_duration, recoil.back_duration, rand_angle)
+
 /obj/projectile/bullet/slug
 	armour_penetration = 40
 	damage = 33

--- a/code/modules/projectiles/projectile/reusable.dm
+++ b/code/modules/projectiles/projectile/reusable.dm
@@ -4,6 +4,7 @@
 	var/ammo_type = /obj/item/ammo_casing/caseless/
 	var/dropped = 0
 	impact_effect_type = null
+	ricochets_max = 0
 
 /obj/projectile/bullet/reusable/get_ru_names()
 	return list(

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -34,6 +34,7 @@
 /obj/projectile/bullet/gyro
 	name ="explosive bolt"
 	icon_state= "bolter"
+	ricochets_max = 0
 
 /obj/projectile/bullet/gyro/get_ru_names()
 	return list(
@@ -55,6 +56,7 @@
 	desc = "USE A WEEL GUN"
 	icon_state= "bolter"
 	damage = 60
+	ricochets_max = 0
 
 /obj/projectile/bullet/a40mm/get_ru_names()
 	return list(
@@ -455,6 +457,7 @@
 	name ="explosive slug"
 	damage = 20
 	knockdown = 5 SECONDS
+	ricochets_max = 0
 
 /obj/projectile/bullet/frag12/get_ru_names()
 	return list(

--- a/code/modules/projectiles/recoil.dm
+++ b/code/modules/projectiles/recoil.dm
@@ -1,3 +1,6 @@
+//Recoil for mob hit
+GLOBAL_DATUM_INIT(mob_hit_recoil, /datum/gun_recoil, GUN_RECOIL_LOW)
+
 /datum/gun_recoil
 	/// Recoil strength in tile size (32 pixels)
 	var/strength
@@ -46,7 +49,7 @@
 	recoil_camera(user, recoil.strength, recoil.in_duration, recoil.back_duration, rand_angle)
 
 /proc/recoil_camera(mob/user, strength, duration, backtime_duration, angle)
-	if(!user || !user.client)
+	if(!user || !istype(user) || !user.client)
 		return
 	var/client/sufferer = user.client
 	strength *= ICON_SIZE_ALL


### PR DESCRIPTION
## Что этот ПР делает

1. Увеличение урона многим `/obj/projectile/bullet` и `/obj/projectile/energy` (*увеличение урона максимум до 3 у пуль с уроном меньше 35, дробь и резиновые пули не трогал*)
2. Рикошет от стен для баллистики (*5% шанс для винтовочных пуль, 10% для пистолетных и 20% для резиновых пуль, дробь и экспансивки не рикошетят*). После рикошета пуля теряет половину урона (*стамина и брут урон*), может рикошетить только один раз. При рикошете пуля отклоняется на +-30 градусов случайно.
3. Тряска экрана когда по кукле попали с баллистики (*уникальный механ для баллистики, у лазера есть замыливание зрения, сила тряски экрана - low как у пистолетов*).

## Почему это хорошо для игры

1. Немного апаем дальнобойное оружие, которое сильно занерфлено после промахов и разбросов.
2. Добавление прикольного механа рикошетов, офицерам надо будет думать прежде чем палить в людном месте (*будут ведь думать?*)
3. Новая фишка баллистики с тряской экрана при попадании, ну типа немного трясет при попадании пули, да и почему только у лазера есть фишка с замыливанием зрения? Несправедливо.


## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>


https://github.com/user-attachments/assets/e8ff29c4-5b5b-450b-88fc-45d015cf0d04

https://github.com/user-attachments/assets/45268e73-e263-4149-aae0-5d5f399d16bf

https://github.com/user-attachments/assets/8f818925-798b-4ea6-b8ff-ebe5e22a642c

https://github.com/user-attachments/assets/21d69e82-ab83-43b1-98ad-4585646b3ae0

</p>
</details>

## Тестирование

Проверил на локалке.
Наверное можно и без тестмержа, если что быстро откачу 🙂 