### PR TITLE
bugfix: Исправлен баг консоли карго

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -57,7 +57,7 @@ SUBSYSTEM_DEF(shuttle)
 /datum/controller/subsystem/shuttle/Initialize()
 	ordernum = rand(1,9000)
 
-	cargo_money_account = GLOB.department_accounts["Cargo"]
+	cargo_money_account = GLOB.department_accounts[STATION_DEPARTMENT_SUPPLY]
 
 	if(!emergency)
 		log_runtime(EXCEPTION("No /obj/docking_port/mobile/emergency placed on the map!"))

--- a/code/modules/economy/quests/_base_quests.dm
+++ b/code/modules/economy/quests/_base_quests.dm
@@ -161,7 +161,7 @@
 	/// Positions that will be paid. (Noooo I won't do part of this in new)
 	var/list/bounty_jobs = list()
 	/// The department key is specified to take it from the global list, no, I will not upload to new, I'm afraid to break even
-	var/linked_departament = "Cargo"
+	var/linked_departament = STATION_DEPARTMENT_SUPPLY
 
 /datum/cargo_quest/New(storage, read_datum = FALSE)
 	if(!read_datum)

--- a/code/modules/economy/quests/centcomm_departaments.dm
+++ b/code/modules/economy/quests/centcomm_departaments.dm
@@ -190,7 +190,7 @@
 	station_money_account.credit(round(reward * PERCENTAGE_PAYMENTS_STATION), "Завершённый запрос на поставку", "Терминал Бизель №[rand(111,333)]", "Счёт объекта")
 
 	SScapitalism.total_cargo_bounty += round(reward * PERCENTAGE_PAYMENTS_CARGO)
-	var/datum/money_account/cargo_money_account = GLOB.department_accounts["Cargo"]
+	var/datum/money_account/cargo_money_account = GLOB.department_accounts[STATION_DEPARTMENT_SUPPLY]
 	cargo_money_account.credit(round(reward * PERCENTAGE_PAYMENTS_CARGO), "Завершённый запрос на поставку", "Терминал Бизель №[rand(111,333)]", "Счёт Отдела снабжения")
 
 	return TRUE

--- a/code/modules/economy/quests/quest_console.dm
+++ b/code/modules/economy/quests/quest_console.dm
@@ -73,7 +73,7 @@
 				"tech_id" = initial(tech.id)
 			))
 		data["purchased_techs"] = purchased_techs
-	var/datum/money_account/cargo_money_account = GLOB.department_accounts["Cargo"]
+	var/datum/money_account/cargo_money_account = GLOB.department_accounts[STATION_DEPARTMENT_SUPPLY]
 	data["cargo_money"] = cargo_money_account.money
 	data["points"] = round(SSshuttle.points)
 	return data
@@ -182,7 +182,7 @@
 				to_chat(user, span_warning("Институт ЦК не может поделиться с вами данной технологий в данный момент."))
 				playsound(src, pick('sound/machines/button.ogg', 'sound/machines/button_alternate.ogg', 'sound/machines/button_meloboom.ogg'), 20)
 				return FALSE
-			var/datum/money_account/cargo_money_account = GLOB.department_accounts["Cargo"]
+			var/datum/money_account/cargo_money_account = GLOB.department_accounts[STATION_DEPARTMENT_SUPPLY]
 			var/attempt_pin = tgui_input_number(user, "Введите пароль", "Транзакция с ЦК")
 			if(..() || !attempt_account_access(cargo_money_account.account_number, attempt_pin, 2))
 				to_chat(user, span_warning("Не удаётся получить доступ к учётной записи: неверные учётные данные."))


### PR DESCRIPTION
## Что этот ПР делает

Консоли карго теперь работают корректно, проблемы была в переименовании идентификатора отдела карго из "Cargo" в "Supply", при попытке достать аккаунт отдела возникала ошибка, так как там было "Cargo" вместо дефайна id отдела.

## Почему это хорошо для игры

<img width="698" height="812" alt="image" src="https://github.com/user-attachments/assets/e8c92e3e-1808-4daa-9186-4df174cabe71" />

## Тестирование

Запустил локалку и открыл консоль, заработало.
