### PR TITLE
tweak: Бонусные 500 кредитов на счете за каждый тир доната при старте игры

### DIFF
--- a/_maps/map_files/debug/fast_load_multiz.dmm
+++ b/_maps/map_files/debug/fast_load_multiz.dmm
@@ -62,6 +62,10 @@
 /obj/machinery/light,
 /turf/simulated/openspace,
 /area/admin)
+"pn" = (
+/obj/machinery/computer/secure_data,
+/turf/simulated/floor/plasteel,
+/area/admin)
 "qp" = (
 /obj/item/tank/jetpack/oxygen,
 /turf/simulated/floor/plasteel,
@@ -189,6 +193,10 @@
 "Me" = (
 /obj/machinery/door/airlock/engineering,
 /turf/simulated/floor/indestructible/plating,
+/area/admin)
+"Nf" = (
+/obj/machinery/computer/account_database,
+/turf/simulated/floor/plasteel,
 /area/admin)
 "Pd" = (
 /obj/effect/landmark/spawner/late/crew,
@@ -2815,7 +2823,7 @@ ay
 ay
 ay
 jk
-HE
+pn
 HE
 HE
 HE
@@ -2881,7 +2889,7 @@ ay
 ay
 ay
 jk
-HE
+Nf
 nF
 HE
 HE

--- a/code/__DEFINES/donat.dm
+++ b/code/__DEFINES/donat.dm
@@ -6,3 +6,6 @@
 
 // Maximum donation level
 #define DONATOR_LEVEL_MAX 4
+
+/// Credits by donation tier (I - 500, II - 1000, III - 1500, IV - 2000)
+#define START_CREDITS_BY_DONATION_TIER 750

--- a/code/__DEFINES/donat.dm
+++ b/code/__DEFINES/donat.dm
@@ -8,4 +8,4 @@
 #define DONATOR_LEVEL_MAX 4
 
 /// Credits by donation tier (I - 500, II - 1000, III - 1500, IV - 2000)
-#define START_CREDITS_BY_DONATION_TIER 750
+#define START_CREDITS_BY_DONATION_TIER 500

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -705,6 +705,8 @@ SUBSYSTEM_DEF(jobs)
 
 /datum/controller/subsystem/jobs/proc/CreateMoneyAccount(mob/living/human, rank, datum/job/job)
 	var/money_amount = rand(job.min_start_money, job.max_start_money)
+	if(human.client.donator_level > 0)
+		money_amount += human.client.donator_level * START_CREDITS_BY_DONATION_TIER
 	var/datum/money_account/M = create_account(human.real_name, money_amount, null, job, TRUE)
 	if(human.dna)
 		GLOB.dna2account[human.dna] = M


### PR DESCRIPTION
## Что этот ПР делает

Бонусные 500 кредитов за каждый тир доната при старте игры на аккаунте персонажа.
Тиры доната:
- Tier I: +500
- Tier II: +1000
- Tier III: +1500
- Tier IV: +2000

В тестовую карту еще добвил консоли для аккаунтов и записей сб, без них игра не создает аккаунты.

## Почему это хорошо для игры

Полезные плюшки для донатеров в зависимости от тира.

## Тестирование

Поставил на тестовой карте консоль аккаунтов, поставил тир доната через VV и хашел в раунд, бабки появились.
