### PR TITLE
qol/local: добавление списка дополнительных ключей у датума emote + возможность боргам писать эмоции на русском

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -276,11 +276,11 @@
 			stack_trace("Keyless emote: [emote_instance.type]")
 
 		if(emote_instance.additional_keys)
-			for(var/key in emote_instance.additional_keys)
-				if(!.[key])
-					.[key] = list(emote_instance)
+			for(var/a_key in emote_instance.additional_keys)
+				if(!.[a_key])
+					.[a_key] = list(emote_instance)
 				else
-					.[key] += emote_instance
+					.[a_key] += emote_instance
 
 		if(emote_instance.key_third_person) // This one is optional
 			if(!.[emote_instance.key_third_person])

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -270,16 +270,17 @@
 		if(emote_instance.key)
 			if(!.[emote_instance.key])
 				.[emote_instance.key] = list(emote_instance)
-
-				if(emote_instance.key_ru)
-					if(!.[emote_instance.key_ru])
-						.[emote_instance.key_ru] = list(emote_instance)
-					else
-						.[emote_instance.key_ru] += emote_instance
 			else
 				.[emote_instance.key] += emote_instance
 		else if(emote_instance.message) // Assuming all non-base emotes have this
 			stack_trace("Keyless emote: [emote_instance.type]")
+
+		if(emote_instance.additional_keys)
+			for(var/key in emote_instance.additional_keys)
+				if(!.[key])
+					.[key] = list(emote_instance)
+				else
+					.[key] += emote_instance
 
 		if(emote_instance.key_third_person) // This one is optional
 			if(!.[emote_instance.key_third_person])

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -270,6 +270,12 @@
 		if(emote_instance.key)
 			if(!.[emote_instance.key])
 				.[emote_instance.key] = list(emote_instance)
+
+				if(emote_instance.key_ru)
+					if(!.[emote_instance.key_ru])
+						.[emote_instance.key_ru] = list(emote_instance)
+					else
+						.[emote_instance.key_ru] += emote_instance
 			else
 				.[emote_instance.key] += emote_instance
 		else if(emote_instance.message) // Assuming all non-base emotes have this

--- a/code/datums/emote/emote.dm
+++ b/code/datums/emote/emote.dm
@@ -10,8 +10,8 @@
 /datum/emote
 	/// What calls the emote.
 	var/key = ""
-	/// What calls the emote, but in Russian (optional)
-	var/key_ru = ""
+	/// Alternative keys
+	var/list/additional_keys
 	/// This will also call the emote.
 	var/key_third_person = ""
 	/// Message displayed when emote is used. Might be a list with different messages.

--- a/code/datums/emote/emote.dm
+++ b/code/datums/emote/emote.dm
@@ -10,7 +10,7 @@
 /datum/emote
 	/// What calls the emote.
 	var/key = ""
-
+	/// What calls the emote, but in Russian (optional)
 	var/key_ru = ""
 	/// This will also call the emote.
 	var/key_third_person = ""

--- a/code/datums/emote/emote.dm
+++ b/code/datums/emote/emote.dm
@@ -10,6 +10,8 @@
 /datum/emote
 	/// What calls the emote.
 	var/key = ""
+
+	var/key_ru = ""
 	/// This will also call the emote.
 	var/key_third_person = ""
 	/// Message displayed when emote is used. Might be a list with different messages.

--- a/code/datums/keybindings/emote.dm
+++ b/code/datums/keybindings/emote.dm
@@ -724,39 +724,19 @@
 	linked_emote = /datum/emote/living/silicon/scream
 	name = "Кричать"
 
-/datum/keybinding/emote/silicon/scream2
-	linked_emote = /datum/emote/living/silicon/scream
-	name = "Кричать"
-
 /datum/keybinding/emote/silicon/ping
 	linked_emote = /datum/emote/living/silicon/ping
 	name = "Звенеть"
 
-/datum/keybinding/emote/silicon/ping2
-	linked_emote = /datum/emote/living/silicon/ping
-	name = "Звенеть"
-
-/datum/keybinding/emote/silicon/buzz1
+/datum/keybinding/emote/silicon/buzz
 	linked_emote = /datum/emote/living/silicon/buzz1
