### PR TITLE
bugfix: фиксы кругового меню ящика для инструментов

### DIFF
--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -61,7 +61,11 @@
 
 /// Check if we can use tools inside toolbox via radial menu
 /obj/item/storage/toolbox/proc/check_for_radial_menu_availability(atom/object, mob/living/user, proximity)
+	if(user.incapacitated())
+		return FALSE
+
 	if(!proximity)
+		balloon_alert(user, "слишком далеко!")
 		return FALSE
 
 	if(ismob(object))
@@ -100,8 +104,15 @@
 
 	playsound(user, 'sound/items/handling/toolbox_open.ogg', 50)
 
-	var/obj/item/picked_item = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE, anim_speed = 0.1)
+	var/obj/item/picked_item = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, PROC_REF(check_menu), user, object), require_near = TRUE, anim_speed = 0.1)
 	if(!picked_item)
+		return
+
+	if(user.incapacitated())
+		return
+
+	if(!user.Adjacent(object))
+		balloon_alert(user, "слишком далеко!")
 		return
 
 	var/obj/item/selected
@@ -123,12 +134,13 @@
  * Runs a series of pre-checks before opening the radial menu to the user.
  *
  * Arguments:
- * * user - the mob trying to open the radial menu.
+ * * user - the mob trying to open the radial menu
+ * * object - atom we interact with
  */
-/obj/item/storage/toolbox/proc/check_menu(mob/living/user)
+/obj/item/storage/toolbox/proc/check_menu(mob/living/user, atom/object)
 	if(!istype(user))
 		return FALSE
-	if(user.incapacitated() || !user.Adjacent(src))
+	if(user.incapacitated() || !user.Adjacent(object))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

<!-- Вы можете совмещать до 2-х тэгов, например, balance/tweak:
Список возможных тэгов для пр-а:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map: Вы меняете только карту.
- image: Вы добавляете/удаляете спрайты.
- sound: Вы добавляете/удаляете звуки.
- spellcheck: Вы исправили опечатку.
- local: Вы добавляете новый текст на русском или переводите на русский.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает
Поправил логику чеков на возможность использовать инструмент из тулбокса через круговое меню. Теперь если юзер отходит от объекта, то цепь действий прерывается.

Плюс балун алёрты для удобства.
<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2. В ином случае, опишите баг и его воспроизведение. -->

## Тестирование
Йеп.
<!-- Как Вы тестировали свои изменения? Ведь тестировали? -->
