### PR TITLE
tweak: Убрать сб модуль у станционных киборгов

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -345,8 +345,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			"Medical" = /obj/item/robot_module/medical,
 			"Miner" = /obj/item/robot_module/miner,
 			"Janitor" = /obj/item/robot_module/janitor,
-			"Service" = /obj/item/robot_module/butler,
-			"Security" = /obj/item/robot_module/security
+			"Service" = /obj/item/robot_module/butler
 		)
 
 	if(islist(limited_modules) && LAZYLEN(limited_modules))


### PR DESCRIPTION
## Что этот ПР делает

Убирает станционным киборгам возможность выбрать сб модуль

## Почему это хорошо для игры

Единственное отличие киборгов с данным модулем от стандартного сб это возможность забить на срп сб и вообще забыть о существовании кнопки say, не выдавая ни ареста, ни сейлогов при аресте. Я считаю что не следует пояснять почему металлический офицер который может гонять по техам в зк, вязать вообще без слов и без статуса, а дубинку которого физически нельзя выбить из рук - не очень хороший для станции вариант киборга. антагам может это мешает и не сильно, но страдает тут скорее обычный экипаж который в большинстве случаев не может ничего противопоставить щитурити боргу. помимо этого добавлю что большинство сб боргов забивают на законы и идут просто выполнять работу сб.

## Тестирование

Локалка
