### PR TITLE
tweak: Follow links

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -7,5 +7,6 @@
 
 // A link given to ghost alice to follow bob
 #define FOLLOW_LINK(alice, bob) "<a href=byond://?src=[alice.UID()];follow=[bob.UID()]>(F)</a>"
+#define FOLLOW_LINK_WITH_DISPLAY(alice, bob, display) "<a href=byond://?src=[alice.UID()];follow=[bob.UID()]>[display]</a>"
 #define TURF_LINK(alice, turfy) "<a href=byond://?src=[alice.UID()];x=[turfy.x];y=[turfy.y];z=[turfy.z]>(T)</a>"
 #define FOLLOW_OR_TURF_LINK(alice, bob, turfy) "<a href=byond://?src=[alice.UID()];follow=[bob.UID()];x=[turfy.x];y=[turfy.y];z=[turfy.z]>(F)</a>"

--- a/code/__HELPERS/chat.dm
+++ b/code/__HELPERS/chat.dm
@@ -5,8 +5,8 @@
 		if(isnull(source))
 			to_chat(observer, "[message]", type = message_type)
 			continue
-		var/link = FOLLOW_LINK(observer, source)
-		to_chat(observer, "[link] [message]", type = message_type)
+		var/link = ghost_follow_link(observer, source)
+		to_chat(observer, "([link]) [message]", type = message_type)
 
 /// Sends a message to everyone within the list, as well as all observers.
 /proc/relay_to_list_and_observers(message, list/mob_list, source, message_type = null)

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -230,7 +230,7 @@
 	if(!ghost || isliving(ghost))
 		return
 	var/atom/atom_parent = parent
-	to_chat(ghost, span_green("Вы можете снова ввести команду для управления [atom_parent.declent_ru(INSTRUMENTAL)] ([ghost_follow_link(parent, ghost)])."))
+	to_chat(ghost, "([ghost_follow_link(parent, ghost)]) [span_green("Вы можете снова ввести команду для управления [atom_parent.declent_ru(INSTRUMENTAL)].")]")
 
 /// Dummy to call since we can't proc reference builtins
 /datum/component/deadchat_control/proc/_step(ref, dir)

--- a/code/datums/emote/emote.dm
+++ b/code/datums/emote/emote.dm
@@ -207,14 +207,14 @@
 				if(!ghost.client)
 					continue
 				if((ghost.client.prefs.toggles & PREFTOGGLE_CHAT_GHOSTSIGHT) && !(ghost in viewers(user_turf, null)))
-					ghost.show_message(span_italics("[user] ([ghost_follow_link(user, ghost)]) [msg]"), chat_message_type = MESSAGE_TYPE_LOCALCHAT)
+					ghost.show_message(span_emote("([ghost_follow_link(ghost, user)])<b>[user]</b> [msg]"), chat_message_type = MESSAGE_TYPE_LOCALCHAT)
 
 		if(isobserver(user))
 			for(var/mob/dead/observer/ghost in viewers(user))
 				ghost.show_message(span_deadsay("[displayed_msg]"), EMOTE_VISIBLE, chat_message_type = MESSAGE_TYPE_LOCALCHAT)
 
 		else if((emote_type & (EMOTE_AUDIBLE|EMOTE_SOUND)) && user.mind && !user.mind.miming)
-			user.audible_message(displayed_msg, deaf_message = span_italics("You see how <b>[user]</b> [msg]"))
+			user.audible_message(displayed_msg, deaf_message = span_emote("You see how <b>[user]</b> [msg]"))
 		else
 			user.visible_message(displayed_msg)
 
@@ -602,7 +602,7 @@
 			if(!ghost.client)
 				continue
 			if(ghost.client.prefs.toggles & PREFTOGGLE_CHAT_GHOSTSIGHT && !(ghost in viewers(origin_turf, null)))
-				ghost.show_message("[ghost_follow_link(src, ghost)] [ghost_text]")
+				ghost.show_message("([ghost_follow_link(src, ghost)]) [ghost_text]")
 
 	visible_message(text)
 

--- a/code/datums/spells/alien_spells/whisper.dm
+++ b/code/datums/spells/alien_spells/whisper.dm
@@ -25,5 +25,5 @@
 	to_chat(target, "<span class='noticealien'>You hear a strange, alien voice in your head...<span class='noticealien'> [msg]")
 	to_chat(user, span_noticealien("You said: [msg] to [target]"))
 	for(var/mob/dead/observer/ghosts in GLOB.player_list)
-		ghosts.show_message("<i>Alien message from <b>[user]</b> ([ghost_follow_link(user, ghost=ghosts)]) to <b>[target]</b> ([ghost_follow_link(target, ghost=ghosts)]): [msg]</i>")
+		ghosts.show_message("<i>Alien message from ([ghost_follow_link(user, ghost=ghosts)])<b>[user]</b> to ([ghost_follow_link(target, ghost=ghosts)])<b>[target]</b>: [msg]</i>")
 

--- a/code/datums/spells/alien_spells/whisper.dm
+++ b/code/datums/spells/alien_spells/whisper.dm
@@ -25,5 +25,5 @@
 	to_chat(target, "<span class='noticealien'>You hear a strange, alien voice in your head...<span class='noticealien'> [msg]")
 	to_chat(user, span_noticealien("You said: [msg] to [target]"))
 	for(var/mob/dead/observer/ghosts in GLOB.player_list)
-		ghosts.show_message("<i>Alien message from ([ghost_follow_link(user, ghost=ghosts)])<b>[user]</b> to ([ghost_follow_link(target, ghost=ghosts)])<b>[target]</b>: [msg]</i>")
+		ghosts.show_message("<i>Alien message from ([ghost_follow_link(user, ghost = ghosts)])<b>[user]</b> to ([ghost_follow_link(target, ghost=ghosts)])<b>[target]</b>: [msg]</i>")
 

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -248,7 +248,7 @@
 		user.show_message(span_abductor("Вы проецируете свой разум на [(target in user.get_visible_mobs()) ? target.name : "неизвестную сущность"]: [say]"))
 
 		for(var/mob/dead/observer/G in GLOB.player_list)
