### PR TITLE
qol+local: добавляет боргам возможность писать эмоции на русском языке

### DIFF
--- a/code/datums/keybindings/emote.dm
+++ b/code/datums/keybindings/emote.dm
@@ -724,19 +724,39 @@
 	linked_emote = /datum/emote/living/silicon/scream
 	name = "Кричать"
 
+/datum/keybinding/emote/silicon/scream2
+	linked_emote = /datum/emote/living/silicon/scream
+	name = "Кричать"
+
 /datum/keybinding/emote/silicon/ping
 	linked_emote = /datum/emote/living/silicon/ping
 	name = "Звенеть"
 
-/datum/keybinding/emote/silicon/buzz
-	linked_emote = /datum/emote/living/silicon/buzz
+/datum/keybinding/emote/silicon/ping2
+	linked_emote = /datum/emote/living/silicon/ping
+	name = "Звенеть"
+
+/datum/keybinding/emote/silicon/buzz1
+	linked_emote = /datum/emote/living/silicon/buzz1
+	name = "Жужжать"
+
+/datum/keybinding/emote/silicon/buzz12
+	linked_emote = /datum/emote/living/silicon/buzz12
 	name = "Жужжать"
 
 /datum/keybinding/emote/silicon/buzz2
 	linked_emote = /datum/emote/living/silicon/buzz2
 	name = "Жужжать раздражённо"
 
+/datum/keybinding/emote/silicon/buzz22
+	linked_emote = /datum/emote/living/silicon/buzz22
+	name = "Жужжать раздражённо"
+
 /datum/keybinding/emote/silicon/beep
+	linked_emote = /datum/emote/living/silicon/beep
+	name = "Бипать"
+
+/datum/keybinding/emote/silicon/beep2
 	linked_emote = /datum/emote/living/silicon/beep
 	name = "Бипать"
 
@@ -744,7 +764,15 @@
 	linked_emote = /datum/emote/living/silicon/boop
 	name = "Бупать"
 
+/datum/keybinding/emote/silicon/boop2
+	linked_emote = /datum/emote/living/silicon/boop
+	name = "Бупать"
+
 /datum/keybinding/emote/silicon/yes
+	linked_emote = /datum/emote/living/silicon/yes
+	name = "Утвердительно"
+
+/datum/keybinding/emote/silicon/yes2
 	linked_emote = /datum/emote/living/silicon/yes
 	name = "Утвердительно"
 
@@ -752,7 +780,15 @@
 	linked_emote = /datum/emote/living/silicon/no
 	name = "Отрицательно"
 
+/datum/keybinding/emote/silicon/no2
+	linked_emote = /datum/emote/living/silicon/no
+	name = "Отрицательно"
+
 /datum/keybinding/emote/silicon/law
+	linked_emote = /datum/emote/living/silicon/law
+	name = "Указать кто здесь закон"
+
+/datum/keybinding/emote/silicon/law2
 	linked_emote = /datum/emote/living/silicon/law
 	name = "Указать кто здесь закон"
 

--- a/code/modules/mob/living/silicon/silicon_emote.dm
+++ b/code/modules/mob/living/silicon/silicon_emote.dm
@@ -17,6 +17,20 @@
 			return FALSE
 
 /datum/emote/living/silicon/scream
+	key = "крик"
+	key_third_person = "screams"
+	message = "громко сигнал%(ит,ят)%!"
+	message_mime = "ярко сверка%(ет,ют)% лампочками!"
+	message_postfix = ", смотря на %t!"
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	cooldown = 5 SECONDS
+	unintentional_audio_cooldown = 3.5 SECONDS
+	vary = TRUE
+	sound = 'sound/goonstation/voice/robot_scream.ogg'
+	volume = 80
+
+/datum/emote/living/silicon/scream2
 	key = "scream"
 	key_third_person = "screams"
 	message = "громко сигнал%(ит,ят)%!"
@@ -31,6 +45,16 @@
 	volume = 80
 
 /datum/emote/living/silicon/ping
+	key = "пинг"
+	key_third_person = "pings"
+	message = "звен%(ит,ят)%."
+	message_mime = "тихо звен%(ит,ят)%."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/ping.ogg'
+
+/datum/emote/living/silicon/ping2
 	key = "ping"
 	key_third_person = "pings"
 	message = "звен%(ит,ят)%."
@@ -40,7 +64,17 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/ping.ogg'
 
