### PR TITLE
balance: врины неуязвимы к космосу

### DIFF
--- a/code/modules/mob/living/carbon/human/species/wryn.dm
+++ b/code/modules/mob/living/carbon/human/species/wryn.dm
@@ -16,9 +16,9 @@
 	first names, these names are generally simplistic and easy to pronounce. Wryn have rarely had to communicate using their mouths, \
 	so in order to integrate with the multi-species crew they have been taught broken sol?."
 
-	cold_level_1 = 200 //Default 260 - Lower is better
-	cold_level_2 = 150 //Default 200
-	cold_level_3 = 115 //Default 120
+	cold_level_1 = -200 //Default 260 - Lower is better
+	cold_level_2 = -150 //Default 200
+	cold_level_3 = -115 //Default 120
 
 	heat_level_1 = 300 //Default 360 - Higher is better
 	heat_level_2 = 310 //Default 400

--- a/code/modules/mob/living/carbon/human/species/wryn.dm
+++ b/code/modules/mob/living/carbon/human/species/wryn.dm
@@ -16,9 +16,9 @@
 	first names, these names are generally simplistic and easy to pronounce. Wryn have rarely had to communicate using their mouths, \
 	so in order to integrate with the multi-species crew they have been taught broken sol?."
 
-	cold_level_1 = -200 //Default 260 - Lower is better
-	cold_level_2 = -150 //Default 200
-	cold_level_3 = -115 //Default 120
+	cold_level_1 = 200 //Default 260 - Lower is better
+	cold_level_2 = 150 //Default 200
+	cold_level_3 = 115 //Default 120
 
 	heat_level_1 = 300 //Default 360 - Higher is better
 	heat_level_2 = 310 //Default 400
@@ -60,6 +60,7 @@
 		TRAIT_NO_SCAN,
 		TRAIT_TEMPERATURE_MOVEMENT,
 		TRAIT_STRONG_PULLING,
+		TRAIT_RESIST_COLD,
 	)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | HAS_BODY_ACCESSORY


### PR DESCRIPTION
## Что этот ПР делает
дает неуязвимость вринам к космосу

## Почему это хорошо для игры
вринам не нужен больше раковый геймплей через кофе что бы путишествовать по космосу

## Демонстрация изменений

<img width="936" height="898" alt="Снимок экрана 2025-11-13 005439" src="https://github.com/user-attachments/assets/841170a3-afe6-4287-9246-c08313231e75" />
<img width="944" height="938" alt="Снимок экрана 2025-11-13 005451" src="https://github.com/user-attachments/assets/1256871e-d020-40d5-8438-c1c0a7698025" />
<img width="928" height="883" alt="Снимок экрана 2025-11-13 005459" src="https://github.com/user-attachments/assets/97db2a3e-7429-49e3-8d76-728759a299cb" />
