### PR TITLE
balance: Добавлен шанс на Knockdown при использовании огнетушителя для ускорения

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -147,10 +147,10 @@
 		var/movementdirection = REVERSE_DIR(direction)
 		addtimer(CALLBACK(src, PROC_REF(move_chair), user.buckled, movementdirection), 0.1 SECONDS)
 		if(prob(20))
-			var/mob/living/carbon/human/human = user
 			user.buckled.unbuckle_mob(user)
-			if(istype(human))
-				human.Knockdown(1 SECONDS)
+			var/mob/living/living = user
+			if(istype(living))
+				living.Knockdown(1 SECONDS)
 	else
 		user.newtonian_move(REVERSE_DIR(direction))
 

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -146,6 +146,11 @@
 	if(user.buckled && isobj(user.buckled) && !user.buckled.anchored)
 		var/movementdirection = REVERSE_DIR(direction)
 		addtimer(CALLBACK(src, PROC_REF(move_chair), user.buckled, movementdirection), 0.1 SECONDS)
+		if(prob(20))
+			var/mob/living/carbon/human/human = user
+			user.buckled.unbuckle_mob(user)
+			if(istype(human))
+				human.Knockdown(1 SECONDS)
 	else
 		user.newtonian_move(REVERSE_DIR(direction))
 


### PR DESCRIPTION
## Что этот ПР делает

Добавляет 15% шанс на Knockdown в 1 секунду при попытке ускориться с помощью огнетушителя на транспорте (*любой предмет на который можно сесть - buckled*).

## Почему это хорошо для игры

Маленький нерф калового механа с помощью которого можно убежать от кого угодно.

## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>

Лень снимать видос, но шанс 15% не такой большой.

</p>
</details>

## Тестирование

Проверил на локалке.