-	name = "Жужжать"
-
-/datum/keybinding/emote/silicon/buzz12
-	linked_emote = /datum/emote/living/silicon/buzz12
 	name = "Жужжать"
 
 /datum/keybinding/emote/silicon/buzz2
 	linked_emote = /datum/emote/living/silicon/buzz2
 	name = "Жужжать раздражённо"
 
-/datum/keybinding/emote/silicon/buzz22
-	linked_emote = /datum/emote/living/silicon/buzz22
-	name = "Жужжать раздражённо"
-
 /datum/keybinding/emote/silicon/beep
-	linked_emote = /datum/emote/living/silicon/beep
-	name = "Бипать"
-
-/datum/keybinding/emote/silicon/beep2
 	linked_emote = /datum/emote/living/silicon/beep
 	name = "Бипать"
 
@@ -764,15 +744,7 @@
 	linked_emote = /datum/emote/living/silicon/boop
 	name = "Бупать"
 
-/datum/keybinding/emote/silicon/boop2
-	linked_emote = /datum/emote/living/silicon/boop
-	name = "Бупать"
-
 /datum/keybinding/emote/silicon/yes
-	linked_emote = /datum/emote/living/silicon/yes
-	name = "Утвердительно"
-
-/datum/keybinding/emote/silicon/yes2
 	linked_emote = /datum/emote/living/silicon/yes
 	name = "Утвердительно"
 
@@ -780,15 +752,7 @@
 	linked_emote = /datum/emote/living/silicon/no
 	name = "Отрицательно"
 
-/datum/keybinding/emote/silicon/no2
-	linked_emote = /datum/emote/living/silicon/no
-	name = "Отрицательно"
-
 /datum/keybinding/emote/silicon/law
-	linked_emote = /datum/emote/living/silicon/law
-	name = "Указать кто здесь закон"
-
-/datum/keybinding/emote/silicon/law2
 	linked_emote = /datum/emote/living/silicon/law
 	name = "Указать кто здесь закон"
 

--- a/code/datums/keybindings/emote.dm
+++ b/code/datums/keybindings/emote.dm
@@ -724,19 +724,39 @@
 	linked_emote = /datum/emote/living/silicon/scream
 	name = "Кричать"
 
+/datum/keybinding/emote/silicon/scream2
+	linked_emote = /datum/emote/living/silicon/scream
+	name = "Кричать"
+
 /datum/keybinding/emote/silicon/ping
 	linked_emote = /datum/emote/living/silicon/ping
 	name = "Звенеть"
 
-/datum/keybinding/emote/silicon/buzz
-	linked_emote = /datum/emote/living/silicon/buzz
+/datum/keybinding/emote/silicon/ping2
+	linked_emote = /datum/emote/living/silicon/ping
+	name = "Звенеть"
+
+/datum/keybinding/emote/silicon/buzz1
+	linked_emote = /datum/emote/living/silicon/buzz1
+	name = "Жужжать"
+
+/datum/keybinding/emote/silicon/buzz12
+	linked_emote = /datum/emote/living/silicon/buzz12
 	name = "Жужжать"
 
 /datum/keybinding/emote/silicon/buzz2
 	linked_emote = /datum/emote/living/silicon/buzz2
 	name = "Жужжать раздражённо"
 
+/datum/keybinding/emote/silicon/buzz22
+	linked_emote = /datum/emote/living/silicon/buzz22
+	name = "Жужжать раздражённо"
+
 /datum/keybinding/emote/silicon/beep
+	linked_emote = /datum/emote/living/silicon/beep
+	name = "Бипать"
+
+/datum/keybinding/emote/silicon/beep2
 	linked_emote = /datum/emote/living/silicon/beep
 	name = "Бипать"
 
@@ -744,7 +764,15 @@
 	linked_emote = /datum/emote/living/silicon/boop
 	name = "Бупать"
 
+/datum/keybinding/emote/silicon/boop2
+	linked_emote = /datum/emote/living/silicon/boop
+	name = "Бупать"
+
 /datum/keybinding/emote/silicon/yes
+	linked_emote = /datum/emote/living/silicon/yes
+	name = "Утвердительно"
+
+/datum/keybinding/emote/silicon/yes2
 	linked_emote = /datum/emote/living/silicon/yes
 	name = "Утвердительно"
 
@@ -752,7 +780,15 @@
 	linked_emote = /datum/emote/living/silicon/no
 	name = "Отрицательно"
 