-/datum/emote/living/silicon/buzz
+/datum/emote/living/silicon/buzz1
+	key = "бзз"
+	key_third_person = "buzzes"
+	message = "жужж%(ит,ат)%."
+	message_mime = "тихо жужж%(ит,ат)%."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/buzz-sigh.ogg'
+
+/datum/emote/living/silicon/buzz12
 	key = "buzz"
 	key_third_person = "buzzes"
 	message = "жужж%(ит,ат)%."
@@ -51,6 +85,15 @@
 	sound = 'sound/machines/buzz-sigh.ogg'
 
 /datum/emote/living/silicon/buzz2
+	key = "бзз2"
+	message = "изда%(ёт,ют)% раздраженный жужжащий звук."
+	message_mime = "тихо раздражённо жужж%(ит,ат)%."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/buzz-two.ogg'
+
+/datum/emote/living/silicon/buzz22
 	key = "buzz2"
 	message = "изда%(ёт,ют)% раздраженный жужжащий звук."
 	message_mime = "тихо раздражённо жужж%(ит,ат)%."
@@ -60,6 +103,16 @@
 	sound = 'sound/machines/buzz-two.ogg'
 
 /datum/emote/living/silicon/beep
+	key = "бип"
+	key_third_person = "beeps"
+	message = "пищ%(ит,ат)%."
+	message_mime = "тихо пищ%(ит,ат)%."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/twobeep.ogg'
+
+/datum/emote/living/silicon/beep2
 	key = "beep"
 	key_third_person = "beeps"
 	message = "пищ%(ит,ат)%."
@@ -70,6 +123,16 @@
 	sound = 'sound/machines/twobeep.ogg'
 
 /datum/emote/living/silicon/boop
+	key = "буп"
+	key_third_person = "boops"
+	message = "изда%(ёт,ют)% короткий гудок."
+	message_mime = "тихо гуд%(ит,ят)%."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/boop.ogg'
+
+/datum/emote/living/silicon/boop2
 	key = "boop"
 	key_third_person = "boops"
 	message = "изда%(ёт,ют)% короткий гудок."
@@ -80,6 +143,15 @@
 	sound = 'sound/machines/boop.ogg'
 
 /datum/emote/living/silicon/yes
+	key = "да"
+	message = "изда%(ёт,ют)% утвердительный сигнал."
+	message_mime = "утвердительно сверка%(ет,ют)% лампочками."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/synth_yes.ogg'
+
+/datum/emote/living/silicon/yes2
 	key = "yes"
 	message = "изда%(ёт,ют)% утвердительный сигнал."
 	message_mime = "утвердительно сверка%(ет,ют)% лампочками."
@@ -89,6 +161,15 @@
 	sound = 'sound/machines/synth_yes.ogg'
 
 /datum/emote/living/silicon/no
+	key = "нет"
+	message = "изда%(ёт,ют)% отрицательный сигнал."
+	message_mime = "отрицательно сверка%(ет,ют)% лампочками."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/synth_no.ogg'
+
+/datum/emote/living/silicon/no2
 	key = "no"
 	message = "изда%(ёт,ют)% отрицательный сигнал."
 	message_mime = "отрицательно сверка%(ет,ют)% лампочками."
@@ -98,6 +179,14 @@
 	sound = 'sound/machines/synth_no.ogg'
 
 /datum/emote/living/silicon/law
+	key = "закон"
+	message = "указыва%(ет,ют)% на штрих-код службы безопасноти."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/voice/biamthelaw.ogg'
+
+/datum/emote/living/silicon/law2
 	key = "law"
 	message = "указыва%(ет,ют)% на штрих-код службы безопасноти."
 	message_postfix = ", смотря на %t."


### PR DESCRIPTION
## Что этот ПР делает

Теперь игроки на боргах могут не менять раскладку чтобы писать эмоции, а писать их на русском. Например, вместо *yes можно писать *да. Возможность писать на английском оставлена

## Почему это хорошо для игры

Переключать раскладку ради одного звука - геморно. Добавлять панельку эмоцию будет перегружено (у боргов и так доп панельки есть). А так вполне удобно

## Тестирование

Запустил, написал всеми вариантами (и на русском и на английском), все работает. Через *help тоже отображается

P.s. это мой первый ПР. И вообще я считай первый день нормально пытаюсь разобраться как и что делать. Лучше внимательно посмотрите что я понаписал и если надо дайте рекомендации что не так)
