### PR TITLE
balance: Уменьшена дальность бросков тел

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -5,6 +5,7 @@
 	blood_volume = BLOOD_VOLUME_NORMAL
 	rotate_on_lying = TRUE
 	pull_hand = null
+	throw_range = 3
 	var/list/stomach_contents
 	var/list/processing_patches
 	var/list/internal_organs	= list()


### PR DESCRIPTION
## Что этот ПР делает

Определяем дальность броска тел на 3 (*в игре это будет два тайла*).

## Почему это хорошо для игры

Сейчас у нас для тел не установлена дальность бросков, поэтмоу берется дефолтное значение 7 (*6 тайлов*), на такое же расстояние кидаются флешки в игре. А некоторые предметы и того меньше.
Логично что кидать 80 кг тело можно кидать не так далеко.
Ну и плюсом убираем страту с бросками тел ради станов.

## Тестирование

Проверил на локалке, все работает нормально. Сила влияет на дальность броска как и раньше, это я не трогал.