+/datum/keybinding/emote/silicon/no2
+	linked_emote = /datum/emote/living/silicon/no
+	name = "Отрицательно"
+
 /datum/keybinding/emote/silicon/law
+	linked_emote = /datum/emote/living/silicon/law
+	name = "Указать кто здесь закон"
+
+/datum/keybinding/emote/silicon/law2
 	linked_emote = /datum/emote/living/silicon/law
 	name = "Указать кто здесь закон"
 

--- a/code/datums/keybindings/emote.dm
+++ b/code/datums/keybindings/emote.dm
@@ -729,7 +729,7 @@
 	name = "Звенеть"
 
 /datum/keybinding/emote/silicon/buzz
-	linked_emote = /datum/emote/living/silicon/buzz1
+	linked_emote = /datum/emote/living/silicon/buzz
 	name = "Жужжать"
 
 /datum/keybinding/emote/silicon/buzz2

--- a/code/modules/mob/living/silicon/silicon_emote.dm
+++ b/code/modules/mob/living/silicon/silicon_emote.dm
@@ -17,6 +17,20 @@
 			return FALSE
 
 /datum/emote/living/silicon/scream
+	key = "крик"
+	key_third_person = "screams"
+	message = "громко сигнал%(ит,ят)%!"
+	message_mime = "ярко сверка%(ет,ют)% лампочками!"
+	message_postfix = ", смотря на %t!"
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	cooldown = 5 SECONDS
+	unintentional_audio_cooldown = 3.5 SECONDS
+	vary = TRUE
+	sound = 'sound/goonstation/voice/robot_scream.ogg'
+	volume = 80
+
+/datum/emote/living/silicon/scream2
 	key = "scream"
 	key_third_person = "screams"
 	message = "громко сигнал%(ит,ят)%!"
@@ -31,6 +45,16 @@
 	volume = 80
 
 /datum/emote/living/silicon/ping
+	key = "пинг"
+	key_third_person = "pings"
+	message = "звен%(ит,ят)%."
+	message_mime = "тихо звен%(ит,ят)%."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/ping.ogg'
+
+/datum/emote/living/silicon/ping2
 	key = "ping"
 	key_third_person = "pings"
 	message = "звен%(ит,ят)%."
@@ -40,7 +64,17 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/ping.ogg'
 
-/datum/emote/living/silicon/buzz
+/datum/emote/living/silicon/buzz1
+	key = "бзз"
+	key_third_person = "buzzes"
+	message = "жужж%(ит,ат)%."
+	message_mime = "тихо жужж%(ит,ат)%."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/buzz-sigh.ogg'
+
+/datum/emote/living/silicon/buzz12
 	key = "buzz"
 	key_third_person = "buzzes"
 	message = "жужж%(ит,ат)%."
@@ -51,6 +85,15 @@
 	sound = 'sound/machines/buzz-sigh.ogg'
 
 /datum/emote/living/silicon/buzz2
+	key = "бзз2"
+	message = "изда%(ёт,ют)% раздраженный жужжащий звук."
+	message_mime = "тихо раздражённо жужж%(ит,ат)%."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/buzz-two.ogg'
+
+/datum/emote/living/silicon/buzz22
 	key = "buzz2"
 	message = "изда%(ёт,ют)% раздраженный жужжащий звук."
 	message_mime = "тихо раздражённо жужж%(ит,ат)%."
@@ -60,6 +103,16 @@
 	sound = 'sound/machines/buzz-two.ogg'
 
 /datum/emote/living/silicon/beep
+	key = "бип"
+	key_third_person = "beeps"
+	message = "пищ%(ит,ат)%."
+	message_mime = "тихо пищ%(ит,ат)%."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/twobeep.ogg'
+
+/datum/emote/living/silicon/beep2
 	key = "beep"
 	key_third_person = "beeps"
 	message = "пищ%(ит,ат)%."
@@ -70,6 +123,16 @@
 	sound = 'sound/machines/twobeep.ogg'
 
 /datum/emote/living/silicon/boop
+	key = "буп"
+	key_third_person = "boops"
+	message = "изда%(ёт,ют)% короткий гудок."
+	message_mime = "тихо гуд%(ит,ят)%."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/boop.ogg'
+
+/datum/emote/living/silicon/boop2
 	key = "boop"
 	key_third_person = "boops"
 	message = "изда%(ёт,ют)% короткий гудок."
