### PR TITLE
qol: security belt-shoulder system будет иметь карманы

### DIFF
--- a/code/modules/client/preference/loadout/loadout_suit.dm
+++ b/code/modules/client/preference/loadout/loadout_suit.dm
@@ -151,7 +151,7 @@
 
 /datum/gear/suit/sec_rps
 	index_name = "security belt-shoulder system"
-	path = /obj/item/clothing/suit/armor/vest/sec_rps
+	path = /obj/item/clothing/suit/storage/sec_rps
 	allowed_roles = list(JOB_TITLE_HOS, JOB_TITLE_WARDEN, JOB_TITLE_DETECTIVE, JOB_TITLE_OFFICER, JOB_TITLE_PILOT)
 
 //SURAGI JACKET

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -170,11 +170,15 @@
 	desc = "A navy-blue armored jacket with blue shoulder designations and '/Warden/' stitched into one of the chest pockets."
 	icon_state = "warden_jacket_alt"
 
-/obj/item/clothing/suit/armor/vest/sec_rps
+/obj/item/clothing/suit/storage/sec_rps
 	name = "security belt-shoulder system"
 	desc = "A belt-shoulder system for officers that are more inclined towards style than safety."
 	icon_state = "sec_rps"
 	armor=  list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 5, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
+	undyeable = TRUE
+	allowed = list(/obj/item/gun/energy,/obj/item/reagent_containers/spray/pepper,/obj/item/gun/projectile,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/restraints/handcuffs,/obj/item/flashlight/seclite,/obj/item/kitchen/knife/combat)
+	pockets_count = 4
+	pockets_max_combined_w_class = 8
 
 /obj/item/clothing/suit/armor/vest/capcarapace
 	name = "captain's carapace"

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -1,13 +1,15 @@
 /obj/item/clothing/suit/storage
+	var/pockets_count = 2 // two slots by default
+	var/pockets_max_combined_w_class = 4
 	var/obj/item/storage/internal/pockets
 	w_class = WEIGHT_CLASS_NORMAL //we don't want these to be able to fit in their own pockets.
 
 /obj/item/clothing/suit/storage/Initialize(mapload)
 	. = ..()
 	pockets = new/obj/item/storage/internal(src)
-	pockets.storage_slots = 2	//two slots
+	pockets.storage_slots = pockets_count
 	pockets.max_w_class = WEIGHT_CLASS_SMALL		//fit only pocket sized items
-	pockets.max_combined_w_class = 4
+	pockets.max_combined_w_class = pockets_max_combined_w_class
 
 /obj/item/clothing/suit/storage/Destroy()
 	QDEL_NULL(pockets)

--- a/code/modules/vending/clothesmate_department.dm
+++ b/code/modules/vending/clothesmate_department.dm
@@ -124,7 +124,7 @@
 				/obj/item/clothing/suit/tracksuit/red = 5,
 				/obj/item/clothing/suit/hooded/wintercoat/security = 5,
 				/obj/item/clothing/suit/jacket/pilot = 5,
-				/obj/item/clothing/suit/armor/vest/sec_rps = 5,
+				/obj/item/clothing/suit/storage/sec_rps = 5,
 				/obj/item/clothing/suit/armor/secjacket = 5,
 				/obj/item/clothing/suit/storage/suragi_jacket/medsec = 3,
 				/obj/item/clothing/suit/storage/brigdoc = 3,


### PR DESCRIPTION
## Что этот ПР делает

Добавляет 4 кармана для верхней одежды сб "security belt-shoulder system".

## Почему это хорошо для игры

Верхняя одежда для сб которая которая ничего не дает - ни защиты, ни карманов (*хотя даже по спрайту видно что у него много карманов должно быть*).
Добавляем 4 кармана чтобы хранить мелочи в разгрузке, взамен у него нулевая броня.

## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>

Сам предмет:
<img width="97" height="109" alt="image" src="https://github.com/user-attachments/assets/af900c9c-2625-4f81-95cb-80ddd430e04b" />

Как выглядят карманы:
<img width="694" height="318" alt="image" src="https://github.com/user-attachments/assets/c9759804-84bf-417d-aa73-11700948ec01" />

</p>
</details>

## Тестирование

<!-- Как Вы тестировали свои изменения? Ведь тестировали? -->
