### PR TITLE
tweak: Использование радиального меню при попытке вытащить модуль с оружия

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -671,10 +671,14 @@
 		if(!attachments_by_slot[slot])
 			continue
 		var/obj/item/gun_module/module = attachments_by_slot[slot]
-		choices += module.declent_ru(NOMINATIVE)
+		choices[module.declent_ru(NOMINATIVE)] = image(icon = module.icon, icon_state = module.icon_state)
 	if(length(choices) == 0)
 		return
-	var/choice = tgui_input_list(user, "Выберите модуль, который хотите снять", "Снять модуль", choices, choices[1], 0, GLOB.conscious_state)
+	var/choice = choices[1]
+	if(length(choices) > 1)
+		choice = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, PROC_REF(reskin_radial_check), user), require_near = TRUE)
+	if(!choice)
+		return FALSE
 	for(var/slot in attachments_by_slot)
 		if(!attachments_by_slot[slot])
 			continue


### PR DESCRIPTION
## Что этот ПР делает

Замена выбора модуля через список на выбор через радиальное меню (*кто не понял смотрите картинку демонстрации*).

## Почему это хорошо для игры

Более удобный вариант выбора модуля для отсоединения. Выбор через список требует два клика для выбора, а радиальное меню требует один клик.

## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>

<img width="495" height="436" alt="image" src="https://github.com/user-attachments/assets/0104de98-5a31-4462-81ac-d59d4e4110fe" />

</p>
</details>

## Тестирование

Локалка.