@@ -80,6 +143,15 @@
 	sound = 'sound/machines/boop.ogg'
 
 /datum/emote/living/silicon/yes
+	key = "да"
+	message = "изда%(ёт,ют)% утвердительный сигнал."
+	message_mime = "утвердительно сверка%(ет,ют)% лампочками."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/synth_yes.ogg'
+
+/datum/emote/living/silicon/yes2
 	key = "yes"
 	message = "изда%(ёт,ют)% утвердительный сигнал."
 	message_mime = "утвердительно сверка%(ет,ют)% лампочками."
@@ -89,6 +161,15 @@
 	sound = 'sound/machines/synth_yes.ogg'
 
 /datum/emote/living/silicon/no
+	key = "нет"
+	message = "изда%(ёт,ют)% отрицательный сигнал."
+	message_mime = "отрицательно сверка%(ет,ют)% лампочками."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/machines/synth_no.ogg'
+
+/datum/emote/living/silicon/no2
 	key = "no"
 	message = "изда%(ёт,ют)% отрицательный сигнал."
 	message_mime = "отрицательно сверка%(ет,ют)% лампочками."
@@ -98,6 +179,14 @@
 	sound = 'sound/machines/synth_no.ogg'
 
 /datum/emote/living/silicon/law
+	key = "закон"
+	message = "указыва%(ет,ют)% на штрих-код службы безопасноти."
+	message_postfix = ", смотря на %t."
+	message_param = EMOTE_PARAM_USE_POSTFIX
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/voice/biamthelaw.ogg'
+
+/datum/emote/living/silicon/law2
 	key = "law"
 	message = "указыва%(ет,ют)% на штрих-код службы безопасноти."
 	message_postfix = ", смотря на %t."

--- a/code/modules/mob/living/silicon/silicon_emote.dm
+++ b/code/modules/mob/living/silicon/silicon_emote.dm
@@ -18,7 +18,7 @@
 
 /datum/emote/living/silicon/scream
 	key = "scream"
-	key_ru = "крик"
+	additional_keys = list("крик")
 	key_third_person = "screams"
 	message = "громко сигнал%(ит,ят)%!"
 	message_mime = "ярко сверка%(ет,ют)% лампочками!"
@@ -33,7 +33,7 @@
 
 /datum/emote/living/silicon/ping
 	key = "ping"
-	key_ru = "пинг"
+	additional_keys = list("пинг")
 	key_third_person = "pings"
 	message = "звен%(ит,ят)%."
 	message_mime = "тихо звен%(ит,ят)%."
@@ -44,7 +44,7 @@
 
 /datum/emote/living/silicon/buzz
 	key = "buzz"
-	key_ru = "бзз"
+	additional_keys = list("бзз")
 	key_third_person = "buzzes"
 	message = "жужж%(ит,ат)%."
 	message_mime = "тихо жужж%(ит,ат)%."
@@ -55,7 +55,7 @@
 
 /datum/emote/living/silicon/buzz2
 	key = "buzz2"
-	key_ru = "бзз2"
+	additional_keys = list("бзз2")
 	message = "изда%(ёт,ют)% раздраженный жужжащий звук."
 	message_mime = "тихо раздражённо жужж%(ит,ат)%."
 	message_postfix = ", смотря на %t."
@@ -65,7 +65,7 @@
 
 /datum/emote/living/silicon/beep
 	key = "beep"
-	key_ru = "бип"
+	additional_keys = list("бип")
 	key_third_person = "beeps"
 	message = "пищ%(ит,ат)%."
 	message_mime = "тихо пищ%(ит,ат)%."
@@ -76,7 +76,7 @@
 
 /datum/emote/living/silicon/boop
 	key = "boop"
-	key_ru = "буп"
+	additional_keys = list("буп")
 	key_third_person = "boops"
 	message = "изда%(ёт,ют)% короткий гудок."
 	message_mime = "тихо гуд%(ит,ят)%."
@@ -87,7 +87,7 @@
 
 /datum/emote/living/silicon/yes
 	key = "yes"
