### PR TITLE
bugfix: Удален рецепт экспансивных пуль тауруса их автолата

### DIFF
--- a/code/modules/research/designs/protolathe/weapon_designs.dm
+++ b/code/modules/research/designs/protolathe/weapon_designs.dm
@@ -145,7 +145,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 48000)
 	build_path = /obj/item/ammo_box/expansive45colt
-	category = list(PROTOLATHE_CATEGORY_WEAPON, PRINTER_CATEGORY_HACKED, AUTOLATHE_CATEGORY_SECURITY)
+	category = list(PROTOLATHE_CATEGORY_WEAPON)
 
 /datum/design/lmag
 	id = "lmag"


### PR DESCRIPTION
## Что этот ПР делает

Переносил рецепт экспансивных патронов в протолат и проебався, этот пр чинит это.

## Почему это хорошо для игры

Экспансивки слишком мощные чтобы давать сб раундстарт, его переносил в протолат, но неудачно.

## Тестирование

На локалке. В автолате больше нету, в протолате появляется при комбат=2 и материалс=1 в разделе оружия.
