### PR TITLE
bugfix: выключение эмиссивок у ящиков, которые не должны светиться

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -19,6 +19,8 @@
 	var/list/announce_beacons = list()
 	/// Overlay for lightmask of our crate
 	var/overlay_lightmask
+	/// Can our crate make emissive light?
+	var/can_be_emissive = FALSE
 
 /obj/structure/closet/crate/update_icon_state()
 	icon_state = "[initial(icon_state)][opened ? "_open" : ""]"
@@ -29,7 +31,8 @@
 	. = list()
 	if(manifest)
 		. += "manifest"
-	underlays += emissive_appearance(icon, overlay_lightmask, src)
+	if(can_be_emissive)
+		underlays += emissive_appearance(icon, overlay_lightmask, src)
 
 /obj/structure/closet/crate/can_open()
 	return TRUE
@@ -183,6 +186,7 @@
 	locked = TRUE
 	can_be_emaged = TRUE
 	overlay_lightmask = "securecrate_lightmask"
+	can_be_emissive = TRUE
 
 /obj/structure/closet/crate/secure/update_overlays()
 	. = ..()


### PR DESCRIPTION
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

<!-- Вы можете совмещать до 2-х тэгов, например, balance/tweak:
Список возможных тэгов для пр-а:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map: Вы меняете только карту.
- image: Вы добавляете/удаляете спрайты.
- sound: Вы добавляете/удаляете звуки.
- spellcheck: Вы исправили опечатку.
- local: Вы добавляете новый текст на русском или переводите на русский.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает
Добавляет новый вариабл, определяющий, будет ли ящик иметь эмиссивку, по-умочанию выключен у обычных ящиков и включен у ящиков с замками.
Надо было всё-таки проверить...
<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2. В ином случае, опишите баг и его воспроизведение. -->