### PR TITLE
add: Добавление прогрессбара перезарядки магазинов и спидлоадеров

### DIFF
--- a/code/__DEFINES/gun.dm
+++ b/code/__DEFINES/gun.dm
@@ -119,3 +119,6 @@ GLOBAL_LIST_INIT(gun_module_slot_ru_name, list(
 #define BULLET_TYPE_FIRE "fire"
 #define BULLET_TYPE_LASER "laser"
 #define BULLET_TYPE_DISABLER "disabler"
+
+/// Magazine reload duration
+#define GUN_MAGAZINE_RELOAD_DURATION (1 SECONDS)

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -101,6 +101,10 @@
 
 #define isgun(A) (istype(A, /obj/item/gun))
 
+#define isspeedloader(A) (istype(A, /obj/item/ammo_box/speedloader))
+
+#define isammocasing(A) (istype(A, /obj/item/ammo_casing))
+
 #define isbaton(A) (istype(A, /obj/item/melee/baton))
 
 #define is_pen(W) (istype(W, /obj/item/pen))

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -103,8 +103,6 @@
 
 #define isspeedloader(A) (istype(A, /obj/item/ammo_box/speedloader))
 
-#define isammocasing(A) (istype(A, /obj/item/ammo_casing))
-
 #define isbaton(A) (istype(A, /obj/item/melee/baton))
 
 #define is_pen(W) (istype(W, /obj/item/pen))

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -137,7 +137,6 @@
 	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
 	caliber = CALIBER_12X70
 	max_ammo = 4
-	multiload = FALSE
 
 /obj/item/ammo_box/magazine/internal/shot/ammo_count(countempties = TRUE)
 	. = 0

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -95,6 +95,7 @@
 	if(!do_after(user, GUN_MAGAZINE_RELOAD_DURATION, new_magazine, DA_IGNORE_LYING | DA_IGNORE_USER_LOC_CHANGE, interaction_key = src, max_interact_count = 1))
 		balloon_alert(user, "отменено")
 		return FALSE
+
 	if(user && !user.drop_transfer_item_to_loc(new_magazine, src, silent = TRUE))
 		return FALSE
 	. = TRUE

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -133,6 +133,20 @@
 
 	return ..()
 
+/obj/item/gun/projectile/proc/speedloader_reload(obj/item/item, mob/user)
+	. = TRUE
+	if(!isspeedloader(item) && !isammocasing(item))
+		return FALSE
+	add_fingerprint(user)
+	if(isspeedloader(item) && !do_after(user, GUN_MAGAZINE_RELOAD_DURATION, item, DA_IGNORE_LYING | DA_IGNORE_USER_LOC_CHANGE, interaction_key = src, max_interact_count = 1))
+		balloon_alert(user, "отменено")
+		return FALSE
+	var/num_loaded = magazine.reload(item, user)
+	if(!num_loaded)
+		return
+	update_icon()
+	chamber_round(FALSE)
+
 /obj/item/gun/projectile/attack_self(mob/living/user)
 	add_fingerprint(user)
 	. = ..()

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -91,17 +91,21 @@
 	return !magazine
 
 /obj/item/gun/projectile/proc/reload(obj/item/ammo_box/magazine/new_magazine, mob/user)
-	if(user && magazine.loc == user && !user.drop_transfer_item_to_loc(new_magazine, src, silent = TRUE))
+	playsound(loc, magin_sound, 50, TRUE)
+	if(!do_after(user, GUN_MAGAZINE_RELOAD_DURATION, new_magazine, DA_IGNORE_LYING | DA_IGNORE_USER_LOC_CHANGE, interaction_key = src, max_interact_count = 1))
+		balloon_alert(user, "отменено")
+		return FALSE
+	if(user && !user.drop_transfer_item_to_loc(new_magazine, src, silent = TRUE))
 		return FALSE
 	. = TRUE
 	magazine = new_magazine
 	if(magazine.loc != src)
 		magazine.forceMove(src)
-	playsound(loc, magin_sound, 50, TRUE)
 	chamber_round()
 	update_weight()
 	magazine.update_icon()
 	update_icon()
+	balloon_alert(user, "заряжено")
 
 /obj/item/gun/projectile/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/ammo_box/magazine))
