### PR TITLE
tweak: Многие вещи из лодаута теперь требуют доната

### DIFF
--- a/code/modules/client/preference/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference/loadout/loadout_accessories.dm
@@ -178,6 +178,7 @@
 	allowed_roles = list(JOB_TITLE_RD, JOB_TITLE_SCIENTIST, JOB_TITLE_SCIENTIST_STUDENT, JOB_TITLE_ROBOTICIST)
 
 /datum/gear/accessory/holsters
+	donator_tier = 2
 	index_name = "holster, select"
 	display_name = "Кобура"
 	path = /obj/item/clothing/accessory/holster/

--- a/code/modules/client/preference/loadout/loadout_glasses.dm
+++ b/code/modules/client/preference/loadout/loadout_glasses.dm
@@ -40,36 +40,43 @@
 	path = /obj/item/clothing/glasses/regular
 
 /datum/gear/glasses/sectacticool
+	donator_tier = 1
 	index_name = "Security tactical glasses"
 	path = /obj/item/clothing/glasses/hud/security/sunglasses/tacticool
 	allowed_roles = list(JOB_TITLE_HOS, JOB_TITLE_WARDEN, JOB_TITLE_OFFICER, JOB_TITLE_PILOT)
 
 /datum/gear/glasses/medhudpatch
+	donator_tier = 1
 	index_name = "Medical HUD eyepatch"
 	path = /obj/item/clothing/glasses/hud/health/patch
 	allowed_roles = list(JOB_TITLE_CMO, JOB_TITLE_DOCTOR, JOB_TITLE_MINING_MEDIC, JOB_TITLE_INTERN, JOB_TITLE_CHEMIST, JOB_TITLE_PSYCHIATRIST, JOB_TITLE_PARAMEDIC, JOB_TITLE_VIROLOGIST, JOB_TITLE_BRIGDOC, JOB_TITLE_CORONER)
 
 /datum/gear/glasses/sechudpatch
+	donator_tier = 1
 	index_name = "Security HUD eyepatch"
 	path = /obj/item/clothing/glasses/hud/security/patch
 	allowed_roles = list(JOB_TITLE_HOS, JOB_TITLE_WARDEN, JOB_TITLE_OFFICER, JOB_TITLE_PILOT, JOB_TITLE_JUDGE, JOB_TITLE_DETECTIVE)
 
 /datum/gear/glasses/sechudpatch/read_only
+	donator_tier = 1
 	index_name = "Security HUD eyepatch (read only)"
 	path = /obj/item/clothing/glasses/hud/security/patch/read_only
 	allowed_roles = list(JOB_TITLE_LAWYER)
 
 /datum/gear/glasses/hydrohudpatch
+	donator_tier = 1
 	index_name = "Hydroponic HUD eyepatch"
 	path = /obj/item/clothing/glasses/hud/hydroponic/patch
 	allowed_roles = list(JOB_TITLE_BOTANIST)
 
 /datum/gear/glasses/diaghudpatch
+	donator_tier = 1
 	index_name = "Diagnostic HUD eyepatch"
 	path = /obj/item/clothing/glasses/hud/diagnostic/patch
 	allowed_roles = list(JOB_TITLE_ROBOTICIST, JOB_TITLE_RD)
 
 /datum/gear/glasses/skillhudpatch
+	donator_tier = 1
 	index_name = "Skills HUD eyepatch"
 	path = /obj/item/clothing/glasses/hud/skills/patch
 	allowed_roles = list(JOB_TITLE_HOP, JOB_TITLE_CAPTAIN)

--- a/code/modules/client/preference/loadout/loadout_glasses.dm
+++ b/code/modules/client/preference/loadout/loadout_glasses.dm
@@ -58,7 +58,6 @@
 	allowed_roles = list(JOB_TITLE_HOS, JOB_TITLE_WARDEN, JOB_TITLE_OFFICER, JOB_TITLE_PILOT, JOB_TITLE_JUDGE, JOB_TITLE_DETECTIVE)
 
 /datum/gear/glasses/sechudpatch/read_only
-	donator_tier = 1
 	index_name = "Security HUD eyepatch (read only)"
 	path = /obj/item/clothing/glasses/hud/security/patch/read_only
 	allowed_roles = list(JOB_TITLE_LAWYER)

