### PR TITLE
tweak: Подключение шлема скафандра к кислородному баллону

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -978,7 +978,7 @@
 	name = "Space helmet"
 	icon_state = "space"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
-	clothing_flags = STOPSPRESSUREDMAGE|THICKMATERIAL
+	clothing_flags = STOPSPRESSUREDMAGE|THICKMATERIAL|AIRTIGHT
 	flags_cover = HEADCOVERSEYES|HEADCOVERSMOUTH
 	flags_inv = parent_type::flags_inv|HIDEHAIR|HIDENAME|HIDEMASK
 	item_state = "s_helmet"

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -96,7 +96,7 @@
 
 /obj/item/clothing/head/helmet/space/vox
 	armor = list(melee = 40, bullet = 40, laser = 30, energy = 15, bomb = 30, bio = 30, rad = 30, fire = 80, acid = 85)
-	clothing_flags = STOPSPRESSUREDMAGE
+	clothing_flags = STOPSPRESSUREDMAGE|AIRTIGHT
 	flags_cover = HEADCOVERSEYES
 	icon = 'icons/obj/clothing/species/vox/hats.dmi'
 	icon_state = null

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -335,7 +335,7 @@
 	var/obj/item/clothing/suit/space/hardsuit/syndi/linkedsuit = null
 	actions_types = list(/datum/action/item_action/toggle_helmet_mode)
 	visor_flags_inv = HIDEMASK|HIDEGLASSES|HIDENAME|HIDETAIL
-	visor_clothing_flags = STOPSPRESSUREDMAGE
+	visor_clothing_flags = STOPSPRESSUREDMAGE|AIRTIGHT
 	var/combat_rad = 50
 	var/combat_slow = 0
 	var/eva_slow = 1
@@ -398,12 +398,12 @@
 
 	if(linkedsuit.on)
 		linkedsuit.slowdown = eva_slow
-		linkedsuit.clothing_flags |= STOPSPRESSUREDMAGE
+		linkedsuit.clothing_flags |= STOPSPRESSUREDMAGE|AIRTIGHT
 		linkedsuit.cold_protection |= (UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS|TAIL)
 		linkedsuit.armor.rad = 100
 	else
 		linkedsuit.slowdown = combat_slow
-		linkedsuit.clothing_flags &= ~STOPSPRESSUREDMAGE
+		linkedsuit.clothing_flags &= ~STOPSPRESSUREDMAGE|AIRTIGHT
 		linkedsuit.cold_protection &= ~(UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS|TAIL)
 		linkedsuit.armor.rad = combat_rad
 
@@ -741,7 +741,7 @@
 	icon_state = "hardsuit-singuloth"
 	item_state = "singuloth_hardsuit"
 	armor = list(melee = 45, bullet = 25, laser = 30, energy = 10, bomb = 25, bio = 100, rad = 100, fire = 95, acid = 95)
-	clothing_flags = STOPSPRESSUREDMAGE
+	clothing_flags = STOPSPRESSUREDMAGE|AIRTIGHT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/singuloth
 	sprite_sheets = null
 

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -186,7 +186,7 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/head.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/head.dmi',
 	)
-	clothing_flags = STOPSPRESSUREDMAGE
+	clothing_flags = STOPSPRESSUREDMAGE|AIRTIGHT
 	flags_cover = HEADCOVERSEYES
 	dog_fashion = /datum/dog_fashion/head/santa
 	species_restricted = null
@@ -227,7 +227,7 @@
 	icon_state = "pirate"
 	item_state = "pirate"
 	armor = list(MELEE = 30, BULLET = 50, LASER = 30,ENERGY = 15, BOMB = 30, BIO = 30, RAD = 30, FIRE = 60, ACID = 75)
-	clothing_flags = STOPSPRESSUREDMAGE
+	clothing_flags = STOPSPRESSUREDMAGE|AIRTIGHT
 	flags_cover = HEADCOVERSEYES
 	strip_delay = 40
 	put_on_delay = 20


### PR DESCRIPTION
## Что этот ПР делает
Дает возможность включить кислородный балон, если надет space helmet.

## Почему это хорошо для игры
QoL.
Плюсы: Теперь можно курить в разгерме.
Минусы:  Теперь можно курить в разгерме.
Баланс СБ/Антаг уничтожен.

## Демонстрация изменений

<!-- Заполните, если Вы меняли спрайты, карту или ваши изменения требуют визуальной демонстрации изменений. -->
<details><summary>Демонстрации изменений</summary>
<p>

<img width="795" height="973" alt="image" src="https://github.com/user-attachments/assets/2b53b22a-98cc-45b2-a51d-433d1fc34152" />
<img width="846" height="970" alt="image" src="https://github.com/user-attachments/assets/8c3d7e57-62f2-4112-b240-352e908b1634" />

</p>
</details>

## Тестирование
МЭКи не трогал. Возможно нужно будет для них делать правки.
