### PR TITLE
qol: Добавлено автонаведение на самую пострадавшую часть тела при использовании бинтов, китов и зашивалок

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -32,7 +32,7 @@
 
 	if(ishuman(target))
 		var/mob/living/carbon/human/human_target = target
-		var/selected_zone = user.zone_selected
+		var/selected_zone = get_priority_targeting(target, user, def_zone)
 		var/obj/item/organ/external/affecting = human_target.get_organ(selected_zone)
 
 		if(isgolem(human_target))
@@ -109,8 +109,90 @@
 	)
 	return .|ATTACK_CHAIN_SUCCESS
 
+/obj/item/stack/medical/proc/get_priority_targeting(mob/living/target, mob/living/user)
+	return user.zone_selected
+
+/obj/item/stack/medical/proc/get_max_bleeding_targeting(mob/living/target, mob/living/user)
+	. = user.zone_selected
+	if(!ishuman(target))
+		return
+
+	var/mob/living/carbon/human/human_target = target
+	var/obj/item/organ/external/target_bodypart = null
+	for(var/obj/item/organ/external/bodypart as anything in human_target.bodyparts)
+		if(bodypart.is_robotic())
+			continue
+		if(bodypart.bleeding_amount <= 0 || bodypart.bleeding_amount <= bodypart.bleedsuppress)
+			continue
+		if(target_bodypart && bodypart.bleeding_amount <= target_bodypart.bleeding_amount)
+			continue
+		target_bodypart = bodypart
+
+	if(!target_bodypart)
+		return
+
+	return target_bodypart.limb_zone
+
+/obj/item/stack/medical/proc/get_max_brute_damage_targeting(mob/living/target, mob/living/user)
+	. = user.zone_selected
+	if(!ishuman(target))
+		return
+
+	var/mob/living/carbon/human/human_target = target
+	var/obj/item/organ/external/target_bodypart = null
+	for(var/obj/item/organ/external/bodypart as anything in human_target.bodyparts)
+		if(bodypart.is_robotic() || bodypart.brute_dam <= 0)
+			continue
+		if(target_bodypart && bodypart.brute_dam <= target_bodypart.brute_dam)
+			continue
+		target_bodypart = bodypart
+
+	if(!target_bodypart)
+		return
+
+	return target_bodypart.limb_zone
+
+/obj/item/stack/medical/proc/get_max_burn_damage_targeting(mob/living/target, mob/living/user)
+	. = user.zone_selected
+	if(!ishuman(target))
+		return
+
+	var/mob/living/carbon/human/human_target = target
+	var/obj/item/organ/external/target_bodypart = null
+	for(var/obj/item/organ/external/bodypart as anything in human_target.bodyparts)
+		if(bodypart.is_robotic() || bodypart.burn_dam <= 0)
+			continue
+		if(target_bodypart && bodypart.burn_dam <= target_bodypart.burn_dam)
+			continue
+		target_bodypart = bodypart
+
+	if(!target_bodypart)
+		return
+
+	return target_bodypart.limb_zone
+
+/obj/item/stack/medical/proc/get_max_damage_targeting(mob/living/target, mob/living/user)
+	. = user.zone_selected
+	if(!ishuman(target))
+		return
+
+	var/mob/living/carbon/human/human_target = target
+	var/obj/item/organ/external/target_bodypart = null
+	for(var/obj/item/organ/external/bodypart as anything in human_target.bodyparts)
+		if(bodypart.is_robotic() || bodypart.burn_dam <= 0 && bodypart.brute_dam <= 0)
+			continue
+		if(target_bodypart && bodypart.burn_dam + bodypart.brute_dam <= target_bodypart.burn_dam + target_bodypart.brute_dam)
+			continue
+		target_bodypart = bodypart
+
+	if(!target_bodypart)
+		return
+
+	return target_bodypart.limb_zone
+
 /obj/item/stack/medical/proc/human_heal(mob/living/carbon/human/target, mob/user)