-			G.show_message(span_italics("Телепатическое сообщение от <b>[user]</b> ([ghost_follow_link(user, ghost=G)]) для <b>[target]</b> ([ghost_follow_link(target, ghost=G)]): [say]"))
+			G.show_message(span_italics("Телепатическое сообщение от ([ghost_follow_link(user, ghost=G)])<b>[user]</b> для ([ghost_follow_link(target, ghost=G)])<b>[target]</b>: [say]"))
 
 /obj/effect/proc_holder/spell/mindscan
 	name = "Scan Mind"
@@ -318,7 +318,7 @@
 		user.show_message(span_abductor("Вы слышите голос [target.name]: [say]"))
 
 		for(var/mob/dead/observer/G in GLOB.player_list)
-			G.show_message(span_italics("Телепатический ответ от <b>[target]</b> ([ghost_follow_link(target, ghost=G)]) для <b>[user]</b> ([ghost_follow_link(user, ghost=G)]): [say]"))
+			G.show_message(span_italics("Телепатический ответ от ([ghost_follow_link(target, ghost=G)])<b>[target]</b> для ([ghost_follow_link(user, ghost=G)])<b>[user]</b>: [say]"))
 
 /obj/effect/proc_holder/spell/mindscan/Destroy()
 	for(var/mob/living/target in available_targets)

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -248,7 +248,7 @@
 		user.show_message(span_abductor("Вы проецируете свой разум на [(target in user.get_visible_mobs()) ? target.name : "неизвестную сущность"]: [say]"))
 
 		for(var/mob/dead/observer/G in GLOB.player_list)
-			G.show_message(span_italics("Телепатическое сообщение от ([ghost_follow_link(user, ghost=G)])<b>[user]</b> для ([ghost_follow_link(target, ghost=G)])<b>[target]</b>: [say]"))
+			G.show_message(span_italics("Телепатическое сообщение от ([ghost_follow_link(user, ghost = G)])<b>[user]</b> для ([ghost_follow_link(target, ghost=G)])<b>[target]</b>: [say]"))
 
 /obj/effect/proc_holder/spell/mindscan
 	name = "Scan Mind"
@@ -318,7 +318,7 @@
 		user.show_message(span_abductor("Вы слышите голос [target.name]: [say]"))
 
 		for(var/mob/dead/observer/G in GLOB.player_list)
-			G.show_message(span_italics("Телепатический ответ от ([ghost_follow_link(target, ghost=G)])<b>[target]</b> для ([ghost_follow_link(user, ghost=G)])<b>[user]</b>: [say]"))
+			G.show_message(span_italics("Телепатический ответ от ([ghost_follow_link(target, ghost = G)])<b>[target]</b> для ([ghost_follow_link(user, ghost=G)])<b>[user]</b>: [say]"))
 
 /obj/effect/proc_holder/spell/mindscan/Destroy()
 	for(var/mob/living/target in available_targets)

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -248,7 +248,7 @@
 
 			for(var/M in GLOB.dead_mob_list)
 				if(isobserver(M))
-					to_chat(M, span_changeling("([ghost_follow_link(src, ghost=M)])<i>Кортикальная связь <b>[truename]</b>: [sended_message]</i>"))
+					to_chat(M, span_changeling("([ghost_follow_link(src, ghost = M)])<i>Кортикальная связь <b>[truename]</b>: [sended_message]</i>"))
 
 		to_chat(src, span_changeling("<i>[truename] [say_string]:</i> [sended_message]"))
 		talk_to_borer_action.Grant(host)
@@ -285,7 +285,7 @@
 
 	for(var/M in GLOB.dead_mob_list)
 		if(isobserver(M))
-			to_chat(M, span_changeling("([ghost_follow_link(src, ghost=M)])<i>Кортикальная связь <b>[src]</b>: [input]</i>"))
+			to_chat(M, span_changeling("([ghost_follow_link(src, ghost = M)])<i>Кортикальная связь <b>[src]</b>: [input]</i>"))
 
 	to_chat(src, span_changeling("<i>[src] says:</i> [input]"))
 
@@ -310,7 +310,7 @@
 
 	for(var/M in GLOB.dead_mob_list)
 		if(isobserver(M))
-			to_chat(M, span_changeling("([ghost_follow_link(src, ghost=M)])<i>Кортикальная связь <b>[B]</b>: [input]</i>"))
+			to_chat(M, span_changeling("([ghost_follow_link(src, ghost = M)])<i>Кортикальная связь <b>[B]</b>: [input]</i>"))
 
 	to_chat(src, span_changeling("<i>[B.truename] says:</i> [input]"))
 

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -241,14 +241,14 @@
 		return
 
 	if(src && !QDELETED(src) && !QDELETED(host))
-		var/say_string = (docile) ? "slurs" :"states"
+		var/say_string = (docile) ? "оскорбляет" :"заявляет"
 		if(host)
 			to_chat(host, span_changeling("<i>[truename] [say_string]:</i> [sended_message]"))
 			add_say_logs(src, sended_message, host, "BORER")
 
 			for(var/M in GLOB.dead_mob_list)
 				if(isobserver(M))
-					to_chat(M, span_changeling("<i>Кортикальная связь <b>[truename]</b> ([ghost_follow_link(src, ghost=M)]): [sended_message]</i>"))
+					to_chat(M, span_changeling("([ghost_follow_link(src, ghost=M)])<i>Кортикальная связь <b>[truename]</b>: [sended_message]</i>"))
 
 		to_chat(src, span_changeling("<i>[truename] [say_string]:</i> [sended_message]"))
 		talk_to_borer_action.Grant(host)