@@ -114,14 +118,13 @@
 			if(!user.can_unEquip(new_magazine))
 				return ..()
 			reload(new_magazine, user)
-			balloon_alert(user, "заряжено")
 			return ATTACK_CHAIN_BLOCKED_ALL
 		if(!can_tactical)
 			balloon_alert(user, "уже заряжено!")
 			return ATTACK_CHAIN_PROCEED
 		if(!user.can_unEquip(new_magazine))
 			return ..()
-		balloon_alert(user, "заряжено")
+		balloon_alert(user, "разряжено")
 		magazine.forceMove(drop_location())
 		magazine.update_appearance(UPDATE_ICON|UPDATE_DESC)
 		magazine = null

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -32,28 +32,6 @@
 		if(GUN_BURST_MODE)
 			. += "[initial(icon_state)]burst"
 
-/obj/item/gun/projectile/automatic/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/ammo_box/magazine))
-		add_fingerprint(user)
-		var/obj/item/ammo_box/magazine/new_magazine = I
-		if(!istype(new_magazine, mag_type))
-			balloon_alert(user, "не совместимо!")
-			return ATTACK_CHAIN_PROCEED
-		if(!user.drop_transfer_item_to_loc(new_magazine, src, silent = TRUE))
-			return ..()
-		if(magazine)
-			magazine.forceMove(get_turf(src))
-			magazine.update_appearance()
-		playsound(loc, magin_sound, 50, TRUE)
-		balloon_alert(user, "заряжено")
-		magazine = new_magazine
-		chamber_round()
-		magazine.update_appearance()
-		update_appearance()
-		return ATTACK_CHAIN_BLOCKED_ALL
-
-	return ..()
-
 /obj/item/gun/projectile/automatic/ui_action_click(mob/user, datum/action/action, leftclick)
 	if(istype(action, /datum/action/item_action/toggle_firemode))
 		toggle_firemode()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -34,15 +34,19 @@
 /obj/item/gun/projectile/revolver/process_chamber(eject_casing = FALSE, empty_chamber = TRUE)
 	return ..()
 
-/obj/item/gun/projectile/revolver/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/ammo_box/speedloader) || istype(I, /obj/item/ammo_casing))
+/obj/item/gun/projectile/revolver/attackby(obj/item/item, mob/user, params)
+	if(istype(item, /obj/item/ammo_box/speedloader) || istype(item, /obj/item/ammo_casing))
 		add_fingerprint(user)
-		var/num_loaded = magazine.reload(I, user)
+		. = ATTACK_CHAIN_PROCEED
+		if(istype(item, /obj/item/ammo_box/speedloader) && !do_after(user, GUN_MAGAZINE_RELOAD_DURATION, item, DA_IGNORE_LYING | DA_IGNORE_USER_LOC_CHANGE, interaction_key = src, max_interact_count = 1))
+			balloon_alert(user, "отменено")
+			return
+		var/num_loaded = magazine.reload(item, user)
 		if(num_loaded)
 			update_icon()
 			chamber_round(FALSE)
 			return ATTACK_CHAIN_BLOCKED_ALL
-		return ATTACK_CHAIN_PROCEED
+		return
 
 	return ..()
 

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -35,19 +35,8 @@
 	return ..()
 
 /obj/item/gun/projectile/revolver/attackby(obj/item/item, mob/user, params)