-	key_ru = "да"
+	additional_keys = list("да")
 	message = "изда%(ёт,ют)% утвердительный сигнал."
 	message_mime = "утвердительно сверка%(ет,ют)% лампочками."
 	message_postfix = ", смотря на %t."
@@ -97,7 +97,7 @@
 
 /datum/emote/living/silicon/no
 	key = "no"
-	key_ru = "нет"
+	additional_keys = list("нет")
 	message = "изда%(ёт,ют)% отрицательный сигнал."
 	message_mime = "отрицательно сверка%(ет,ют)% лампочками."
 	message_postfix = ", смотря на %t."
@@ -107,7 +107,7 @@
 
 /datum/emote/living/silicon/law
 	key = "law"
-	key_ru = "закон"
+	additional_keys = list("закон")
 	message = "указыва%(ет,ют)% на штрих-код службы безопасноти."
 	message_postfix = ", смотря на %t."
 	message_param = EMOTE_PARAM_USE_POSTFIX
@@ -126,7 +126,7 @@
 
 /datum/emote/living/silicon/halt
 	key = "halt"
-	key_ru = "стой"
+	additional_keys = list("халт", "стой")
 	message = "ор%(ёт,ут)% \"СТОЯТЬ! СЛУЖБА БЕЗОПАСНОСТИ!\" через динамики!"
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/voice/halt.ogg'

--- a/code/modules/mob/living/silicon/silicon_emote.dm
+++ b/code/modules/mob/living/silicon/silicon_emote.dm
@@ -126,7 +126,7 @@
 
 /datum/emote/living/silicon/halt
 	key = "halt"
-	key_ru = "халт"
+	key_ru = "стой"
 	message = "ор%(ёт,ут)% \"СТОЯТЬ! СЛУЖБА БЕЗОПАСНОСТИ!\" через динамики!"
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/voice/halt.ogg'

--- a/code/modules/mob/living/silicon/silicon_emote.dm
+++ b/code/modules/mob/living/silicon/silicon_emote.dm
@@ -64,7 +64,7 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/ping.ogg'
 
-/datum/emote/living/silicon/buzz1
+/datum/emote/living/silicon/buzz
 	key = "бзз"
 	key_third_person = "buzzes"
 	message = "жужж%(ит,ат)%."
@@ -74,7 +74,7 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/buzz-sigh.ogg'
 
-/datum/emote/living/silicon/buzz1_ru
+/datum/emote/living/silicon/buzz_ru
 	key = "buzz"
 	key_third_person = "buzzes"
 	message = "жужж%(ит,ат)%."

--- a/code/modules/mob/living/silicon/silicon_emote.dm
+++ b/code/modules/mob/living/silicon/silicon_emote.dm
@@ -17,21 +17,8 @@
 			return FALSE
 
 /datum/emote/living/silicon/scream
-	key = "крик"
-	key_third_person = "screams"
-	message = "громко сигнал%(ит,ят)%!"
-	message_mime = "ярко сверка%(ет,ют)% лампочками!"
-	message_postfix = ", смотря на %t!"
-	message_param = EMOTE_PARAM_USE_POSTFIX
-	emote_type = EMOTE_AUDIBLE
-	cooldown = 5 SECONDS
-	unintentional_audio_cooldown = 3.5 SECONDS
-	vary = TRUE
-	sound = 'sound/goonstation/voice/robot_scream.ogg'
-	volume = 80
-
-/datum/emote/living/silicon/scream_ru
 	key = "scream"
+	key_ru = "крик"
 	key_third_person = "screams"
 	message = "громко сигнал%(ит,ят)%!"
 	message_mime = "ярко сверка%(ет,ют)% лампочками!"
@@ -45,17 +32,8 @@
 	volume = 80
 
 /datum/emote/living/silicon/ping
-	key = "пинг"
-	key_third_person = "pings"
-	message = "звен%(ит,ят)%."
-	message_mime = "тихо звен%(ит,ят)%."
-	message_postfix = ", смотря на %t."
-	message_param = EMOTE_PARAM_USE_POSTFIX
-	emote_type = EMOTE_AUDIBLE
-	sound = 'sound/machines/ping.ogg'
-
-/datum/emote/living/silicon/ping_ru
 	key = "ping"
+	key_ru = "пинг"
 	key_third_person = "pings"
 	message = "звен%(ит,ят)%."
 	message_mime = "тихо звен%(ит,ят)%."
