### PR TITLE
bugfix: Удаление механоебства с полным лечением при смене формы с низшего на высший и обратно

### DIFF
--- a/code/game/dna/genes/monkey.dm
+++ b/code/game/dna/genes/monkey.dm
@@ -21,7 +21,7 @@
 	mutant.invisibility = INVISIBILITY_ABSTRACT
 	var/has_primitive_form = mutant.dna.species.primitive_form // cache this
 	if(has_primitive_form)
-		mutant.set_species(has_primitive_form, keep_missing_bodyparts = TRUE)
+		mutant.set_species(has_primitive_form, retain_damage = TRUE, keep_missing_bodyparts = TRUE)
 
 	new /obj/effect/temp_visual/monkeyify(mutant.loc)
 	sleep(2.2 SECONDS)
@@ -50,7 +50,7 @@
 	mutant.invisibility = INVISIBILITY_ABSTRACT
 	var/has_greater_form = mutant.dna.species.greater_form //cache this
 	if(has_greater_form)
-		mutant.set_species(has_greater_form, keep_missing_bodyparts = TRUE)
+		mutant.set_species(has_greater_form, retain_damage = TRUE, keep_missing_bodyparts = TRUE)
 
 	new /obj/effect/temp_visual/monkeyify/humanify(mutant.loc)
 	sleep(2.2 SECONDS)


### PR DESCRIPTION
## Что этот ПР делает

Добавлено сохранение урона при смене формы с низжшего на высший и обратно.

## Почему это хорошо для игры

Больше нельзя полностью вылечить куклу за два днк иньектора. Меньше механоебства в игре.

## Демонстрация изменений

<!-- Заполните, если Вы меняли спрайты, карту или ваши изменения требуют визуальной демонстрации изменений. -->
<details><summary>Демонстрации изменений</summary>
<p>

Вот кукла с уроном:
<img width="496" height="578" alt="image" src="https://github.com/user-attachments/assets/4960efbd-ecd7-4ce4-a936-caadccc81022" />

Вот его превратил в монке форму:
<img width="487" height="581" alt="image" src="https://github.com/user-attachments/assets/8eb7c123-cfe2-4bfc-b327-b35b27528e18" />

А вот его обратно в хуман форму:
<img width="496" height="579" alt="image" src="https://github.com/user-attachments/assets/5081aadc-97f9-4b03-9928-8db59b2ff4bf" />

Ну и вот так проводились тесты:
<img width="291" height="290" alt="image" src="https://github.com/user-attachments/assets/ff5e83a9-d991-46e6-809b-b8f204c936db" />

</p>
</details>

## Тестирование

Проверил на локалке.