@@ -285,7 +285,7 @@
 
 	for(var/M in GLOB.dead_mob_list)
 		if(isobserver(M))
-			to_chat(M, span_changeling("<i>Кортикальная связь <b>[src]</b> ([ghost_follow_link(src, ghost=M)]): [input]</i>"))
+			to_chat(M, span_changeling("([ghost_follow_link(src, ghost=M)])<i>Кортикальная связь <b>[src]</b>: [input]</i>"))
 
 	to_chat(src, span_changeling("<i>[src] says:</i> [input]"))
 
@@ -310,7 +310,7 @@
 
 	for(var/M in GLOB.dead_mob_list)
 		if(isobserver(M))
-			to_chat(M, span_changeling("<i>Кортикальная связь <b>[B]</b> ([ghost_follow_link(src, ghost=M)]): [input]</i>"))
+			to_chat(M, span_changeling("([ghost_follow_link(src, ghost=M)])<i>Кортикальная связь <b>[B]</b>: [input]</i>"))
 
 	to_chat(src, span_changeling("<i>[B.truename] says:</i> [input]"))
 

--- a/code/game/gamemodes/miniantags/demons/demon.dm
+++ b/code/game/gamemodes/miniantags/demons/demon.dm
@@ -91,7 +91,7 @@
 	to_chat(usr, span_notice("<b>Вы шепчете [choice]: </b>[msg]"))
 	to_chat(choice, "[span_deadsay("<b>Внезапно странный демонический голос звучит у вас в голове... </b>")][span_danger("<i> [msg]</i>")]")
 	for(var/mob/dead/observer/G in GLOB.player_list)
-		G.show_message("<i>Демоническое сообщение от ([ghost_follow_link(usr, ghost=G)])<b>[usr]</b> к ([ghost_follow_link(choice, ghost=G)])<b>[choice]</b>: [msg]</i>")
+		G.show_message("<i>Демоническое сообщение от ([ghost_follow_link(usr, ghost = G)])<b>[usr]</b> к ([ghost_follow_link(choice, ghost = G)])<b>[choice]</b>: [msg]</i>")
 
 /obj/item/organ/internal/heart/demon
 	name = "demon heart"

--- a/code/game/gamemodes/miniantags/demons/demon.dm
+++ b/code/game/gamemodes/miniantags/demons/demon.dm
@@ -91,7 +91,7 @@
 	to_chat(usr, span_notice("<b>Вы шепчете [choice]: </b>[msg]"))
 	to_chat(choice, "[span_deadsay("<b>Внезапно странный демонический голос звучит у вас в голове... </b>")][span_danger("<i> [msg]</i>")]")
 	for(var/mob/dead/observer/G in GLOB.player_list)
-		G.show_message("<i>Демоническое сообщение от <b>[usr]</b> ([ghost_follow_link(usr, ghost=G)]) к <b>[choice]</b> ([ghost_follow_link(choice, ghost=G)]): [msg]</i>")
+		G.show_message("<i>Демоническое сообщение от ([ghost_follow_link(usr, ghost=G)])<b>[usr]</b> к ([ghost_follow_link(choice, ghost=G)])<b>[choice]</b>: [msg]</i>")
 
 /obj/item/organ/internal/heart/demon
 	name = "demon heart"

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -234,7 +234,7 @@
 	// Show the message to any ghosts/dead players.
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(M?.client && M.stat == DEAD && !isnewplayer(M))
-			to_chat(M, span_alien("<i>Сообщение Стража <b>[src]</b> ([ghost_follow_link(src, ghost=M)]): [input]</i>"))
+			to_chat(M, span_alien("([ghost_follow_link(src, ghost=M)])<i>Сообщение Стража <b>[src]</b>: [input]</i>"))
 
 /mob/living/simple_animal/hostile/guardian/proc/ToggleMode()
 	to_chat(src, span_danger("У вас нет другого режима!"))
@@ -314,10 +314,10 @@
 			return
 
 	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Вы хотите поиграть за [mob_name] ([guardian_type]) у [user.real_name]?", ROLE_GUARDIAN, FALSE, 10 SECONDS, source = src, role_cleanname = "[mob_name] ([guardian_type])")
-	
+
 	if(QDELETED(user))
 		return
-		
+
 	var/mob/dead/observer/theghost = null
 
 	if(length(candidates))

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -234,7 +234,7 @@
 	// Show the message to any ghosts/dead players.
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(M?.client && M.stat == DEAD && !isnewplayer(M))
-			to_chat(M, span_alien("([ghost_follow_link(src, ghost=M)])<i>Сообщение Стража <b>[src]</b>: [input]</i>"))
+			to_chat(M, span_alien("([ghost_follow_link(src, ghost = M)])<i>Сообщение Стража <b>[src]</b>: [input]</i>"))
 
 /mob/living/simple_animal/hostile/guardian/proc/ToggleMode()
 	to_chat(src, span_danger("У вас нет другого режима!"))

