### PR TITLE
bugfix: Исправление названия карго заказов

### DIFF
--- a/code/modules/economy/quests/thing_quests.dm
+++ b/code/modules/economy/quests/thing_quests.dm
@@ -369,11 +369,11 @@
 	required_minerals[item_path] += difficult_list[item_path]["amount"]
 	desc = list()
 	for(var/mineral in required_minerals)
-		var/atom/AM = new item_path(locate(1, 1, 1))
+		var/atom/AM = new mineral(locate(1, 1, 1))
 		var/object_name = AM.declent_ru(NOMINATIVE)
 		qdel(AM)
 
-		desc += "[capitalize(object_name)]<br>Объём: [required_minerals[item_path]]<br>"
+		desc += "[capitalize(object_name)]<br>Объём: [required_minerals[mineral]]<br>"
 	if(item_path in unique_minerals)
 		difficult_list.Remove(item_path)
 	current_list = required_minerals.Copy()

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -63,7 +63,8 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/item/reagent_containers/iv_bag/proc/end_processing()
-	add_attack_logs(injection_target, injection_target, "injection of [name](mode: [mode == IV_INJECT ? "Injecting" : "Drawing"])  stopped.")
+	if(isprocessing)
+		add_attack_logs(injection_target, injection_target, "injection of [name](mode: [mode == IV_INJECT ? "Injecting" : "Drawing"])  stopped.")
 	injection_target = null
 	injection_limb = null
 	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
## Что этот ПР делает

Исправляет баг с формированием списка заказа в карго консоли если выпадает заказ минералов.

## Почему это хорошо для игры

Багфиксы это всегда хорошо.
Ну и надо делать просьбы Вани.

## Демонстрация изменений

<!-- Заполните, если Вы меняли спрайты, карту или ваши изменения требуют визуальной демонстрации изменений. -->
<details><summary>Демонстрации изменений</summary>
<p>

Было:
<img width="464" height="170" alt="image" src="https://github.com/user-attachments/assets/fe0f393c-c7f4-4f1d-98ec-12bcc7114bdc" />

Стало:
<img width="485" height="183" alt="image" src="https://github.com/user-attachments/assets/ea824f27-f3c0-47b2-ae6a-32e6b932048e" />

</p>
</details>

## Тестирование

Проверил на локалке (*не фастлоад, так что пришлось долго ждать запусков*)
