### PR TITLE
tweak: Осмотр куклы на правую кнопку мыши

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -996,6 +996,20 @@
 		balloon_alert(usr, "пульс замерен")
 
 
+/mob/living/carbon/human/verb/begin_strip()
+	set name = "Осмотреть"
+	set desc = "Осмотреть цель."
+	set src in view(1)
+
+	if(!isliving(usr) || usr.incapacitated() || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
+		return
+
+	if(usr == src)
+		check_self_for_injuries()
+		return
+
+	SEND_SIGNAL(src, COMSIG_DO_MOB_STRIP, usr, usr)
+
 /**
  * Set up DNA and species.
  *

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -997,8 +997,8 @@
 
 
 /mob/living/carbon/human/verb/begin_strip()
-	set name = "Осмотреть"
-	set desc = "Осмотреть цель."
+	set name = "Обычкать"
+	set desc = "Обыскать цель."
 	set src in view(1)
 
 	if(!isliving(usr) || usr.incapacitated() || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -997,7 +997,7 @@
 
 
 /mob/living/carbon/human/verb/begin_strip()
-	set name = "Обычкать"
+	set name = "Обыскать"
 	set desc = "Обыскать цель."
 	set src in view(1)
 


### PR DESCRIPTION
## Что этот ПР делает

Добавлено "Осмотреть" на парвую кнопку мыши для все `/mob/living/carbon/human`.

При использовании открывает меню раздевания (*осмотра*).
При использовании на себе выполняет самопроверку на ранения (*в крите сейчас невозможно проверку на ранения делать, с этой штукой уже можно будет*).

## Почему это хорошо для игры

QoL и альтернативный вариант раздевания без перетаскивания. 
Ну и Кисик просил: https://discord.com/channels/617003227182792704/1427206998859972659/1427206998859972659

## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>

<img width="689" height="760" alt="image" src="https://github.com/user-attachments/assets/c7b3a3e8-294b-489b-8894-d9e903bf6df6" />


</p>
</details>

## Тестирование

Локалка, все ок.