-	if(istype(item, /obj/item/ammo_box/speedloader) || istype(item, /obj/item/ammo_casing))
-		add_fingerprint(user)
-		. = ATTACK_CHAIN_PROCEED
-		if(istype(item, /obj/item/ammo_box/speedloader) && !do_after(user, GUN_MAGAZINE_RELOAD_DURATION, item, DA_IGNORE_LYING | DA_IGNORE_USER_LOC_CHANGE, interaction_key = src, max_interact_count = 1))
-			balloon_alert(user, "отменено")
-			return
-		var/num_loaded = magazine.reload(item, user)
-		if(num_loaded)
-			update_icon()
-			chamber_round(FALSE)
-			return ATTACK_CHAIN_BLOCKED_ALL
-		return
-
+	if(speedloader_reload(item, user))
+		return ATTACK_CHAIN_PROCEED
 	return ..()
 
 /obj/item/gun/projectile/revolver/unload_act(mob/user)

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -17,18 +17,8 @@
 	recoil = GUN_RECOIL_HIGH
 
 /obj/item/gun/projectile/shotgun/attackby(obj/item/item, mob/user, params)
-	if(istype(item, /obj/item/ammo_box/speedloader) || istype(item, /obj/item/ammo_casing))
-		. = ATTACK_CHAIN_PROCEED
-		if(istype(item, /obj/item/ammo_box/speedloader) && !do_after(user, GUN_MAGAZINE_RELOAD_DURATION, item, DA_IGNORE_LYING | DA_IGNORE_USER_LOC_CHANGE, interaction_key = src, max_interact_count = 1))
-			balloon_alert(user, "отменено")
-			return
-		add_fingerprint(user)
-		var/num_loaded = magazine.reload(item, user)
-		if(num_loaded)
-			update_appearance()
-			return ATTACK_CHAIN_BLOCKED_ALL
-		return
-
+	if(speedloader_reload(item, user))
+		return ATTACK_CHAIN_PROCEED
 	return ..()
 
 /obj/item/gun/projectile/shotgun/process_chamber(eject_casing = TRUE, empty_chamber = TRUE)

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -16,14 +16,18 @@
 	accuracy = GUN_ACCURACY_SHOTGUN
 	recoil = GUN_RECOIL_HIGH
 
-/obj/item/gun/projectile/shotgun/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/ammo_box/speedloader) || istype(I, /obj/item/ammo_casing))
+/obj/item/gun/projectile/shotgun/attackby(obj/item/item, mob/user, params)
+	if(istype(item, /obj/item/ammo_box/speedloader) || istype(item, /obj/item/ammo_casing))
+		. = ATTACK_CHAIN_PROCEED
+		if(istype(item, /obj/item/ammo_box/speedloader) && !do_after(user, GUN_MAGAZINE_RELOAD_DURATION, item, DA_IGNORE_LYING | DA_IGNORE_USER_LOC_CHANGE, interaction_key = src, max_interact_count = 1))
+			balloon_alert(user, "отменено")
+			return
 		add_fingerprint(user)
-		var/num_loaded = magazine.reload(I, user)
+		var/num_loaded = magazine.reload(item, user)
 		if(num_loaded)
 			update_appearance()
 			return ATTACK_CHAIN_BLOCKED_ALL
-		return ATTACK_CHAIN_PROCEED
+		return
 
 	return ..()
 

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -22,6 +22,7 @@
 		if(istype(item, /obj/item/ammo_box/speedloader) && !do_after(user, GUN_MAGAZINE_RELOAD_DURATION, item, DA_IGNORE_LYING | DA_IGNORE_USER_LOC_CHANGE, interaction_key = src, max_interact_count = 1))
 			balloon_alert(user, "отменено")
 			return
+
 		add_fingerprint(user)
 		var/num_loaded = magazine.reload(item, user)
 		if(num_loaded)


### PR DESCRIPTION
## Что этот ПР делает

Добавляет прогрессбар на перезарядку магазина и спидлоадеров в 1 секунду.

## Почему это хорошо для игры

Нет бесконечной стрельбе с тонной магазов в сумке. Теперь пусть хоть выдохнут 1 секунду во время перезарядки. 
Ну и обещаю в навыках добавить ускорение/замедление этого действия.

## Тестирование

Проверил на локалке, пушки нормально перезаряжаются.