--- a/code/game/gamemodes/miniantags/guardian/host_actions.dm
+++ b/code/game/gamemodes/miniantags/guardian/host_actions.dm
@@ -39,7 +39,7 @@
 	// Show the message to any ghosts/dead players.
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(M?.client && M.stat == DEAD && !isnewplayer(M))
-			to_chat(M, span_changeling("<i>Сообщение от хранителя <b>[owner]</b> ([ghost_follow_link(owner, ghost=M)]): [input]</i>"))
+			to_chat(M, span_changeling("([ghost_follow_link(owner, ghost=M)])<i>Сообщение от хранителя <b>[owner]</b>: [input]</i>"))
 
 /**
  * # Recall guardian action
@@ -85,10 +85,10 @@
 
 	to_chat(owner, span_danger("Поиск подходящего призрака..."))
 	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Вы хотите занять роль [guardian.real_name]?", ROLE_GUARDIAN, FALSE, 15 SECONDS, source = guardian)
-	
+
 	if(QDELETED(guardian) || QDELETED(owner))
 		return
-	
+
 	if(!LAZYLEN(candidates))
 		to_chat(owner, span_danger("Не нашлось призраков, готовых взять управление вашим хранителем. Попробуйте снова через 5 минут."))
 		log_game("[owner](ckey: [owner.ckey]) has tried to replace their guardian, but there were no candidates willing to enroll.")

--- a/code/game/gamemodes/miniantags/guardian/host_actions.dm
+++ b/code/game/gamemodes/miniantags/guardian/host_actions.dm
@@ -39,7 +39,7 @@
 	// Show the message to any ghosts/dead players.
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(M?.client && M.stat == DEAD && !isnewplayer(M))
-			to_chat(M, span_changeling("([ghost_follow_link(owner, ghost=M)])<i>Сообщение от хранителя <b>[owner]</b>: [input]</i>"))
+			to_chat(M, span_changeling("([ghost_follow_link(owner, ghost = M)])<i>Сообщение от хранителя <b>[owner]</b>: [input]</i>"))
 
 /**
  * # Recall guardian action

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -137,7 +137,7 @@
 		return emote(copytext(message, 2), intentional = TRUE)
 
 	for(var/mob/M in GLOB.mob_list)
-		var/rendered = span_revennotice("<b>[src]</b> [(isobserver(M) ? ("([ghost_follow_link(src, ghost=M)])") : "")] говорит: \"[message]\"")
+		var/rendered = span_revennotice("[(isobserver(M) ? ("([ghost_follow_link(src, ghost=M)])") : "")]<b>[src]</b> говорит: \"[message]\"")
 		if(istype(M, /mob/living/simple_animal/revenant) || isobserver(M))
 			to_chat(M, rendered)
 
@@ -178,10 +178,10 @@
 		giveSpells()
 	else
 		var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Вы хотите занять роль Ревенанта?", poll_time = 15 SECONDS, source = /mob/living/simple_animal/revenant)
-		
+
 		if(QDELETED(src))
 			return
-			
+
 		var/mob/dead/observer/theghost = null
 		if(length(candidates))
 			theghost = pick(candidates)
@@ -473,7 +473,7 @@
 
 	if(!key_of_revenant)
 		message_admins("The new revenant's old client either could not be found or is in a new, living mob - grabbing a random candidate instead...")
-		var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a revenant?", ROLE_REVENANT, TRUE, source = /mob/living/simple_animal/revenant)		
+		var/list/candidates = SSghost_spawns.poll_candidates("Do you want to play as a revenant?", ROLE_REVENANT, TRUE, source = /mob/living/simple_animal/revenant)
 		if(length(candidates))
 			var/mob/new_owner = pick(candidates)
 			key_of_revenant = new_owner.key

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -137,7 +137,7 @@
 		return emote(copytext(message, 2), intentional = TRUE)
 
 	for(var/mob/M in GLOB.mob_list)
-		var/rendered = span_revennotice("[(isobserver(M) ? ("([ghost_follow_link(src, ghost=M)])") : "")]<b>[src]</b> говорит: \"[message]\"")
+		var/rendered = span_revennotice("[(isobserver(M) ? ("([ghost_follow_link(src, ghost = M)])") : "")]<b>[src]</b> говорит: \"[message]\"")
 		if(istype(M, /mob/living/simple_animal/revenant) || isobserver(M))
 			to_chat(M, rendered)
 

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -3,7 +3,7 @@
 	desc = "The first three prototypes were discontinued after mass casualty incidents."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "disco0"
-	atom_say_verb = "states"
+	atom_say_verb = "заявляет"
 	density = TRUE
 	var/active = FALSE
 	var/list/rangers = list()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3995,25 +3995,33 @@
 	tatorhud.join_hud(hunter_mob)
 	set_antag_hud(hunter_mob, "hudsyndicate")
 
-/proc/admin_jump_link(atom/target)
-	if(!target) return
+/**
+ * Generates admin follow links for tracking specific atoms, with special handling for clients, AIs, and observer mobs
+ *
+ * Arguments:
+ * * target_atom - The atom to create an admin follow link for
+ */
+/proc/admin_jump_link(atom/target_atom)
+	if(!target_atom)
+		return
+
 	// The way admin jump links handle their src is weirdly inconsistent...
+	if(isclient(target_atom))
+		var/client/target_client = target_atom
+		if(target_client.mob)
+			target_atom = target_client.mob
 
-	if(isclient(target))
-		var/client/C = target
-		if(C.mob)
-			target = C.mob
+	. = ADMIN_FLW(target_atom, "FLW")
 
-	. = ADMIN_FLW(target, "FLW")
+	if(isAI(target_atom)) // AI core/eye follow links
+		var/mob/living/silicon/ai/ai_instance = target_atom
+		if(ai_instance.client && ai_instance.eyeobj) // No point following clientless AI eyes
+			. += "|[ADMIN_FLW(ai_instance.eyeobj, "EYE")]"
 
-	if(isAI(target)) // AI core/eye follow links
-		var/mob/living/silicon/ai/A = target
-		if(A.client && A.eyeobj) // No point following clientless AI eyes
-			. += "|[ADMIN_FLW(A.eyeobj,"EYE")]"
-	else if(istype(target, /mob/dead/observer))
-		var/mob/dead/observer/O = target
-		if(O.mind && O.mind.current)
-			. += "|[ADMIN_FLW(O.mind.current,"BDY")]"
+	else if(isobserver(target_atom))
+		var/mob/dead/observer/observer_instance = target_atom
+		if(observer_instance.mind && observer_instance.mind.current)
+			. += "|[ADMIN_FLW(observer_instance.mind.current, "BDY")]"
 
 /proc/you_realy_want_do_this(mob/user)
 	user = user || usr

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -19,7 +19,7 @@ GLOBAL_LIST_EMPTY(overminds)
 	layer = FLY_LAYER
 	plane = ABOVE_GAME_PLANE
 	pass_flags = PASSBLOB