@@ -65,17 +43,8 @@
 	sound = 'sound/machines/ping.ogg'
 
 /datum/emote/living/silicon/buzz
-	key = "бзз"
-	key_third_person = "buzzes"
-	message = "жужж%(ит,ат)%."
-	message_mime = "тихо жужж%(ит,ат)%."
-	message_postfix = ", смотря на %t."
-	message_param = EMOTE_PARAM_USE_POSTFIX
-	emote_type = EMOTE_AUDIBLE
-	sound = 'sound/machines/buzz-sigh.ogg'
-
-/datum/emote/living/silicon/buzz_ru
 	key = "buzz"
+	key_ru = "бзз"
 	key_third_person = "buzzes"
 	message = "жужж%(ит,ат)%."
 	message_mime = "тихо жужж%(ит,ат)%."
@@ -85,16 +54,8 @@
 	sound = 'sound/machines/buzz-sigh.ogg'
 
 /datum/emote/living/silicon/buzz2
-	key = "бзз2"
-	message = "изда%(ёт,ют)% раздраженный жужжащий звук."
-	message_mime = "тихо раздражённо жужж%(ит,ат)%."
-	message_postfix = ", смотря на %t."
-	message_param = EMOTE_PARAM_USE_POSTFIX
-	emote_type = EMOTE_AUDIBLE
-	sound = 'sound/machines/buzz-two.ogg'
-
-/datum/emote/living/silicon/buzz2_ru
 	key = "buzz2"
+	key_ru = "бзз2"
 	message = "изда%(ёт,ют)% раздраженный жужжащий звук."
 	message_mime = "тихо раздражённо жужж%(ит,ат)%."
 	message_postfix = ", смотря на %t."
@@ -103,17 +64,8 @@
 	sound = 'sound/machines/buzz-two.ogg'
 
 /datum/emote/living/silicon/beep
-	key = "бип"
-	key_third_person = "beeps"
-	message = "пищ%(ит,ат)%."
-	message_mime = "тихо пищ%(ит,ат)%."
-	message_postfix = ", смотря на %t."
-	message_param = EMOTE_PARAM_USE_POSTFIX
-	emote_type = EMOTE_AUDIBLE
-	sound = 'sound/machines/twobeep.ogg'
-
-/datum/emote/living/silicon/beep_ru
 	key = "beep"
+	key_ru = "бип"
 	key_third_person = "beeps"
 	message = "пищ%(ит,ат)%."
 	message_mime = "тихо пищ%(ит,ат)%."
@@ -123,17 +75,8 @@
 	sound = 'sound/machines/twobeep.ogg'
 
 /datum/emote/living/silicon/boop
-	key = "буп"
-	key_third_person = "boops"
-	message = "изда%(ёт,ют)% короткий гудок."
-	message_mime = "тихо гуд%(ит,ят)%."
-	message_postfix = ", смотря на %t."
-	message_param = EMOTE_PARAM_USE_POSTFIX
-	emote_type = EMOTE_AUDIBLE
-	sound = 'sound/machines/boop.ogg'
-
-/datum/emote/living/silicon/boop_ru
 	key = "boop"
+	key_ru = "буп"
 	key_third_person = "boops"
 	message = "изда%(ёт,ют)% короткий гудок."
 	message_mime = "тихо гуд%(ит,ят)%."
@@ -143,16 +86,8 @@
 	sound = 'sound/machines/boop.ogg'
 
 /datum/emote/living/silicon/yes
-	key = "да"
-	message = "изда%(ёт,ют)% утвердительный сигнал."
-	message_mime = "утвердительно сверка%(ет,ют)% лампочками."
-	message_postfix = ", смотря на %t."
-	message_param = EMOTE_PARAM_USE_POSTFIX
-	emote_type = EMOTE_AUDIBLE
-	sound = 'sound/machines/synth_yes.ogg'
-
-/datum/emote/living/silicon/yes_ru
 	key = "yes"
+	key_ru = "да"
 	message = "изда%(ёт,ют)% утвердительный сигнал."
 	message_mime = "утвердительно сверка%(ет,ют)% лампочками."
 	message_postfix = ", смотря на %t."
@@ -161,16 +96,8 @@
 	sound = 'sound/machines/synth_yes.ogg'
 
 /datum/emote/living/silicon/no
