### PR TITLE
bugfix: Исправление бага с печатью магазина на новую ПП искру

### DIFF
--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -1231,6 +1231,9 @@
 	caliber = CALIBER_LASER
 	max_ammo = 12
 
+/obj/item/ammo_box/magazine/lr30mag/empty
+	start_empty = TRUE
+
 /obj/item/ammo_box/magazine/lr30mag/get_ru_names()
 	return list(
 		NOMINATIVE = "автоматный магазин LR-30 (лазерный)",

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -821,7 +821,7 @@
 	id = "sparkle-a12-9mm"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 3000)
-	build_path = /obj/item/ammo_box/magazine/sp91rc/empty
+	build_path = /obj/item/ammo_box/magazine/sparkle_a12/empty
 	category = list("hacked", "Security")
 
 /datum/design/buckshot_shell

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -179,8 +179,8 @@
 	id = "lmag"
 	build_type = PROTOLATHE | AUTOLATHE
 	req_tech = list("combat" = 4, "powerstorage" = 4)
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 2000)
-	build_path = /obj/item/ammo_box/magazine/lr30mag
+	materials = list(MAT_METAL = 2000)
+	build_path = /obj/item/ammo_box/magazine/lr30mag/empty
 	category = list("Weapons", "hacked", "Security")
 
 /datum/design/lmag_box


### PR DESCRIPTION
## Что этот ПР делает

1. Теперь в автолате нормально печатается магазин пп искры.
2. Магазины к Lr-30 теперь печатаются пустыми.

## Почему это хорошо для игры

Проебался чутка, не дотестил. Ну и убрал баг с дюпом металла через магазы к лрке

## Демонстрация изменений

## Тестирование

В автолате теперь нормальный магаз печатается, пустой.