-	verb_say = "states"
+	verb_say = "заявляет"
 
 	hud_type = /datum/hud/blob_overmind
 	var/obj/structure/blob/special/core/blob_core = null // The blob overmind's core

--- a/code/modules/antagonists/vampire/vampire_powers/dantalion_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/dantalion_powers.dm
@@ -134,7 +134,7 @@
 		to_chat(player, span_gamesay("<i>Рабская телепатия, [span_name("[title]")] телепатезирует, [message]<i>"))
 
 	for(var/mob/ghost in GLOB.dead_mob_list)
-		to_chat(ghost, span_gamesay("<i>Рабская телепатия, [span_name("[title]")] ([ghost_follow_link(user, ghost)]) телепатезирует, [message]<i>"))
+		to_chat(ghost, span_gamesay("([ghost_follow_link(user, ghost)])<i>Рабская телепатия, [span_name("[title]")] телепатезирует, [message]<i>"))
 
 	log_say("(DANTALION) [input]", user)
 	user.create_log(SAY_LOG, "(DANTALION) [input]")

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -58,6 +58,6 @@
 		patient_zero = H
 
 		for(var/mob/M in GLOB.dead_mob_list)
-			to_chat(M, span_deadsay("<b>[patient_zero]</b> был(а) заражён(а) <b>[D.name]</b> ([ghost_follow_link(patient_zero, M)])"))
+			to_chat(M, span_deadsay("([ghost_follow_link(patient_zero, M)])<b>[patient_zero]</b> был[GEND_A_O_I(patient_zero)] заражён[GEND_A_O_Y(patient_zero)] <b>[D.name]</b>"))
 
 		break

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -49,7 +49,7 @@
 				to_chat(ai_player, "<br>")
 
 				for(var/ghost in GLOB.dead_mob_list)
-					to_chat(ghost, span_deadsay("<b>[ai_player] ([ghost_follow_link(ai_player, ghost)])</b> получил новый закон:\n<b>'[message]'</b>"))
+					to_chat(ghost, span_deadsay("([ghost_follow_link(ai_player, ghost)])<b>[ai_player]</b> получил новый закон:\n<b>'[message]'</b>"))
 
 	if(botEmagChance)
 		for(var/mob/living/simple_animal/bot/bot as anything in GLOB.bots_list)

--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -351,7 +351,7 @@
 
 	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Хотите стать духом талисмана защиты [user.real_name]?", ROLE_PAI, FALSE, 15 SECONDS, source = src)
 	var/mob/dead/observer/theghost = null
-	
+
 	if(QDELETED(slave) || QDELETED(src))
 		return
 
@@ -525,7 +525,7 @@
 	to_chat(usr, span_hierophant("Вы говорите в разум [choice]:</b> [msg]"))
 	to_chat(choice, "[span_deadsay(span_hierophant("Странные, магические и одновременно чуждые мысли обращаются к вам..."))] [span_hierophant("[msg]")]")
 	for(var/mob/dead/observer/G in GLOB.player_list)
-		G.show_message(span_hierophant("Послание Иерофанта от <b>[usr]</b> ([ghost_follow_link(usr, ghost=G)]) к <b>[choice]</b> ([ghost_follow_link(choice, ghost=G)]): [msg]</i>")) //what the fuck...
+		G.show_message(span_hierophant("Послание Иерофанта от ([ghost_follow_link(usr, ghost=G)])<b>[usr]</b> к \[[ghost_follow_link(choice, ghost=G)]\]<b>[choice]</b>: [msg]</i>")) //what the fuck...
 
 /obj/item/clothing/accessory/necklace/hierophant_talisman/on_attached(obj/item/clothing/under/new_suit, mob/attacher)
 	. = ..()

--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -525,7 +525,7 @@
 	to_chat(usr, span_hierophant("Вы говорите в разум [choice]:</b> [msg]"))
 	to_chat(choice, "[span_deadsay(span_hierophant("Странные, магические и одновременно чуждые мысли обращаются к вам..."))] [span_hierophant("[msg]")]")
 	for(var/mob/dead/observer/G in GLOB.player_list)
-		G.show_message(span_hierophant("Послание Иерофанта от ([ghost_follow_link(usr, ghost=G)])<b>[usr]</b> к \[[ghost_follow_link(choice, ghost=G)]\]<b>[choice]</b>: [msg]</i>")) //what the fuck...
+		G.show_message(span_hierophant("Послание Иерофанта от ([ghost_follow_link(usr, ghost = G)])<b>[usr]</b> к \[[ghost_follow_link(choice, ghost = G)]\]<b>[choice]</b>: [msg]</i>")) //what the fuck...
 
 /obj/item/clothing/accessory/necklace/hierophant_talisman/on_attached(obj/item/clothing/under/new_suit, mob/attacher)
 	. = ..()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -614,22 +614,32 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	return ..()
 
+/**
+ * Generates follow links for ghosts to track specific atoms, with special handling for AIs and observer mobs
+ *
+ * Arguments:
+ * * target - The atom to create a follow link for
+ * * ghost - The ghost mob that will use the follow link
+ */
 /proc/ghost_follow_link(atom/target, atom/ghost)