-	key = "нет"
-	message = "изда%(ёт,ют)% отрицательный сигнал."
-	message_mime = "отрицательно сверка%(ет,ют)% лампочками."
-	message_postfix = ", смотря на %t."
-	message_param = EMOTE_PARAM_USE_POSTFIX
-	emote_type = EMOTE_AUDIBLE
-	sound = 'sound/machines/synth_no.ogg'
-
-/datum/emote/living/silicon/no_ru
 	key = "no"
+	key_ru = "нет"
 	message = "изда%(ёт,ют)% отрицательный сигнал."
 	message_mime = "отрицательно сверка%(ет,ют)% лампочками."
 	message_postfix = ", смотря на %t."
@@ -179,15 +106,8 @@
 	sound = 'sound/machines/synth_no.ogg'
 
 /datum/emote/living/silicon/law
-	key = "закон"
-	message = "указыва%(ет,ют)% на штрих-код службы безопасноти."
-	message_postfix = ", смотря на %t."
-	message_param = EMOTE_PARAM_USE_POSTFIX
-	emote_type = EMOTE_AUDIBLE
-	sound = 'sound/voice/biamthelaw.ogg'
-
-/datum/emote/living/silicon/law_ru
 	key = "law"
+	key_ru = "закон"
 	message = "указыва%(ет,ют)% на штрих-код службы безопасноти."
 	message_postfix = ", смотря на %t."
 	message_param = EMOTE_PARAM_USE_POSTFIX
@@ -206,6 +126,7 @@
 
 /datum/emote/living/silicon/halt
 	key = "halt"
+	key_ru = "халт"
 	message = "ор%(ёт,ут)% \"СТОЯТЬ! СЛУЖБА БЕЗОПАСНОСТИ!\" через динамики!"
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/voice/halt.ogg'

--- a/code/modules/mob/living/silicon/silicon_emote.dm
+++ b/code/modules/mob/living/silicon/silicon_emote.dm
@@ -30,7 +30,7 @@
 	sound = 'sound/goonstation/voice/robot_scream.ogg'
 	volume = 80
 
-/datum/emote/living/silicon/scream2
+/datum/emote/living/silicon/scream_ru
 	key = "scream"
 	key_third_person = "screams"
 	message = "громко сигнал%(ит,ят)%!"
@@ -54,7 +54,7 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/ping.ogg'
 
-/datum/emote/living/silicon/ping2
+/datum/emote/living/silicon/ping_ru
 	key = "ping"
 	key_third_person = "pings"
 	message = "звен%(ит,ят)%."
@@ -74,7 +74,7 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/buzz-sigh.ogg'
 
-/datum/emote/living/silicon/buzz12
+/datum/emote/living/silicon/buzz1_ru
 	key = "buzz"
 	key_third_person = "buzzes"
 	message = "жужж%(ит,ат)%."
@@ -93,7 +93,7 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/buzz-two.ogg'
 
-/datum/emote/living/silicon/buzz22
+/datum/emote/living/silicon/buzz2_ru
 	key = "buzz2"
 	message = "изда%(ёт,ют)% раздраженный жужжащий звук."
 	message_mime = "тихо раздражённо жужж%(ит,ат)%."
@@ -112,7 +112,7 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/twobeep.ogg'
 
-/datum/emote/living/silicon/beep2
+/datum/emote/living/silicon/beep_ru
 	key = "beep"
 	key_third_person = "beeps"
 	message = "пищ%(ит,ат)%."
@@ -132,7 +132,7 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/boop.ogg'
 
-/datum/emote/living/silicon/boop2
+/datum/emote/living/silicon/boop_ru
 	key = "boop"
 	key_third_person = "boops"
 	message = "изда%(ёт,ют)% короткий гудок."
@@ -151,7 +151,7 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/synth_yes.ogg'
 
-/datum/emote/living/silicon/yes2
+/datum/emote/living/silicon/yes_ru
 	key = "yes"
 	message = "изда%(ёт,ют)% утвердительный сигнал."
 	message_mime = "утвердительно сверка%(ет,ют)% лампочками."
@@ -169,7 +169,7 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/machines/synth_no.ogg'
 
-/datum/emote/living/silicon/no2
+/datum/emote/living/silicon/no_ru
 	key = "no"
 	message = "изда%(ёт,ют)% отрицательный сигнал."
 	message_mime = "отрицательно сверка%(ет,ют)% лампочками."
