### PR TITLE
balance: таймстоп ратвара теперь останавливает только пули

### DIFF
--- a/code/game/gamemodes/clockwork/clockwork_items.dm
+++ b/code/game/gamemodes/clockwork/clockwork_items.dm
@@ -1639,7 +1639,6 @@
 				add_attack_logs(user, user, "Time stopped with [src]")
 				qdel(src)
 				var/obj/effect/timestop/clockwork/timestop = new /obj/effect/timestop/clockwork(get_turf(user))
-				timestop.immune |= user
 				timestop.timestop()
 			if(RECONSTRUCT_SPELL)
 				add_attack_logs(user, user, "Reconstructed with [src]")

--- a/code/game/gamemodes/clockwork/clockwork_items.dm
+++ b/code/game/gamemodes/clockwork/clockwork_items.dm
@@ -1598,6 +1598,7 @@
 	icon_state = "shard"
 	sharp = TRUE //youch!!
 	force = 5
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/clockwork/shard/Initialize(mapload)
 	. = ..()

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -780,6 +780,10 @@
 	var/freezerange = 1
 	var/duration = 140
 	alpha = 125
+	///Can our timestop freeze humans?
+	var/human_freeze = TRUE
+	///Can our timestop freeze projectiles?
+	var/projectile_freeze = TRUE
 
 /obj/effect/timestop/New()
 	..()
@@ -793,7 +797,7 @@
 	playsound(get_turf(src), 'sound/magic/timeparadox2.ogg', 100, TRUE, -1)
 	for(var/i in 1 to duration-1)
 		for(var/A in orange (freezerange, loc))
-			if(isliving(A))
+			if(isliving(A) && human_freeze)
 				var/mob/living/M = A
 				if(M in immune)
 					continue
@@ -804,7 +808,7 @@
 					H.AIStatus = AI_OFF
 					H.lose_target()
 				stopped_atoms |= M
-			else if(isprojectile(A))
+			else if(isprojectile(A) && projectile_freeze)
 				var/obj/projectile/P = A
 				P.paused = TRUE
 				stopped_atoms |= P
@@ -839,7 +843,8 @@
 	timestop()
 
 /obj/effect/timestop/clockwork
-	duration = 80
+	duration = 160
+	human_freeze = FALSE
 
 /obj/item/stack/tile/bluespace
 	name = "bluespace floor tile"


### PR DESCRIPTION
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

<!-- Вы можете совмещать до 2-х тэгов, например, balance/tweak:
Список возможных тэгов для пр-а:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map: Вы меняете только карту.
- image: Вы добавляете/удаляете спрайты.
- sound: Вы добавляете/удаляете звуки.
- spellcheck: Вы исправили опечатку.
- local: Вы добавляете новый текст на русском или переводите на русский.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает
теперь таймстоп ратвара не останавливает людей, а только проджектайлы. Возвращен смолл сайз таймстопу.
<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2. В ином случае, опишите баг и его воспроизведение. -->

## Почему это хорошо для игры
Ну, сыграли раунд с "нерфнутым" таймстопом культа. ОБР захуярили просто держа в двух-трех таймстопах и нажимая по ним ЛКМ, пока те могли лишь писать "кайф" и кидать эмоуты смайлика. Предмет, изначально задумывающийся защитным, превратился в ноубрейнер лоу-скилл ваншот хуйнюшку, наличие которой позволяет перебить всех врагов без какого либо сопротивления. Теперь это реально защитный предмет, позволяющий захватить вражеские пули (а у нас щас все вооружение брига представляет из себя пулеметы, стреляющие по десятке пуль в секунду) и дать возможность сбежать или свернуть за угол.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в билд. -->

## Тестирование
Зашел на локалку, заспавнил таймстоп мага. Застряли и пули, и люди.
Заспавнил таймстоп ратвара (через шард), застряли только пули, люди спокойно ходили
<!-- Как Вы тестировали свои изменения? Ведь тестировали? -->