-	var/obj/item/organ/external/affecting = target.get_organ(user.zone_selected)
+	var/selected_zone = get_priority_targeting(target, user)
+	var/obj/item/organ/external/affecting = target.get_organ(selected_zone)
 	user.visible_message(
 		span_green("[user] использу[PLUR_ET_YUT(user)] [declent_ru(NOMINATIVE)] на [affecting.declent_ru(ACCUSATIVE)] [target]."),
 		span_green("Вы используете [declent_ru(NOMINATIVE)] на [affecting.declent_ru(ACCUSATIVE)] [target]."),
@@ -212,7 +294,8 @@
 	if(!get_amount())
 		to_chat(user, span_danger("Не хватает медикаментов!"))
 		return ATTACK_CHAIN_PROCEED
-	var/obj/item/organ/external/affecting = target.get_organ(user.zone_selected)
+	var/selected_zone = get_priority_targeting(target, user, def_zone)
+	var/obj/item/organ/external/affecting = target.get_organ(selected_zone)
 	if(affecting.open != ORGAN_CLOSED)
 		to_chat(user, span_danger("[capitalize(affecting.declent_ru(NOMINATIVE))] открыта, тут уже не помочь бинтами!"))
 		. &= ~ATTACK_CHAIN_SUCCESS
@@ -231,6 +314,9 @@
 	human_heal(target, user)
 	target.UpdateDamageIcon()
 	update_icon()
+
+/obj/item/stack/medical/bruise_pack/get_priority_targeting(mob/living/target, mob/living/user)
+	return get_max_bleeding_targeting(target, user)
 
 /obj/item/stack/medical/bruise_pack/improvised
 	name = "improvised gauze"
@@ -315,6 +401,9 @@
 /obj/item/stack/medical/bruise_pack/advanced/syndicate
 	energy_type = /datum/robot_energy_storage/medical/syndicate
 
+/obj/item/stack/medical/bruise_pack/advanced/get_priority_targeting(mob/living/target, mob/living/user)
+	return get_max_brute_damage_targeting(target, user)
+
 /obj/item/stack/medical/bruise_pack/extended
 	name = "extended trauma kit"
 	singular_name = "extended trauma kit"
@@ -350,6 +439,8 @@
 	use_flags = DA_IGNORE_LYING
 	merge_type = /obj/item/stack/medical/ointment
 
+/obj/item/stack/medical/ointment/get_priority_targeting(mob/living/target, mob/living/user)
+	return get_max_burn_damage_targeting(target, user)
 
 /obj/item/stack/medical/ointment/syndicate
 	energy_type = /datum/robot_energy_storage/medical/syndicate
@@ -363,7 +454,8 @@
 		to_chat(user, span_danger("Not enough medical supplies!"))
 		return ATTACK_CHAIN_PROCEED
 
-	var/obj/item/organ/external/affecting = target.get_organ(user.zone_selected)
+	var/selected_zone = get_priority_targeting(target, user, def_zone)
+	var/obj/item/organ/external/affecting = target.get_organ(selected_zone)
 	if(affecting.open != ORGAN_CLOSED)
 		to_chat(user, span_danger("[capitalize(affecting.declent_ru(NOMINATIVE))] открыта, тут уже не помочь мазью!"))
 		. &= ~ATTACK_CHAIN_SUCCESS
@@ -438,6 +530,9 @@
 /obj/item/stack/medical/bruise_pack/comfrey/update_icon_state()
 	return
 
+/obj/item/stack/medical/bruise_pack/comfrey/get_priority_targeting(mob/living/target, mob/living/user)
+	return get_max_brute_damage_targeting(target, user)
+
 /obj/item/stack/medical/ointment/aloe
 	name = "Aloe Vera leaf"
 	singular_name = "Aloe Vera leaf"
@@ -484,7 +579,8 @@
 		to_chat(user, span_danger("No splints left!"))
 		return ATTACK_CHAIN_PROCEED
 
-	var/obj/item/organ/external/bodypart = target.get_organ(user.zone_selected)
+	var/selected_zone = get_priority_targeting(target, user, def_zone)
+	var/obj/item/organ/external/bodypart = target.get_organ(selected_zone)
 	var/bodypart_name = bodypart.name
 
 	if(!(bodypart.limb_zone in available_splint_zones))
@@ -583,7 +679,9 @@
 	. = ATTACK_CHAIN_PROCEED
 	if(!ishuman(target))
 		return .
-	var/obj/item/organ/external/affecting = target.get_organ(user.zone_selected)
+
+	var/selected_zone = get_priority_targeting(target, user, def_zone)
+	var/obj/item/organ/external/affecting = target.get_organ(selected_zone)
 	if(affecting.bleeding_amount <= 0)
 		user.balloon_alert(user, "нечего зашивать!")
 		. &= ~ATTACK_CHAIN_SUCCESS
@@ -615,6 +713,9 @@
 	user.balloon_alert(user, "зашито!")
 	target.UpdateDamageIcon()
 	update_icon()
+
+/obj/item/stack/medical/suture/get_priority_targeting(mob/living/target, mob/living/user)
+	return get_max_bleeding_targeting(target, user)
 
 /obj/item/stack/medical/suture/advanced
 	name = "advanced suture kit"
@@ -665,6 +766,9 @@
 
 /obj/item/stack/medical/bruise_pack/synthflesh_kit/update_icon_state()
 	icon_state = "synthkit_[round_down((amount+1) / 2, 1)]"
+
+/obj/item/stack/medical/bruise_pack/synthflesh_kit/get_priority_targeting(mob/living/target, mob/living/user)
+	return get_max_damage_targeting(target, user)
 
 
 // MARK: Tourniquet

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -109,87 +109,6 @@
 	)
 	return .|ATTACK_CHAIN_SUCCESS
 