@@ -186,7 +186,7 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/voice/biamthelaw.ogg'
 
-/datum/emote/living/silicon/law2
+/datum/emote/living/silicon/law_ru
 	key = "law"
 	message = "указыва%(ет,ют)% на штрих-код службы безопасноти."
 	message_postfix = ", смотря на %t."

--- a/code/modules/mob/mob_emote.dm
+++ b/code/modules/mob/mob_emote.dm
@@ -104,6 +104,18 @@
 				else
 					base_keys += full_key
 				all_keys += P.key
+			if(P.key_ru)
+				if(P.key_ru in all_keys)
+					continue
+				if(P.can_run_emote(user, status_check = FALSE, intentional = TRUE))
+					if(P.message_param && P.param_desc)
+						// Add our parameter description, like flap-user
+						full_key = P.key_ru + "\[[EMOTE_PARAM_SEPARATOR][P.param_desc]\]"
+					if(istype(H) && P.species_type_whitelist_typecache && H.dna && is_type_in_typecache(H.dna.species, P.species_type_whitelist_typecache))
+						species_emotes += full_key
+					else
+						base_keys += full_key
+					all_keys += P.key_ru
 
 	base_keys = sortList(base_keys)
 	message += base_keys.Join(", ")

--- a/code/modules/mob/mob_emote.dm
+++ b/code/modules/mob/mob_emote.dm
@@ -104,18 +104,19 @@
 				else
 					base_keys += full_key
 				all_keys += P.key
-			if(P.key_ru)
-				if(P.key_ru in all_keys)
-					continue
-				if(P.can_run_emote(user, status_check = FALSE, intentional = TRUE))
-					if(P.message_param && P.param_desc)
-						// Add our parameter description, like flap-user
-						full_key = P.key_ru + "\[[EMOTE_PARAM_SEPARATOR][P.param_desc]\]"
-					if(istype(H) && P.species_type_whitelist_typecache && H.dna && is_type_in_typecache(H.dna.species, P.species_type_whitelist_typecache))
-						species_emotes += full_key
-					else
-						base_keys += full_key
-					all_keys += P.key_ru
+			if(P.additional_keys)
+				for(var/a_key in P.additional_keys)
+					if(a_key in all_keys)
+						continue
+					if(P.can_run_emote(user, status_check = FALSE, intentional = TRUE))
+						if(P.message_param && P.param_desc)
+							// Add our parameter description, like flap-user
+							full_key = a_key + "\[[EMOTE_PARAM_SEPARATOR][P.param_desc]\]"
+						if(istype(H) && P.species_type_whitelist_typecache && H.dna && is_type_in_typecache(H.dna.species, P.species_type_whitelist_typecache))
+							species_emotes += full_key
+						else
+							base_keys += full_key
+						all_keys += a_key
 
 	base_keys = sortList(base_keys)
 	message += base_keys.Join(", ")

--- a/code/modules/mob/mob_emote.dm
+++ b/code/modules/mob/mob_emote.dm
@@ -106,6 +106,7 @@
 				all_keys += P.key
 			if(P.additional_keys)
 				for(var/a_key in P.additional_keys)
+					full_key = a_key
 					if(a_key in all_keys)
 						continue
 					if(P.can_run_emote(user, status_check = FALSE, intentional = TRUE))


### PR DESCRIPTION
## Что этот ПР делает

Теперь игроки на боргах могут не менять раскладку чтобы писать эмоции, а писать их на русском. Например, вместо *yes можно писать *да. Возможность писать на английском оставлена

## Почему это хорошо для игры

Переключать раскладку ради одного звука - геморно. Добавлять панельку эмоцию будет перегружено (у боргов и так доп панельки есть). А так вполне удобно

## Тестирование

Запустил, написал всеми вариантами (и на русском и на английском), все работает. Через *help тоже отображается

P.s. это мой первый ПР. И вообще я считай первый день нормально пытаюсь разобраться как и что делать. Лучше внимательно посмотрите что я понаписал и если надо дайте рекомендации что не так)

p.s 2 я переделал то что было до этого. Хз надо было закрывать тот ПР или можно было как-то там сделать. В общем теперь все точно нормально без всякой фигни
