### PR TITLE
map: Больше нет переключателей света в стекле на дельте

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -14808,7 +14808,7 @@
 /area/security/securearmory)
 "bQe" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/machinery/light_switch/directional/west,
+/obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -149868,7 +149868,7 @@ bGz
 bMe
 bNX
 bQe
-dos
+bGz
 bUe
 xfX
 nAT

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -89158,9 +89158,6 @@
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
-/obj/machinery/light_switch/directional/south{
-	pixel_y = -38
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -89235,6 +89232,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -37958,24 +37958,6 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/locker)
-"dTT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light_switch/directional/south,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
-	},
-/area/security/prison/cell_block/A)
 "dTW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -89175,6 +89157,9 @@
 	},
 /obj/item/radio/intercom{
 	pixel_y = -28
+	},
+/obj/machinery/light_switch/directional/south{
+	pixel_y = -38
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -176838,7 +176823,7 @@ ubg
 wuf
 ojn
 gVB
-dTT
+pKE
 okq
 pZL
 llt


### PR DESCRIPTION
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

<!-- Вы можете совмещать до 2-х тэгов, например, balance/tweak:
Список возможных тэгов для пр-а:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map: Вы меняете только карту.
- image: Вы добавляете/удаляете спрайты.
- sound: Вы добавляете/удаляете звуки.
- spellcheck: Вы исправили опечатку.
- local: Вы добавляете новый текст на русском или переводите на русский.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает
Почему то переключатель света у СЕ был в стекле и его можно было кликать только через альтклик если не разбирать стекло, я убрал 1 табличку ПОД ВЫСОКИМ НАПРЯЖЕНИЕМ(Там еще 1 осталась) и поставил на стену где она была переключатель, в бриге тоже самое.
<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2. В ином случае, опишите баг и его воспроизведение. -->

## Почему это хорошо для игры
Переключатель света в окне не гуд
<!-- Опишите, почему, по вашему, следует добавить эти изменения в билд. -->