-	if((!target) || (!ghost)) return
-	if(isAI(target)) // AI core/eye follow links
-		var/mob/living/silicon/ai/A = target
-		. = "<a href='byond://?src=[ghost.UID()];follow=[A.UID()]'>ядро</a>"
-		if(A.client && A.eyeobj) // No point following clientless AI eyes
-			. += "|<a href='byond://?src=[ghost.UID()];follow=[A.eyeobj.UID()]'>око</a>"
+	if(!istype(target) || !istype(ghost))
 		return
-	else if(istype(target, /mob/dead/observer))
-		var/mob/dead/observer/O = target
-		. = "<a href='byond://?src=[ghost.UID()];follow=[target.UID()]'>следовать</a>"
-		if(O.mind && O.mind.current)
-			. += "|<a href='byond://?src=[ghost.UID()];follow=[O.mind.current.UID()]'>тело</a>"
+
+	if(isAI(target)) // AI core/eye follow links
+		var/mob/living/silicon/ai/ai = target
+		. = FOLLOW_LINK_WITH_DISPLAY(ghost, ai, "ядро")
+		if(ai.client && ai.eyeobj) // No point following clientless AI eyes
+			. += "|[FOLLOW_LINK_WITH_DISPLAY(ghost, ai.eyeobj, "глаз")]"
+		return
+
+	else if(isobserver(target))
+		var/mob/dead/observer/observer = target
+		. = FOLLOW_LINK_WITH_DISPLAY(ghost, target, "следовать")
+		if(observer.mind && observer.mind.current)
+			. += "|[FOLLOW_LINK_WITH_DISPLAY(ghost, observer.mind.current, "тело")]"
 		return
 	else
-		return "<a href='byond://?src=[ghost.UID()];follow=[target.UID()]'>следовать</a>"
+		return FOLLOW_LINK_WITH_DISPLAY(ghost, target, "следовать")
 
 //BEGIN TELEPORT HREF CODE
 /mob/dead/observer/Topic(href, href_list)
@@ -820,18 +830,30 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return TRUE
 
 /**
+ * Handles the pointing action for observer mobs, notifying nearby mobs and adding a follow link for invisible ghosts
+ *
  * This is a mob verb instead of atom for performance reasons.
  * See /mob/verb/examinate() in mob.dm for more info.
  * Overriden here and in /mob/living for different point span classes and sanity checks.
+ *
+ * Arguments:
+ * * target - The atom that the observer is pointing at
  */
 /mob/dead/observer/run_pointed(atom/target)
 	if(!..())
 		return FALSE
-	var/follow_link
-	if(invisibility) // Only show the button if the ghost is not visible to the living
-		follow_link = " ([ghost_follow_link(target, src)])"
-	usr.visible_message(span_deadsay("<b>[src]</b> указывает на [target][follow_link]."))
-	add_deadchat_logs(src, "point to [key_name(target)] [COORD(target)]")
+
+	for(var/mob/current_mob in range(7, src))
+		if(current_mob.see_invisible < invisibility)
+			continue // can't view the invisible
+
+		var/follow_button
+		if(invisibility) // Only show the button if the ghost is not visible to the living
+			follow_button = "([ghost_follow_link(target, current_mob)])" // Ghost needs to be link clicker, otherwise it breaks
+
+		current_mob.show_message(span_deadsay("<b>[src]</b> указыва[PLUR_ET_YUT(src)] на [follow_button] [target]."), EMOTE_VISIBLE)
+		add_deadchat_logs(src, "point to [key_name(target)] [COORD(target)]")
+
 	return TRUE
 
 /mob/dead/observer/proc/incarnate_ghost(use_old_mind=FALSE)

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -8,7 +8,7 @@
 	return say_dead(message)
 
 /mob/dead/observer/handle_track(message, verb = "говор%(ит,ят)%", atom/movable/speaker = null, speaker_name, atom/follow_target, hard_to_hear)
-	return "([ghost_follow_link(follow_target, ghost=src)])[speaker_name]"
+	return "([ghost_follow_link(follow_target, ghost = src)])[speaker_name]"
 
 /mob/dead/observer/handle_speaker_name(atom/movable/speaker = null, vname, hard_to_hear, check_name_against)
 	var/speaker_name = ..()

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -8,7 +8,7 @@
 	return say_dead(message)
 
 /mob/dead/observer/handle_track(message, verb = "говор%(ит,ят)%", atom/movable/speaker = null, speaker_name, atom/follow_target, hard_to_hear)
-	return "[speaker_name] ([ghost_follow_link(follow_target, ghost=src)])"
+	return "([ghost_follow_link(follow_target, ghost=src)])[speaker_name]"
 
 /mob/dead/observer/handle_speaker_name(atom/movable/speaker = null, vname, hard_to_hear, check_name_against)
 	var/speaker_name = ..()

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -158,7 +158,7 @@
 		else
 			to_chat(src, "[span_name(speaker.name)] что-то говор[PLUR_IT_YAT(speaker)], но вы ничего не слышите!")
 	else
-		to_chat(src, span_gamesay("[span_name(speaker_name)][speaker.GetAltName()] [track][verb_message(message_pieces, message, speaker, genderize_decode(speaker, verb))]"))
+		to_chat(src, span_gamesay("[track][span_name(speaker_name)][speaker.GetAltName()] [verb_message(message_pieces, message, speaker, genderize_decode(speaker, verb))]"))
 
 		// Create map text message
 		if(client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT) // can_hear is checked up there on L99

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -133,7 +133,7 @@
 	var/msg = span_gamesay("[name], [span_name("[speaker_mask]")] [genderize_decode(speaker, get_spoken_verb(message))], [format_message(message, speaker)]")
 	for(var/mob/player in GLOB.player_list)
 		if(istype(player,/mob/dead) && follow)
