### PR TITLE
bugfix: Исправление бага с горением турели

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -448,8 +448,11 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		if(force < 5)
 			return
 
+	if(health <= 0) //already died
+		return
+
 	health -= force
-	if(force > 5 && prob(45) && spark_system)
+	if(force > 5 && prob(45) && spark_system && !spark_system.total_effects)
 		spark_system.start()
 	if(health <= 0)
 		die()	//the death process :(
@@ -501,6 +504,8 @@ GLOBAL_LIST_EMPTY(turret_icons)
 			take_damage(initial(health) * 8 / 3)
 
 /obj/machinery/porta_turret/proc/die()	//called when the turret dies, ie, health <= 0
+	if(stat & BROKEN)
+		return
 	health = 0
 	stat |= BROKEN	//enables the BROKEN bit
 	if(spark_system)


### PR DESCRIPTION
## Что этот ПР делает

Убирает спам искрами при горении турели.

## Почему это хорошо для игры

Если идет плазмафлуд на спутнике ии - игра зависает намертво у всех кто зайдет в область экрана. Там пойдет большое количество партиклов которые срутся из турели при горении плазмы.

## Тестирование

На локалке перестало зависать при поджоге плазмы рядом с турелью.
