### PR TITLE
balance: Нерф урона нового ревика

### DIFF
--- a/code/datums/elements/item_skins.dm
+++ b/code/datums/elements/item_skins.dm
@@ -39,11 +39,6 @@
 	if(item.current_skin) //already exists skin, no reskin allowed
 		return
 
-	INVOKE_ASYNC(src, PROC_REF(show_select_skins_radial_menu), item, user)
-	return CLICK_ACTION_SUCCESS
-
-
-/datum/element/item_skins/proc/show_select_skins_radial_menu(obj/item/item, mob/living/carbon/human/user)
 	var/list/skin_options = list()
 	for(var/datum/item_skin_data/skin as anything in item.skins)
 		if(skin.donation_tier > user.client.donator_level)
@@ -54,6 +49,11 @@
 		to_chat(user, span_warning("Для получения скинов необходимо сделать пожертвование в Discord-сообществе проекта!"))
 		return
 
+	INVOKE_ASYNC(src, PROC_REF(show_select_skins_radial_menu), item, user, skin_options)
+	return CLICK_ACTION_SUCCESS
+
+
+/datum/element/item_skins/proc/show_select_skins_radial_menu(obj/item/item, mob/living/carbon/human/user, skin_options)
 	var/choice = show_radial_menu(user, item, skin_options, radius = 40, require_near = TRUE)
 
 	if(!choice || QDELETED(item) || !user.is_in_hands(item) || user.incapacitated() || item.current_skin)

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -43,6 +43,7 @@
 
 /obj/item/ammo_box/speedloader
 	use_bullet_type_overlay = TRUE
+	can_fast_load = FALSE
 
 /obj/item/ammo_box/speedloader/n762
 	name = "speed loader (7.62x38)"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -324,7 +324,7 @@
 	damage = 26
 
 /obj/projectile/bullet/c45colt/hp
-	damage = 28
+	damage = 35
 	armour_penetration = -50
 
 /obj/projectile/bullet/c45colt/ap

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -321,14 +321,14 @@
 	ricochet_chance = 20
 
 /obj/projectile/bullet/c45colt
-	damage = 28
+	damage = 26
 
 /obj/projectile/bullet/c45colt/hp
-	damage = 35
+	damage = 28
 	armour_penetration = -50
 
 /obj/projectile/bullet/c45colt/ap
-	damage = 20
+	damage = 18
 	armour_penetration = 30
 
 //.45 bullet casing

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -449,13 +449,6 @@
 	build_path = /obj/item/ammo_box/rubber45colt
 	category = list(PRINTER_CATEGORY_HACKED, AUTOLATHE_CATEGORY_SECURITY)
 
-/datum/design/hp45colt
-	id = "hp45colt"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 35000)
-	build_path = /obj/item/ammo_box/expansive45colt
-	category = list(PRINTER_CATEGORY_HACKED, AUTOLATHE_CATEGORY_SECURITY)
-
 /datum/design/ap45colt
 	id = "ap45colt"
 	build_type = AUTOLATHE

--- a/code/modules/research/designs/protolathe/weapon_designs.dm
+++ b/code/modules/research/designs/protolathe/weapon_designs.dm
@@ -139,6 +139,14 @@
 	materials = list(MAT_METAL = 48000, MAT_SILVER = 3000, MAT_URANIUM = 4000)
 	build_path = /obj/item/ammo_box/tox46x30mm
 
+/datum/design/hp45colt
+	id = "hp45colt"
+	req_tech = list(RESEARCH_TREE_COMBAT = 2, RESEARCH_TREE_MATERIALS = 1)
+	build_type = PROTOLATHE | AUTOLATHE
+	materials = list(MAT_METAL = 48000)
+	build_path = /obj/item/ammo_box/expansive45colt
+	category = list(PROTOLATHE_CATEGORY_WEAPON, PRINTER_CATEGORY_HACKED, AUTOLATHE_CATEGORY_SECURITY)
+
 /datum/design/lmag
 	id = "lmag"
 	build_type = PROTOLATHE | AUTOLATHE


### PR DESCRIPTION
## Что этот ПР делает

Баланс патронов для револьвера:
- Обычные 28 -> 26
- Бронебойные 20 -> 18
- Экспансивки: перемещены в протолат и увеличена цена печати

Дополнительно спидлоадеры теперь заряжаются как и магазины по пульке а также баг с невозможностью снять модули с револьвера если нет донат тира.

## Почему это хорошо для игры

Револьвер по результатам голосования получился немного выше по статам чем остальные раундстарт ганы, балансим.

## Тестирование

Локалка.