-/obj/item/stack/medical/proc/get_priority_targeting(mob/living/target, mob/living/user)
-	return user.zone_selected
-
-/obj/item/stack/medical/proc/get_max_bleeding_targeting(mob/living/target, mob/living/user)
-	. = user.zone_selected
-	if(!ishuman(target))
-		return
-
-	var/mob/living/carbon/human/human_target = target
-	var/obj/item/organ/external/target_bodypart = null
-	for(var/obj/item/organ/external/bodypart as anything in human_target.bodyparts)
-		if(bodypart.is_robotic())
-			continue
-		if(bodypart.bleeding_amount <= 0 || bodypart.bleeding_amount <= bodypart.bleedsuppress)
-			continue
-		if(target_bodypart && bodypart.bleeding_amount <= target_bodypart.bleeding_amount)
-			continue
-		target_bodypart = bodypart
-
-	if(!target_bodypart)
-		return
-
-	return target_bodypart.limb_zone
-
-/obj/item/stack/medical/proc/get_max_brute_damage_targeting(mob/living/target, mob/living/user)
-	. = user.zone_selected
-	if(!ishuman(target))
-		return
-
-	var/mob/living/carbon/human/human_target = target
-	var/obj/item/organ/external/target_bodypart = null
-	for(var/obj/item/organ/external/bodypart as anything in human_target.bodyparts)
-		if(bodypart.is_robotic() || bodypart.brute_dam <= 0)
-			continue
-		if(target_bodypart && bodypart.brute_dam <= target_bodypart.brute_dam)
-			continue
-		target_bodypart = bodypart
-
-	if(!target_bodypart)
-		return
-
-	return target_bodypart.limb_zone
-
-/obj/item/stack/medical/proc/get_max_burn_damage_targeting(mob/living/target, mob/living/user)
-	. = user.zone_selected
-	if(!ishuman(target))
-		return
-
-	var/mob/living/carbon/human/human_target = target
-	var/obj/item/organ/external/target_bodypart = null
-	for(var/obj/item/organ/external/bodypart as anything in human_target.bodyparts)
-		if(bodypart.is_robotic() || bodypart.burn_dam <= 0)
-			continue
-		if(target_bodypart && bodypart.burn_dam <= target_bodypart.burn_dam)
-			continue
-		target_bodypart = bodypart
-
-	if(!target_bodypart)
-		return
-
-	return target_bodypart.limb_zone
-
-/obj/item/stack/medical/proc/get_max_damage_targeting(mob/living/target, mob/living/user)
-	. = user.zone_selected
-	if(!ishuman(target))
-		return
-
-	var/mob/living/carbon/human/human_target = target
-	var/obj/item/organ/external/target_bodypart = null
-	for(var/obj/item/organ/external/bodypart as anything in human_target.bodyparts)
-		if(bodypart.is_robotic() || bodypart.burn_dam <= 0 && bodypart.brute_dam <= 0)
-			continue
-		if(target_bodypart && bodypart.burn_dam + bodypart.brute_dam <= target_bodypart.burn_dam + target_bodypart.brute_dam)
-			continue
-		target_bodypart = bodypart
-
-	if(!target_bodypart)
-		return
-
-	return target_bodypart.limb_zone
-
 /obj/item/stack/medical/proc/human_heal(mob/living/carbon/human/target, mob/user)
 	var/selected_zone = get_priority_targeting(target, user)
 	var/obj/item/organ/external/affecting = target.get_organ(selected_zone)
