### PR TITLE
bugfix/refactor: Intercom and light switch constructions fix

### DIFF
--- a/_maps/map_files/debug/fast_load_multiz.dmm
+++ b/_maps/map_files/debug/fast_load_multiz.dmm
@@ -14,6 +14,9 @@
 /obj/structure/holosign/barrier/atmos,
 /turf/space,
 /area/space)
+"bP" = (
+/turf/simulated/wall/r_wall,
+/area/fastload)
 "dE" = (
 /obj/machinery/light,
 /turf/simulated/floor/mineral/titanium/purple,
@@ -44,6 +47,12 @@
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/fastload/blue)
+"gC" = (
+/obj/structure/rack,
+/obj/item/mounted/frame/alarm_frame,
+/obj/item/mounted/frame/intercom,
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/fastload)
 "gL" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/stairs{
@@ -141,6 +150,10 @@
 /obj/effect/landmark/spawner/late/cyborg,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/fastload/blue)
+"ze" = (
+/obj/machinery/vending/nta/ertarmory/engineer,
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/fastload)
 "zP" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/mineral/titanium/blue,
@@ -154,6 +167,10 @@
 	},
 /turf/simulated/floor/mineral/titanium/purple,
 /area/fastload/purple)
+"Bc" = (
+/obj/machinery/vending/engivend,
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/fastload)
 "By" = (
 /obj/machinery/light{
 	dir = 8
@@ -163,6 +180,10 @@
 "BO" = (
 /turf/simulated/wall/indestructible/metal,
 /area/fastload/purple)
+"Cc" = (
+/obj/machinery/light_switch/directional/south,
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/fastload)
 "Cd" = (
 /obj/item/clothing/suit/space/hardsuit,
 /turf/simulated/floor/mineral/titanium/blue,
@@ -203,17 +224,28 @@
 /obj/structure/ladder,
 /turf/simulated/floor/mineral/titanium/purple,
 /area/fastload/purple)
-"Pd" = (
-/turf/simulated/openspace,
-/area/fastload)
-"PE" = (
+"ND" = (
+/obj/effect/decal/warning_stripes/arrow{
+	dir = 4
+	},
 /obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/mineral/titanium/purple,
 /area/fastload/purple)
+"Pd" = (
+/turf/simulated/openspace,
+/area/fastload)
 "Qa" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/fastload/blue)
+"RQ" = (
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/rglass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/fastload)
 "Tl" = (
 /obj/structure/ladder,
 /turf/simulated/floor/mineral/titanium/yellow,
@@ -6755,7 +6787,7 @@ YB
 YB
 YB
 YB
-PE
+YB
 BO
 jD
 jD
@@ -6953,7 +6985,7 @@ YB
 YB
 YB
 AX
-AX
+ND
 BO
 jD
 jD
@@ -10584,7 +10616,7 @@ By
 vR
 vR
 vR
-vR
+Bc
 uJ
 jD
 jD
@@ -10648,9 +10680,9 @@ vR
 vR
 vR
 vR
+bP
 vR
-vR
-vR
+ze
 uJ
 jD
 jD
@@ -10716,7 +10748,7 @@ vR
 vR
 vR
 vR
-vR
+RQ
 uJ
 jD
 jD
@@ -10782,7 +10814,7 @@ vR
 vR
 vR
 vR
-vR
+gC
 uJ
 jD
 jD
@@ -11178,7 +11210,7 @@ vR
 vR
 vR
 vR
-vR
+Cc
 uJ
 jD
 jD

--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -71,3 +71,7 @@
 #define MAXCOIL 30
 //Determines how much material is contained in one sheet
 #define SHEET_VOLUME 1000 //cm3
+
+// Mounted Frames BITMASK
+#define MOUNTED_FRAME_SIMFLOOR (1<<0)
+#define MOUNTED_FRAME_NOSPACE (1<<1)

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -356,3 +356,5 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 #define ispowertool(A) (istype(A, /obj/item/crowbar/power) || istype(A, /obj/item/mecha_parts/mecha_equipment/medical/rescue_jaw))
 
 #define is_surgery_tool(W) (istype(W, /obj/item) && (W.tool_behaviour in GLOB.surgery_tool_behaviors))
+
+#define isspacearea(A)	(istype(A, /area/space))

--- a/code/__HELPERS/atoms.dm
+++ b/code/__HELPERS/atoms.dm
@@ -503,39 +503,49 @@
 		steps--
 
 /**
- * Checks for wall-mounted items at a given location and direction
+ * Check if there is already a wall item on the turf loc
  *
  * Arguments:
- * * location - The turf to check for wall items
- * * direction - The direction to check for wall items
+ * * floor_loc - floor tile in front of the wall
+ * * dir_toward_wall - direction from the floor tile in front of the wall towards the wall
+ * * check_external - truthy if we should be checking against items coming out of the wall, rather than visually on top of the wall.
  */
-/proc/check_wall_item(turf/location, direction)
-	for(var/obj/current_object in location)
-		if(is_type_in_typecache(current_object, GLOB.wall_items))
+/proc/check_wall_item(floor_loc, dir_toward_wall, check_external = FALSE)
+	var/wall_loc = get_step(floor_loc, dir_toward_wall)
+	for(var/obj/checked_object in floor_loc)
+		if(!check_external)
+			if(!is_type_in_typecache(checked_object, GLOB.wallitems_interior))
+				continue
+
 			// Direction works sometimes
-			if(current_object.dir == direction)
+			if(checked_object.dir == dir_toward_wall)
 				return TRUE
 
 			// Some stuff doesn't use dir properly, so we need to check pixel instead
-			switch(direction)
-				if(SOUTH)
-					if(current_object.pixel_y > 10)
-						return TRUE
-				if(NORTH)
-					if(current_object.pixel_y < -10)
-						return TRUE
-				if(WEST)
-					if(current_object.pixel_x > 10)
-						return TRUE
-				if(EAST)
-					if(current_object.pixel_x < -10)
-						return TRUE
-
-	// Some stuff is placed directly on the wallturf (signs)
-	for(var/obj/nearby_object in get_step(location, direction))
-		if(is_type_in_typecache(nearby_object, GLOB.wall_items))
-			if(abs(nearby_object.pixel_x) <= 10 && abs(nearby_object.pixel_y) <= 10)
+			// That's exactly what get_turf_pixel() does
+			if(get_turf_pixel(checked_object) == wall_loc)
 				return TRUE
+
+			continue
+
+		if(!is_type_in_typecache(checked_object, GLOB.wallitems_exterior))
+			continue
+
+		if(checked_object.dir == dir_toward_wall)
+			return TRUE
+
+	// Some stuff is placed directly on the wallturf (signs).
+	// If we're only checking for external entities, we don't need to look though these.
+	if(check_external)
+		return FALSE
+
+	for(var/obj/checked_object in wall_loc)
+		if(!is_type_in_typecache(checked_object, GLOB.wallitems_interior))
+			continue
+
+		if(checked_object.pixel_x == 0 && checked_object.pixel_y == 0)
+			return TRUE
+
 	return FALSE
 
 /// Returns the atom type in the specified loc

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -497,31 +497,40 @@
 		skin_list[skin_data.item_path] = list()
 	skin_list[skin_data.item_path] += skin_data
 
-/// Checks if that loc and dir has an item on the wall
-GLOBAL_LIST_INIT(wall_items, typecacheof(list(
-	/obj/machinery/power/apc,
-	/obj/machinery/alarm,
+/**
+ * Checks if that loc and dir has an item on the wall
+**/
+// Wall mounted machinery which are visually on the wall.
+GLOBAL_LIST_INIT(wallitems_interior, typecacheof(list(
 	/obj/item/radio/intercom,
-	/obj/structure/extinguisher_cabinet,
-	/obj/structure/reagent_dispensers/peppertank,
-	/obj/machinery/status_display,
-	/obj/machinery/requests_console,
-	/obj/machinery/light_switch,
-	/obj/structure/sign,
-	/obj/machinery/newscaster,
-	/obj/machinery/firealarm,
-	/obj/structure/noticeboard,
-	/obj/machinery/door_control,
-	/obj/machinery/computer/security/telescreen,
-	/obj/machinery/embedded_controller/radio/airlock,
 	/obj/item/storage/secure/safe,
+	/obj/machinery/alarm,
+	/obj/machinery/computer/security/telescreen,
+	/obj/machinery/computer/security/telescreen/entertainment,
+	/obj/machinery/defibrillator_mount,
+	/obj/machinery/door_control,
 	/obj/machinery/door_timer,
+	/obj/machinery/embedded_controller/radio/airlock,
+	/obj/machinery/firealarm,
 	/obj/machinery/flasher,
 	/obj/machinery/keycard_auth,
-	/obj/structure/mirror,
+	/obj/machinery/light_switch,
+	/obj/machinery/newscaster,
+	/obj/machinery/power/apc,
+	/obj/machinery/requests_console,
+	/obj/machinery/status_display,
 	/obj/structure/closet/fireaxecabinet,
-	/obj/machinery/computer/security/telescreen/entertainment,
+	/obj/structure/extinguisher_cabinet,
+	/obj/structure/mirror,
+	/obj/structure/noticeboard,
+	/obj/structure/reagent_dispensers/peppertank,
 	/obj/structure/sign,
+)))
+
+// Wall mounted machinery which are visually coming out of the wall.
+// These do not conflict with machinery which are visually placed on the wall.
+GLOBAL_LIST_INIT(wallitems_exterior, typecacheof(list(
+	/obj/machinery/light,
 )))
 
 /**

--- a/code/game/machinery/defib_mount.dm
+++ b/code/game/machinery/defib_mount.dm
@@ -167,7 +167,6 @@
 	desc = "Крепление для дефибриллятора, которое предварительно нужно будет закрепить."
 	icon = 'icons/obj/machines/defib_mount.dmi'
 	icon_state = "defibrillator_mount"
-	sheets_refunded = 0
 	materials = list(MAT_METAL = 300, MAT_GLASS = 100)
 	w_class = WEIGHT_CLASS_BULKY
 

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -22,8 +22,12 @@
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 
-/obj/machinery/light_switch/Initialize(mapload)
+/obj/machinery/light_switch/Initialize(mapload, direction)
 	. = ..()
+	if(direction)
+		setDir(direction)
+		set_pixel_offsets_from_dir(26, -26, 26, -26)
+
 	if(istext(area))
 		area = text2path(area)
 

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -31,12 +31,15 @@
 		PREPOSITIONAL = "станционном интеркоме (Общий)",
 	)
 
-/obj/item/radio/intercom/Initialize(mapload, buildstage = INTERCOM_BUILD_SECURED)
+/obj/item/radio/intercom/Initialize(mapload, direction, buildstage = INTERCOM_BUILD_SECURED)
 	. = ..()
 	src.buildstage = buildstage
 	if(buildstage)
 		update_operating_status()
 	else
+		if(direction)
+			setDir(direction)
+			set_pixel_offsets_from_dir(28, -28, 28, -28)
 		b_stat = TRUE
 		set_on(FALSE)
 	GLOB.global_intercoms |= src

--- a/code/game/objects/items/mountable_frames/air_alarm.dm
+++ b/code/game/objects/items/mountable_frames/air_alarm.dm
@@ -8,8 +8,9 @@ Code shamelessly copied from apc_frame
 	desc = "Used for building Air Alarms"
 	icon = 'icons/obj/machines/monitors.dmi'
 	icon_state = "alarm_bitem"
-	materials = list(MAT_METAL=2000)
-	mount_reqs = list("simfloor", "nospace")
+	materials = list(MAT_METAL = 2000)
+	metal_sheets_refunded = 1
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
 
 /obj/item/mounted/frame/alarm_frame/do_build(turf/on_wall, mob/user)
 	var/obj/machinery/alarm/alarm = new(get_turf(src), get_dir(on_wall, user), 1)

--- a/code/game/objects/items/mountable_frames/apc_frame.dm
+++ b/code/game/objects/items/mountable_frames/apc_frame.dm
@@ -3,27 +3,32 @@
 	desc = "Used for repairing or building APCs"
 	icon = 'icons/obj/engines_and_power/apc_repair.dmi'
 	icon_state = "apc_frame"
-	mount_reqs = list("simfloor", "nospace")
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
+	metal_sheets_refunded = 2
 
 /obj/item/mounted/frame/apc_frame/try_build(turf/on_wall, mob/user)
 	if(!..())
 		return
-	var/turf/T = get_turf(user)
-	var/area/A = get_area(T)
-	if(A.get_apc())
+
+	var/turf/build_turf = get_turf(user)
+	var/area/my_area = get_area(build_turf)
+	if(my_area.get_apc())
 		to_chat(user, span_warning("This area already has an APC!"))
 		return //only one APC per area
-	if(!A.requires_power)
+
+	if(!my_area.requires_power)
 		to_chat(user, span_warning("You cannot place [src] in this area!"))
 		return //can't place apcs in areas with no power requirement
-	for(var/obj/machinery/power/terminal/E in T)
-		if(E.master)
+
+	for(var/obj/machinery/power/terminal/terminal in build_turf)
+		if(terminal.master)
 			to_chat(user, span_warning("There is another network terminal here!"))
 			return
 		else
-			new /obj/item/stack/cable_coil(T, 10)
+			new /obj/item/stack/cable_coil(build_turf, 10)
 			to_chat(user, span_notice("You cut the cables and disassemble the unused power terminal."))
-			qdel(E)
+			qdel(terminal)
+
 	return TRUE
 
 /obj/item/mounted/frame/apc_frame/do_build(turf/on_wall, mob/user)

--- a/code/game/objects/items/mountable_frames/apc_frame.dm
+++ b/code/game/objects/items/mountable_frames/apc_frame.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/engines_and_power/apc_repair.dmi'
 	icon_state = "apc_frame"
 	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
-	metal_sheets_refunded = 2
 
 /obj/item/mounted/frame/apc_frame/try_build(turf/on_wall, mob/user)
 	if(!..())

--- a/code/game/objects/items/mountable_frames/buttons_switches.dm
+++ b/code/game/objects/items/mountable_frames/buttons_switches.dm
@@ -3,8 +3,8 @@
 	desc = "Used for repairing or building mass driver buttons"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "launcherbtt_frame"
-	mount_reqs = list("simfloor")
-	sheets_refunded = 1
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR
+	metal_sheets_refunded = 1
 
 /obj/item/mounted/frame/driver_button/do_build(turf/on_wall, mob/user)
 	var/obj/machinery/driver_button/button = new(get_turf(user), get_dir(user, on_wall))
@@ -16,8 +16,8 @@
 	desc = "Used for repairing or building light switches"
 	icon = 'icons/obj/engines_and_power/power.dmi'
 	icon_state = "light-p"
-	mount_reqs = list("simfloor", "nospace")
-	sheets_refunded = 1
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
+	metal_sheets_refunded = 1
 
 /obj/item/mounted/frame/light_switch/do_build(turf/on_wall, mob/user)
 	var/obj/machinery/light_switch/button = new(get_turf(user), get_dir(user, on_wall))
@@ -29,7 +29,7 @@
 	desc = "Used for repairing or building door control buttons"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "doorctrl-panel"
-	sheets_refunded = 1
+	metal_sheets_refunded = 1
 
 /obj/item/mounted/frame/door_control/do_build(turf/on_wall, mob/user)
 	var/obj/machinery/door_control/button = new(get_turf(user), get_dir(user, on_wall), TRUE)

--- a/code/game/objects/items/mountable_frames/extinguisher_frame.dm
+++ b/code/game/objects/items/mountable_frames/extinguisher_frame.dm
@@ -3,7 +3,7 @@
 	desc = "Used for building extinguisher cabinet"
 	icon = 'icons/obj/closet.dmi'
 	icon_state = "extinguisher_frame"
-	mount_reqs = list("simfloor", "nospace")
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
 
 /obj/item/mounted/frame/extinguisher/do_build(turf/on_wall, mob/user)
 	var/obj/structure/extinguisher_cabinet/empty/cabinet = new(get_turf(src), get_dir(user, on_wall))

--- a/code/game/objects/items/mountable_frames/fire_alarm.dm
+++ b/code/game/objects/items/mountable_frames/fire_alarm.dm
@@ -3,7 +3,7 @@
 	desc = "Used for building Fire Alarms"
 	icon = 'icons/obj/machines/monitors.dmi'
 	icon_state = "firealarm_frame"
-	mount_reqs = list("simfloor", "nospace")
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
 
 /obj/item/mounted/frame/firealarm/do_build(turf/on_wall, mob/user)
 	var/obj/machinery/firealarm/alarm = new(get_turf(src), get_dir(user, on_wall), 1)

--- a/code/game/objects/items/mountable_frames/frames.dm
+++ b/code/game/objects/items/mountable_frames/frames.dm
@@ -2,29 +2,41 @@
 	name = "mountable frame"
 	desc = "Place it on a wall."
 	origin_tech = "materials=1;engineering=1"
-	var/sheets_refunded = 2
-	var/list/mount_reqs = list() //can contain simfloor, nospace. Used in try_build to see if conditions are needed, then met
 	usesound = 'sound/items/deconstruct.ogg'
 
-/obj/item/mounted/frame/wrench_act(mob/living/user, obj/item/I)
-	if(!sheets_refunded)
-		return FALSE
+	/// Amount of metal sheets returned upon the frame being wrenched
+	var/metal_sheets_refunded = 2
+	/// Amount of glass sheets returned upon the frame being wrenched
+	var/glass_sheets_refunded = 0
+	/// The requirements for this frame to be placed, uses bit flags
+	var/mount_requirements = 0
+
+/obj/item/mounted/frame/wrench_act(mob/living/user, obj/item/item)
 	. = TRUE
-	if(!I.use_tool(src, user, volume = I.tool_volume))
+	if(!item.use_tool(src, user, volume = item.tool_volume))
 		return .
-	new /obj/item/stack/sheet/metal(drop_location(), sheets_refunded)
+
+	var/turf/user_turf = get_turf(user)
+	if(metal_sheets_refunded)
+		new /obj/item/stack/sheet/metal(user_turf, metal_sheets_refunded)
+	if(glass_sheets_refunded)
+		new /obj/item/stack/sheet/glass(user_turf, glass_sheets_refunded)
+
 	qdel(src)
 
 /obj/item/mounted/frame/try_build(turf/on_wall, mob/user)
-	if(..()) //if we pass the parent tests
-		var/turf/turf_loc = get_turf(user)
+	if(!..())
+		return FALSE
 
-		if(src.mount_reqs.Find("simfloor") && !isfloorturf(turf_loc))
-			to_chat(user, span_warning("[src] cannot be placed on this spot."))
-			return
-		if(src.mount_reqs.Find("nospace"))
-			var/area/my_area = turf_loc.loc
-			if(!istype(my_area) || (my_area.requires_power == 0 || istype(my_area,/area/space)))
-				to_chat(user, span_warning("[src] cannot be placed in this area."))
-				return
-		return 1
+	var/turf/build_turf = get_turf(user)
+	if((mount_requirements & MOUNTED_FRAME_SIMFLOOR) && !isfloorturf(build_turf))
+		to_chat(user, span_warning("[declent_ru(NOMINATIVE)] не может быть размещен[GEND_A_O_Y(src)] на этом месте."))
+		return FALSE
+
+	if(mount_requirements & MOUNTED_FRAME_NOSPACE)
+		var/area/my_area = get_area(build_turf)
+		if(!istype(my_area) || !my_area.requires_power || isspacearea(my_area))
+			to_chat(user, span_warning("[declent_ru(NOMINATIVE)] не может быть размещен[GEND_A_O_Y(src)] в этой зоне."))
+			return FALSE
+
+	return TRUE

--- a/code/game/objects/items/mountable_frames/intercom.dm
+++ b/code/game/objects/items/mountable_frames/intercom.dm
@@ -3,7 +3,7 @@
 	desc = "Used for building intercoms"
 	icon = 'icons/obj/machines/monitors.dmi'
 	icon_state = "intercom-frame"
-	mount_reqs = list("simfloor", "nospace")
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
 
 /obj/item/mounted/frame/intercom/do_build(turf/on_wall, mob/user)
 	new /obj/item/radio/intercom(get_turf(src), get_dir(user, on_wall), 0)

--- a/code/game/objects/items/mountable_frames/lights.dm
+++ b/code/game/objects/items/mountable_frames/lights.dm
@@ -3,8 +3,10 @@
 	desc = "Used for building lights."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "tube-construct-item"
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR
+	wall_external = TRUE
+	/// Specifies which type of light fixture this frame will build
 	var/fixture_type = "tube"
-	mount_reqs = list("simfloor")
 
 /obj/item/mounted/frame/light_fixture/do_build(turf/on_wall, mob/user)
 	to_chat(user, "You begin attaching [src] to \the [on_wall].")
@@ -26,8 +28,10 @@
 	newlight.fingerprintshidden = src.fingerprintshidden
 	newlight.fingerprintslast = src.fingerprintslast
 
-	user.visible_message("[user] attaches \the [src] to \the [on_wall].", \
-		"You attach \the [src] to \the [on_wall].")
+	user.visible_message(
+		"[user] attaches \the [src] to \the [on_wall].",
+		"You attach \the [src] to \the [on_wall].",
+	)
 	qdel(src)
 
 /obj/item/mounted/frame/light_fixture/small
@@ -35,4 +39,4 @@
 	desc = "Used for building small lights."
 	icon_state = "bulb-construct-item"
 	fixture_type = "bulb"
-	sheets_refunded = 1
+	metal_sheets_refunded = 1

--- a/code/game/objects/items/mountable_frames/mountables.dm
+++ b/code/game/objects/items/mountable_frames/mountables.dm
@@ -1,33 +1,40 @@
 /obj/item/mounted
 	var/list/buildon_types = list(/turf/simulated/wall)
+	/// For frames that are external to the wall they are placed on, like light fixtures and cameras.
+	var/wall_external = FALSE
 
-/obj/item/mounted/afterattack(atom/A, mob/user, proximity_flag)
-	var/found_type = 0
-	for(var/turf_type in src.buildon_types)
-		if(istype(A, turf_type))
-			found_type = 1
-			break
+/obj/item/mounted/afterattack(atom/target, mob/user)
+	if(is_type_in_list(target, buildon_types))
+		if(try_build(target, user))
+			return do_build(target, user)
+	..()
 
-	if(found_type)
-		if(try_build(A, user, proximity_flag))
-			return do_build(A, user)
-	else
-		..()
+/**
+ * Check if we can build on this support structure
+ *
+ * Arguments
+ * * atom/support - the atom we are trying to mount on
+ * * mob/user - the player attempting to do the mount
+*/
+/obj/item/mounted/proc/try_build(atom/support, mob/user)
+	if(!support || !user)
+		return FALSE
 
-/obj/item/mounted/proc/try_build(turf/on_wall, mob/user, proximity_flag, params) //checks
-	if(!on_wall || !user)
-		return
-	if(proximity_flag != 1) //if we aren't next to the wall
-		return
-	if(!( get_dir(on_wall,user) in GLOB.cardinal))
-		to_chat(user, span_warning("You need to be standing next to a wall to place \the [src]."))
-		return
+	if(get_dist(support, user) > 1)
+		balloon_alert(user, "вы слишком далеко!")
+		return FALSE
 
-	if(check_wall_item(get_turf(user), get_dir(on_wall,user)))
-		to_chat(user, span_warning("There's already an item on this wall!"))
-		return
+	var/floor_to_support = get_dir(support, user)
+	if(!(floor_to_support in GLOB.cardinal))
+		balloon_alert(user, "встаньте лицом к стене!")
+		return FALSE
 
-	return 1
+	var/turf/wall_location = get_turf(user)
+	if(check_wall_item(wall_location, floor_to_support, wall_external))
+		balloon_alert(user, "здесь уже что-то есть!")
+		return FALSE
+
+	return TRUE
 
 /obj/item/mounted/proc/do_build(turf/on_wall, mob/user) //the buildy bit after we pass the checks
 	return

--- a/code/game/objects/items/mountable_frames/newscaster_frame.dm
+++ b/code/game/objects/items/mountable_frames/newscaster_frame.dm
@@ -3,26 +3,10 @@
 	desc = "Used to build newscasters, just secure to the wall."
 	icon_state = "newscaster"
 	item_state = "syringe_kit"
-	materials = list(MAT_METAL=14000, MAT_GLASS=8000)
-	mount_reqs = list("simfloor", "nospace")
-
-/obj/item/mounted/frame/newscaster_frame/try_build(turf/on_wall, mob/user)
-	if(..())
-		var/turf/loc = get_turf(usr)
-		var/area/A = loc.loc
-		if(!isfloorturf(loc))
-			to_chat(usr, span_alert("Newscaster cannot be placed on this spot."))
-			return
-		if(A.requires_power == 0 || A.name == "Space")
-			to_chat(usr, span_alert("Newscaster cannot be placed in this area."))
-			return
-
-		for(var/obj/machinery/newscaster/T in loc)
-			to_chat(usr, span_alert("There is another newscaster here."))
-			return
-
-		return 1
-	return
+	materials = list(MAT_METAL = 6000, MAT_GLASS = 2000)
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
+	metal_sheets_refunded = 3
+	glass_sheets_refunded = 1
 
 /obj/item/mounted/frame/newscaster_frame/do_build(turf/on_wall, mob/user)
 	var/obj/machinery/newscaster/N = new /obj/machinery/newscaster(get_turf(src), get_dir(on_wall, user), 1)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -820,17 +820,6 @@
 	icon_state = "shower"
 	item_state = "buildpipe"
 
-/obj/item/mounted/shower/try_build(turf/on_wall, mob/user, proximity_flag)
-	//overriding this because we don't care about other items on the wall, but still need to do adjacent checks
-	if(!on_wall || !user)
-		return
-	if(proximity_flag != 1) //if we aren't next to the wall
-		return
-	if(!(get_dir(on_wall, user) in GLOB.cardinal))
-		to_chat(user, span_warning("You need to be standing next to a wall to place \the [src]."))
-		return
-	return 1
-
 /obj/item/mounted/shower/do_build(turf/on_wall, mob/user)
 	var/obj/machinery/shower/S = new(get_turf(user), get_dir(on_wall, user), TRUE)
 	transfer_fingerprints_to(S)

--- a/code/modules/mining/ash_walkers/torch_holder.dm
+++ b/code/modules/mining/ash_walkers/torch_holder.dm
@@ -10,7 +10,8 @@
 	desc = "Один из самых популярных способов осветить пространство в средневековых замках."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "torch_holder_item"
-	mount_reqs = list("simfloor", "nospace")
+	mount_requirements = MOUNTED_FRAME_SIMFLOOR | MOUNTED_FRAME_NOSPACE
+	metal_sheets_refunded = 0
 
 /obj/item/mounted/frame/torch_holder/get_ru_names()
 	return list(


### PR DESCRIPTION
## Что этот ПР делает
Интеркомы и выключатели снова ставятся/собираются с правильными направлениями.
Небольшой рефактор кода вол маунта, но он всё равно плохой. По-хорошему необходимо портировать компонент, юнит тест и объединить всю логику, как на ТГ. Но пока что так.
На фастлоад добавлена разрушаемая стена и несколько вендингов инженерных, чтобы можно было тестировать этот щит.
<img width="341" height="325" alt="image" src="https://github.com/user-attachments/assets/eec872de-5eb8-4ba5-bc51-564e29558b35" />