--- a/code/modules/client/preference/loadout/loadout_hat.dm
+++ b/code/modules/client/preference/loadout/loadout_hat.dm
@@ -122,6 +122,7 @@
 	gear_tweaks += new /datum/gear_tweak/path(berets, src)
 
 /datum/gear/hat/beret_job
+	donator_tier = 1
 	subtype_path = /datum/gear/hat/beret_job
 	subtype_cost_overlap = FALSE
 

--- a/code/modules/client/preference/loadout/loadout_implants.dm
+++ b/code/modules/client/preference/loadout/loadout_implants.dm
@@ -1,10 +1,9 @@
 /datum/gear/implant
+	donator_tier = 1
 	subtype_path = /datum/gear/implant
 	slot = null
 	sort_category = "Импланты"
 	implantable = TRUE
-
-/datum/gear/implant/
 
 //Eye implants
 
@@ -15,12 +14,14 @@
 	allowed_roles = list(JOB_TITLE_CHIEF, JOB_TITLE_ATMOSTECH, JOB_TITLE_ENGINEER, JOB_TITLE_QUARTERMASTER, JOB_TITLE_MINER, JOB_TITLE_MINING_MEDIC)
 
 /datum/gear/implant/security
+	donator_tier = 2
 	index_name = "Security Hud Implant"
 	cost = 3
 	path = /obj/item/organ/internal/cyberimp/eyes/hud/security
 	allowed_roles = list(JOB_TITLE_OFFICER, JOB_TITLE_PILOT, JOB_TITLE_DETECTIVE, JOB_TITLE_WARDEN, JOB_TITLE_HOS, JOB_TITLE_JUDGE)
 
 /datum/gear/implant/medical
+	donator_tier = 2
 	index_name = "Medical Hud Implant"
 	cost = 3
 	path = /obj/item/organ/internal/cyberimp/eyes/hud/medical

--- a/code/modules/client/preference/loadout/loadout_neck.dm
+++ b/code/modules/client/preference/loadout/loadout_neck.dm
@@ -1,4 +1,5 @@
 /datum/gear/neck
+	donator_tier = 1
 	subtype_path = /datum/gear/neck
 	slot = ITEM_SLOT_NECK
 	sort_category = "Плащи"

--- a/code/modules/client/preference/loadout/loadout_plushie.dm
+++ b/code/modules/client/preference/loadout/loadout_plushie.dm
@@ -1,4 +1,5 @@
 /datum/gear/plushie
+	donator_tier = 1
 	sort_category = "Игрушки"
 	subtype_path = /datum/gear/plushie
 


### PR DESCRIPTION
## Что этот ПР делает

Многие вещи которе были доступны без доната в лодауте теперь будут требовать донат тир.

Список изменений:
- Береты профессий требуют тир 1
- Импланты: мезоны, диагностические и научные худы за тир 1, сбшный и медицинский за тир 2.
- Все виды плащей за тир 1
- Все плюшевые игрушки за тир 1
- Кобура за тир 2 (*все равно кобуры выдаются в ваучере или лежат в ящиках глав, в лодауте он чисто для кастомизации в виде поясного варианта*)
- Специализированные очки (*сб, мед, ботаник, диагностик, скилл*) за тир 1

*Все измененные варианты есть в демонстрации изменений*

## Почему это хорошо для игры

Мотивируем игроков брать донат тир для большей кастомизации.

## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>

Береты:
<img width="648" height="378" alt="image" src="https://github.com/user-attachments/assets/514e5e4a-c9e7-4aa6-9b7e-fe97cbc5a61b" />
Импланты:
<img width="626" height="195" alt="image" src="https://github.com/user-attachments/assets/c812cf7e-23ea-45de-a134-ce612a77d1bd" />
Плащи:
<img width="695" height="573" alt="image" src="https://github.com/user-attachments/assets/558b0e88-d8c6-48ba-81b9-303ee2ecaf05" />
Игрушки:
<img width="664" height="535" alt="image" src="https://github.com/user-attachments/assets/c3809ef4-4ab9-47d4-88da-4d27dce6301b" />
Кобура:
<img width="190" height="171" alt="image" src="https://github.com/user-attachments/assets/d47b9887-59c4-417a-a549-9251fcc8837c" />
Очки:
<img width="649" height="450" alt="image" src="https://github.com/user-attachments/assets/9ed807b3-38d2-4e00-8815-e4bceb1033b1" />

</p>
</details>

## Тестирование

Проверено на локалке.