@@ -247,6 +166,64 @@
 	if(check.type != merge_type)
 		return FALSE
 	. = ..()
+
+// MARK: Targeting filter
+
+/obj/item/stack/medical/proc/get_priority_targeting(mob/living/target, mob/living/user)
+	return user.zone_selected
+
+/obj/item/stack/medical/proc/get_priority_targeting_by_filter(mob/living/target, mob/living/user, filter_proc)
+	. = user.zone_selected
+	if(!ishuman(target))
+		return
+
+	var/mob/living/carbon/human/human_target = target
+	var/obj/item/organ/external/target_bodypart = null
+	for(var/obj/item/organ/external/bodypart as anything in human_target.bodyparts)
+		var/accept = call(src, filter_proc)(arglist(list(current=bodypart, max=target_bodypart)))
+		if(accept)
+			target_bodypart = bodypart
+
+	if(!target_bodypart)
+		return
+
+	return target_bodypart.limb_zone
+
+/obj/item/stack/medical/proc/filter_max_bleeding_bodypart(obj/item/organ/external/current, obj/item/organ/external/max)
+	if(current.is_robotic() || current.bleeding_amount <= 0 || current.bleeding_amount <= current.bleedsuppress)
+		return FALSE
+	if(!max)
+		return TRUE
+	if(current.bleeding_amount > max.bleeding_amount)
+		return TRUE
+	return FALSE
+
+/obj/item/stack/medical/proc/filter_max_brute_damage_bodypart(obj/item/organ/external/current, obj/item/organ/external/max)
+	if(current.is_robotic() || current.brute_dam <= 0)
+		return FALSE
+	if(!max)
+		return TRUE
+	if(current.brute_dam > max.brute_dam)
+		return TRUE
+	return FALSE
+
+/obj/item/stack/medical/proc/filter_max_burn_damage_bodypart(obj/item/organ/external/current, obj/item/organ/external/max)
+	if(current.is_robotic() || current.burn_dam <= 0)
+		return FALSE
+	if(!max)
+		return TRUE
+	if(current.burn_dam > max.burn_dam)
+		return TRUE
+	return FALSE
+
+/obj/item/stack/medical/proc/filter_max_damage_bodypart(obj/item/organ/external/current, obj/item/organ/external/max)
+	if(current.is_robotic() || current.burn_dam <= 0 && current.brute_dam <= 0)
+		return FALSE
+	if(!max)
+		return TRUE
+	if(current.burn_dam + current.brute_dam > max.burn_dam + max.brute_dam)
+		return TRUE
+	return FALSE
 
 // MARK: Bruise Packs
 