-			var/msg_dead = span_gamesay("[name], [span_name("[speaker_mask]")] ([ghost_follow_link(speaker, ghost=player)]) [genderize_decode(speaker, get_spoken_verb(message))], [format_message(message, speaker)]")
+			var/msg_dead = span_gamesay("([ghost_follow_link(speaker, ghost=player)])[name], [span_name("[speaker_mask]")] [genderize_decode(speaker, get_spoken_verb(message))], [format_message(message, speaker)]")
 			to_chat(player, msg_dead)
 			continue
 
@@ -746,23 +746,31 @@
 
 	add_say_logs(speaker, message, language = "ROBOT")
 
-	var/message_start = "<i><span class='game say'>[name], [span_name("[speaker.name]")]"
-	var/message_body = span_message("[speaker.say_quote(message)]:</i>[span_robot("\"[message]\"")]</span>")
+	var/list/message_start = list("<i><span class='game say'>[name], [span_name("[speaker.name]")]") //Strings as lists lets you add blocks of text much easier
+	var/list/message_body = list(span_message("[speaker.say_quote(message)],</i>[span_robot("\"[message]\"")]</span>"))
 
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(!isnewplayer(M) && !isbrain(M))
-			var/message_start_dead = "<i><span class='game say'>[name], [span_name("[speaker.name] ([ghost_follow_link(speaker, ghost=M)])")]"
-			M.show_message("[message_start_dead] [message_body]", 2)
+			var/list/message_start_dead = list("([ghost_follow_link(speaker, ghost=M)])<i><span class='game say'>[name], [span_name("[speaker.name]")]")
+			var/list/dead_message = message_start_dead + message_body
+			M.show_message(dead_message.Join(" "), 2)
 
 	for(var/mob/living/S in GLOB.alive_mob_list)
-		if(drone_only && !(isdrone(S)||iscogscarab(S)))
+		if(!S.binarycheck())
+			continue
+		else if(drone_only && !(isdrone(S) || iscogscarab(S)))
 			continue
 		else if(isAI(S))
-			message_start = "<i><span class='game say'>[name], <a href='byond://?src=[S.UID()];track=[speaker.UID()]'>[span_name("[speaker.name]")]</a>"
-		else if(!S.binarycheck())
-			continue
-
-		S.show_message("[message_start] [message_body]", 2)
+			message_start = list("<i><span class='game say'>[name], <a href='byond://?src=[S.UID()];track=[speaker.UID()]'>[span_name("[speaker.name]")]</a>")
+		else if(isrobot(S))
+			var/mob/living/silicon/robot/borg = S
+			if(borg.connected_ai?.name == speaker.name)
+				var/list/big_font_prefix = list("<font size=4>")
+				var/list/big_font_suffix = list("</font>")
+				message_start = big_font_prefix + message_start
+				message_body = message_body + big_font_suffix
+		var/list/final_message = message_start + message_body
+		S.show_message(final_message.Join(" "), 2)
 
 	var/list/listening = hearers(1, src)
 	listening -= src
@@ -770,7 +778,7 @@
 	for(var/mob/living/M in listening)
 		if(issilicon(M) || M.binarycheck())
 			continue
-		M.show_message(span_gamesay("<i>[span_name("синтезированный голос")] [span_message("сообщает: \"бип бип бип\"")]</i>"),2)
+		M.show_message("<i><span class='game say'>[span_name("synthesised voice")] [span_message("beeps, \"beep beep beep\"")]</span></i>",2)
 
 /datum/language/binary/drone
 	name = LANGUAGE_DRONE_BINARY

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -751,7 +751,7 @@
 
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(!isnewplayer(M) && !isbrain(M))
-			var/list/message_start_dead = list("([ghost_follow_link(speaker, ghost=M)])<i><span class='game say'>[name], [span_name("[speaker.name]")]")
+			var/list/message_start_dead = list("([ghost_follow_link(speaker, ghost = M)])<i><span class='game say'>[name], [span_name("[speaker.name]")]")
 			var/list/dead_message = message_start_dead + message_body
 			M.show_message(dead_message.Join(" "), 2)
 
@@ -778,7 +778,7 @@
 	for(var/mob/living/M in listening)
 		if(issilicon(M) || M.binarycheck())
 			continue
-		M.show_message("<i><span class='game say'>[span_name("synthesised voice")] [span_message("beeps, \"beep beep beep\"")]</span></i>",2)
+		M.show_message("<i>[span_gamesay("[span_name("synthesised voice")] [span_message("beeps, \"beep beep beep\"")]")]</i>", 2)
 
 /datum/language/binary/drone
 	name = LANGUAGE_DRONE_BINARY

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -133,7 +133,7 @@
 	var/msg = span_gamesay("[name], [span_name("[speaker_mask]")] [genderize_decode(speaker, get_spoken_verb(message))], [format_message(message, speaker)]")
 	for(var/mob/player in GLOB.player_list)
 		if(istype(player,/mob/dead) && follow)
-			var/msg_dead = span_gamesay("([ghost_follow_link(speaker, ghost=player)])[name], [span_name("[speaker_mask]")] [genderize_decode(speaker, get_spoken_verb(message))], [format_message(message, speaker)]")
+			var/msg_dead = span_gamesay("([ghost_follow_link(speaker, ghost = player)])[name], [span_name("[speaker_mask]")] [genderize_decode(speaker, get_spoken_verb(message))], [format_message(message, speaker)]")
 			to_chat(player, msg_dead)
 			continue
 
@@ -765,8 +765,8 @@
 		else if(isrobot(S))
 			var/mob/living/silicon/robot/borg = S
 			if(borg.connected_ai?.name == speaker.name)
-				var/list/big_font_prefix = list("<font size=4>")
-				var/list/big_font_suffix = list("</font>")
+				var/list/big_font_prefix = list("<span style='font-size: 18px;'>")
+				var/list/big_font_suffix = list("</span>")
 				message_start = big_font_prefix + message_start
 				message_body = message_body + big_font_suffix
 		var/list/final_message = message_start + message_body

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -18,7 +18,7 @@
 	var/designation = ""
 	var/obj/item/camera/siliconcam/aiCamera = null //photography
 //Used in say.dm, allows for pAIs to have different say flavor text, as well as silicons, although the latter is not implemented.
