### PR TITLE
bugfix: Исправлен баг с сообщением в чате о том какое пда снимается при раздевании

### DIFF
--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -158,7 +158,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 		source.visible_message(
 			span_warning("[user] пыта[PLUR_ET_YUT(user)]ся снять КПК с [source.declent_ru(GENITIVE)]."),
 			span_userdanger("[user] пыта[PLUR_ET_YUT(user)]ся снять с вас [item.declent_ru(ACCUSATIVE)]!"),
-			"Слышно шуршание."
+			span_hear("Вы слышите звуки шуршания.")
 		)
 
 	to_chat(user, span_danger("Вы пытаетесь снять КПК с [source.declent_ru(GENITIVE)]..."))
@@ -168,7 +168,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	if(ishuman(source))
 		var/mob/living/carbon/human/victim_human = source
 		if(!victim_human.has_vision())
-			to_chat(source, span_userdanger("Вы чувствуете, как кто-то копается в ваших вещах."))
+			to_chat(source, span_userdanger("Вы чувствуете, как кто-то пытается что-то с вас снять!"))
 
 	return start_unequip_mob(get_item(source), source, user)
 

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -156,12 +156,12 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 
 	if(!in_thief_mode(user))
 		source.visible_message(
-			span_warning("[user] пыта[PLUR_ET_YUT(user)]ся снять PDA с [source.declent_ru(GENITIVE)]."),
+			span_warning("[user] пыта[PLUR_ET_YUT(user)]ся снять КПК с [source.declent_ru(GENITIVE)]."),
 			span_userdanger("[user] пыта[PLUR_ET_YUT(user)]ся снять с вас [item.declent_ru(ACCUSATIVE)]!"),
 			"Слышно шуршание."
 		)
 
-	to_chat(user, span_danger("Вы пытаетесь снять PDA с [source.declent_ru(GENITIVE)]..."))
+	to_chat(user, span_danger("Вы пытаетесь снять КПК с [source.declent_ru(GENITIVE)]..."))
 	add_attack_logs(user, source, "Attempting stripping of [item]")
 	item.add_fingerprint(user)
 

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -149,6 +149,29 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 		? STRIPPABLE_OBSCURING_NONE \
 		: STRIPPABLE_OBSCURING_HIDDEN
 
+/datum/strippable_item/mob_item_slot/pda/start_unequip(atom/source, mob/user)
+	var/obj/item/item = get_item(source)
+	if(isnull(item))
+		return FALSE
+
+	if(!in_thief_mode(user))
+		source.visible_message(
+			span_warning("[user] пыта[PLUR_ET_YUT(user)]ся снять PDA с [source.declent_ru(GENITIVE)]."),
+			span_userdanger("[user] пыта[PLUR_ET_YUT(user)]ся снять с вас [item.declent_ru(ACCUSATIVE)]!"),
+			"Слышно шуршание."
+		)
+
+	to_chat(user, span_danger("Вы пытаетесь снять PDA с [source.declent_ru(GENITIVE)]..."))
+	add_attack_logs(user, source, "Attempting stripping of [item]")
+	item.add_fingerprint(user)
+
+	if(ishuman(source))
+		var/mob/living/carbon/human/victim_human = source
+		if(!victim_human.has_vision())
+			to_chat(source, span_userdanger("Вы чувствуете, как кто-то копается в ваших вещах."))
+
+	return start_unequip_mob(get_item(source), source, user)
+
 /datum/strippable_item/mob_item_slot/belt
 	key = STRIPPABLE_ITEM_BELT
 	item_slot = ITEM_SLOT_BELT


### PR DESCRIPTION
## Что этот ПР делает

Удаляет сообщение о том какой предмет снимается при раздевании со слота пда.

## Почему это хорошо для игры

Можно использовать попытку снятия предмета со слота пда чтобы увидеть какое именно пда находится внутри слота.

## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>

Вот так показывает окно раздевания (*пда скрыто*): 
<img width="1052" height="414" alt="image" src="https://github.com/user-attachments/assets/9cc45c3e-febf-43a2-b000-7f867dc20bbc" />

А вот такое сообщение показывается при попытке снять пда (*сразу видно какой предмет снимается*): 
<img width="541" height="50" alt="image" src="https://github.com/user-attachments/assets/65a2f63a-997b-4338-811f-950e785d0a7f" />

А вот так теперь выглядит сообщение при попытке снятия: 
<img width="393" height="48" alt="image" src="https://github.com/user-attachments/assets/9e8d713e-befc-4cb9-98d0-34346e8bf77d" />

</p>
</details>

## Тестирование

Проверил на локалке.
