### PR TITLE
bugfix: persistent_client fix

### DIFF
--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -16,6 +16,7 @@
 		cling.calculate_stasis_delay(user)
 		user.emote("deathgasp")
 		user.timeofdeath = world.time
+		user.persistent_client?.time_of_death = world.time
 
 	ADD_TRAIT(user, TRAIT_FAKEDEATH, CHANGELING_TRAIT)		//play dead
 	user.updatehealth("fakedeath sting")

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -56,6 +56,7 @@
 
 	set_stat(DEAD)
 	timeofdeath = world.time
+	persistent_client?.time_of_death = world.time
 	..()
 	INVOKE_ASYNC(src, PROC_REF(burst_blob_on_die))
 	var/gib_pref = ""

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -446,7 +446,7 @@
 	if(!canon_client)
 		return
 
-	for(var/datum/callback/callback as anything in persistent_client.post_logout_callbacks)
+	for(var/datum/callback/callback as anything in persistent_client?.post_logout_callbacks)
 		callback.Invoke()
 
 	if(canon_client?.movingmob)


### PR DESCRIPTION
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

<!-- Вы можете совмещать до 2-х тэгов, например, balance/tweak:
Список возможных тэгов для пр-а:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map: Вы меняете только карту.
- image: Вы добавляете/удаляете спрайты.
- sound: Вы добавляете/удаляете звуки.
- spellcheck: Вы исправили опечатку.
- local: Вы добавляете новый текст на русском или переводите на русский.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает
Исправляет баг с таймером респавна и рантайм при выходе из куклы без постоянного клиента.
<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2. В ином случае, опишите баг и его воспроизведение. -->