-	var/speak_statement = "states"
+	var/speak_statement = "заявляет"
 	var/speak_exclamation = "declares"
 	var/speak_query = "queries"
 	var/pose //Yes, now AIs can pose too.

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/ghost.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/ghost.dm
@@ -19,7 +19,7 @@
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/humanize_spider()
 	add_datum_if_not_exist()
 	for(var/mob/dead/observer/G in GLOB.player_list)
-		G.show_message("<i>Призрак взял управление <b>[declent_ru(INSTRUMENTAL)]</b>. ([ghost_follow_link(src, ghost=G)]).</i>")
+		G.show_message("([ghost_follow_link(src, ghost=G)]) <i>Призрак взял управление <b>[declent_ru(INSTRUMENTAL)]</b>.</i>")
 
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/add_datum_if_not_exist()
 	if(mind && !mind.has_antag_datum(/datum/antagonist/terror_spider))

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/ghost.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/ghost.dm
@@ -19,7 +19,7 @@
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/humanize_spider()
 	add_datum_if_not_exist()
 	for(var/mob/dead/observer/G in GLOB.player_list)
-		G.show_message("([ghost_follow_link(src, ghost=G)]) <i>Призрак взял управление <b>[declent_ru(INSTRUMENTAL)]</b>.</i>")
+		G.show_message("([ghost_follow_link(src, ghost = G)]) <i>Призрак взял управление <b>[declent_ru(INSTRUMENTAL)]</b>.</i>")
 
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/add_datum_if_not_exist()
 	if(mind && !mind.has_antag_datum(/datum/antagonist/terror_spider))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -114,10 +114,10 @@
 		question += ", [offer_mob.mind?.special_role ? offer_mob.mind?.special_role : "Нет спец-роли"]"
 	var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("[question]?", poll_time = 10 SECONDS, min_hours = minhours, source = offer_mob)
 	var/mob/dead/observer/theghost = null
-	
+
 	if(QDELETED(offer_mob))
 		return
-		
+
 	REMOVE_TRAIT(offer_mob, TRAIT_BEING_OFFERED, ADMIN_OFFER_TRAIT)
 
 	if(LAZYLEN(candidates))
@@ -487,7 +487,7 @@ GLOBAL_LIST_INIT(intents, list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM
 					else										// Everyone else (dead people who didn't ghost yet, etc.)
 						lname = name
 				lname = "[span_name("[lname]")] "
-			to_chat(M, span_deadsay("[lname][follow][message]"))
+			to_chat(M, span_deadsay("[follow][lname][message]"))
 
 /proc/notify_ghosts(message, ghost_sound = null, enter_link = null, title = null, atom/source = null, image/alert_overlay = null, flashwindow = TRUE, action = NOTIFY_JUMP) //Easy notification of ghosts.
 	for(var/mob/dead/observer/O in GLOB.player_list)

--- a/code/modules/pda/messenger.dm
+++ b/code/modules/pda/messenger.dm
@@ -170,7 +170,7 @@
 		if(!isobserver(mob) || !mob.client || !HASBIT(mob.client.prefs.toggles, PREFTOGGLE_CHAT_GHOSTPDA))
 			continue
 
-		var/ghost_message = "[span_name("[pda.owner]")] ([ghost_follow_link(pda, ghost = mob)]) [span_gamesay("Сообщение на КПК")] --> [span_name("[recipient_pda.owner]")] ([ghost_follow_link(recipient_pda, ghost = mob)]): [span_message("[message]")]"
+		var/ghost_message = "([ghost_follow_link(pda, ghost = mob)])[span_name("[pda.owner]")] [span_gamesay("Сообщение на КПК")] --> ([ghost_follow_link(recipient_pda, ghost = mob)])[span_name("[recipient_pda.owner]")]: [span_message("[message]")]"
 		to_chat(mob, "[ghost_message]")
 
 /datum/data/pda/app/messenger/proc/can_send_message(message, sender, recipient_pda, useMS)


### PR DESCRIPTION
## Что этот ПР делает
Переделал фоллоу линки везде так, чтобы они были не после указываемого объекта, а до. Это упрощает попадание по линку, вне зависимости от названия объекта и кол-ва спама в чате.

Помимо этого также:
https://github.com/ParadiseSS13/Paradise/pull/23504
https://github.com/ParadiseSS13/Paradise/pull/20617

- Переведены сей вербы "states"
- Фикс ссылок поинт ту для гостов
- ИИ выделяется большим жирным в бинарном

## Демонстрация изменений

<!-- Заполните, если Вы меняли спрайты, карту или ваши изменения требуют визуальной демонстрации изменений. -->
<details><summary>Демонстрации изменений</summary>
<p>

**Квадратные скобки на скринах заменены обратно на круглые!**
<img width="419" height="26" alt="image" src="https://github.com/user-attachments/assets/6b912c2d-adff-4cfd-af41-81e9ac908cd5" />
<img width="367" height="25" alt="image" src="https://github.com/user-attachments/assets/e5e9a564-a4cb-493d-ba4e-78c6dd5d8fca" />
<img width="521" height="32" alt="image" src="https://github.com/user-attachments/assets/680cc1ae-e2a1-4deb-ad14-11a342c3b70f" />
<img width="365" height="27" alt="image" src="https://github.com/user-attachments/assets/636d401a-a03a-4b2a-bfd8-6f2a78563ba9" />
<img width="493" height="57" alt="image" src="https://github.com/user-attachments/assets/535c3096-2496-4390-8572-e85bcdb08b49" />

</p>
</details>