@@ -316,7 +293,7 @@
 	update_icon()
 
 /obj/item/stack/medical/bruise_pack/get_priority_targeting(mob/living/target, mob/living/user)
-	return get_max_bleeding_targeting(target, user)
+	return get_priority_targeting_by_filter(target, user, PROC_REF(filter_max_bleeding_bodypart))
 
 /obj/item/stack/medical/bruise_pack/improvised
 	name = "improvised gauze"
@@ -402,7 +379,7 @@
 	energy_type = /datum/robot_energy_storage/medical/syndicate
 
 /obj/item/stack/medical/bruise_pack/advanced/get_priority_targeting(mob/living/target, mob/living/user)
-	return get_max_brute_damage_targeting(target, user)
+	return get_priority_targeting_by_filter(target, user, PROC_REF(filter_max_brute_damage_bodypart))
 
 /obj/item/stack/medical/bruise_pack/extended
 	name = "extended trauma kit"
@@ -440,7 +417,7 @@
 	merge_type = /obj/item/stack/medical/ointment
 
 /obj/item/stack/medical/ointment/get_priority_targeting(mob/living/target, mob/living/user)
-	return get_max_burn_damage_targeting(target, user)
+	return get_priority_targeting_by_filter(target, user, PROC_REF(filter_max_burn_damage_bodypart))
 
 /obj/item/stack/medical/ointment/syndicate
 	energy_type = /datum/robot_energy_storage/medical/syndicate
@@ -531,7 +508,7 @@
 	return
 
 /obj/item/stack/medical/bruise_pack/comfrey/get_priority_targeting(mob/living/target, mob/living/user)
-	return get_max_brute_damage_targeting(target, user)
+	return get_priority_targeting_by_filter(target, user, PROC_REF(filter_max_brute_damage_bodypart))
 
 /obj/item/stack/medical/ointment/aloe
 	name = "Aloe Vera leaf"
@@ -715,7 +692,7 @@
 	update_icon()
 
 /obj/item/stack/medical/suture/get_priority_targeting(mob/living/target, mob/living/user)
-	return get_max_bleeding_targeting(target, user)
+	return get_priority_targeting_by_filter(target, user, PROC_REF(filter_max_bleeding_bodypart))
 
 /obj/item/stack/medical/suture/advanced
 	name = "advanced suture kit"
@@ -768,7 +745,7 @@
 	icon_state = "synthkit_[round_down((amount+1) / 2, 1)]"
 
 /obj/item/stack/medical/bruise_pack/synthflesh_kit/get_priority_targeting(mob/living/target, mob/living/user)
-	return get_max_damage_targeting(target, user)
+	return get_priority_targeting_by_filter(target, user, PROC_REF(filter_max_damage_bodypart))
 
 
 // MARK: Tourniquet

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -180,7 +180,7 @@
 	var/mob/living/carbon/human/human_target = target
 	var/obj/item/organ/external/target_bodypart = null
 	for(var/obj/item/organ/external/bodypart as anything in human_target.bodyparts)
-		var/accept = call(src, filter_proc)(arglist(list(current=bodypart, max=target_bodypart)))
+		var/accept = call(src, filter_proc)(arglist(list(current = bodypart, max = target_bodypart)))
 		if(accept)
 			target_bodypart = bodypart
 


### PR DESCRIPTION
## Что этот ПР делает

1. При использовании бинта теперь не смотрит на то куда игрок нацелен, автоматически выбирает наиболее кровоточащую часть тела и накладывает бинт туда.
2. При использовании китов та же логика, но выбирается наиболее пострадавшая часть тела (по брут и берн урону, в зависимости от типа кита)
3. Зашивалка также автоматически найдет где зашивать.

## Почему это хорошо для игры

1. QoL
2. Понижаем градус духоты в меде после кровотеков.

## Тестирование

Локалка.
