### PR TITLE
server/bugfix: Launch fast_load task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,8 +15,8 @@
             "type": "byond",
             "request": "launch",
             "name": "Fast Launch DreamSeeker(no CC)",
-            "preLaunchTask": "dm: build - fast_${command:CurrentDME}",
-            "dmb": "${workspaceFolder}/fast_${command:CurrentDMB}",
+            "preLaunchTask": "dm: build - fast_paradise.dme",
+            "dmb": "${workspaceFolder}/fast_paradise.dmb",
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,45 +11,45 @@
 			"label": "dm: build - paradise.dme"
 		},
 		{
-            "label": "Create FAST_LOAD DME",
-            "type": "shell",
-            "command": "cmd",
-            "args": [
-                "/c",
-                "(echo #define FAST_LOAD && type \"paradise.dme\") > \"fast_paradise.dme\" && echo Created fast_paradise.dme"
-            ],
-            "problemMatcher": []
-        },
-        {
-            "label": "Build FAST_LOAD DME",
-            "dependsOn": "Create FAST_LOAD DME",
-            "type": "dreammaker",
-            "dme": "fast_paradise.dme",
-            "problemMatcher": [
-                "$dreammaker"
-            ]
-        },
-        {
-            "label": "Remove FAST_LOAD DME",
-            "dependsOn": "Create FAST_LOAD DME",
-            "type": "shell",
-            "command": "cmd",
-            "args": [
-                "/c",
-                "timeout /t 3 /nobreak >nul && del \"fast_paradise.dme\" && echo Temporary file cleaned up"
-            ],
-            "problemMatcher": []
-        },
-        {
-            "label": "dm: build - fast_paradise.dme",
-            "dependsOrder": "sequence",
-            "dependsOn": [
-                "Create FAST_LOAD DME",
-                "Build FAST_LOAD DME",
-                "Remove FAST_LOAD DME"
-            ],
-            "group": "build",
-            "problemMatcher": []
-        }
+			"label": "Create FAST_LOAD DME",
+			"type": "shell",
+			"command": "cmd",
+			"args": [
+				"/c",
+				"(echo #define FAST_LOAD && type \"paradise.dme\") > \"fast_paradise.dme\" && echo Created fast_paradise.dme"
+			],
+			"problemMatcher": []
+		},
+		{
+			"label": "Build FAST_LOAD DME",
+			"dependsOn": "Create FAST_LOAD DME",
+			"type": "dreammaker",
+			"dme": "fast_paradise.dme",
+			"problemMatcher": [
+				"$dreammaker"
+			]
+		},
+		{
+			"label": "Remove FAST_LOAD DME",
+			"dependsOn": "Create FAST_LOAD DME",
+			"type": "shell",
+			"command": "cmd",
+			"args": [
+				"/c",
+				"timeout /t 3 /nobreak >nul && del \"fast_paradise.dme\" && echo Temporary file cleaned up"
+			],
+			"problemMatcher": []
+		},
+		{
+			"label": "dm: build - fast_paradise.dme",
+			"dependsOrder": "sequence",
+			"dependsOn": [
+				"Create FAST_LOAD DME",
+				"Build FAST_LOAD DME",
+				"Remove FAST_LOAD DME"
+			],
+			"group": "build",
+			"problemMatcher": []
+		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,7 +31,7 @@
 		},
 		{
 			"label": "Remove FAST_LOAD DME",
-			"dependsOn": "Create FAST_LOAD DME",
+			"dependsOn": "Build FAST_LOAD DME",
 			"type": "shell",
 			"command": "cmd",
 			"args": [


### PR DESCRIPTION
## Что этот ПР делает
Если CurrentDME был fast_paradise.dme то к нему добавлялся ещё один fast_ из-за чего происходило фиаско. Не придумал лучше способа, чем просто захардкодить. В принципе не вижу реальной надобности в куррентах, если в самом таске оно и так захардкожено??