### PR TITLE
qol: Prevent mouse from blocking projectiles

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -143,6 +143,15 @@
 		get_scooped(M)
 	..()
 
+/mob/living/simple_animal/mouse/bullet_act(obj/projectile/Proj) // No more mouse blocking projectiles
+	if(!Proj)
+		return -1
+
+	if(Proj?.original == src || Proj.firer.a_intent == INTENT_HARM)
+		return ..()
+
+	return -1
+
 /mob/living/simple_animal/mouse/attackby(obj/item/I, mob/user, params)
 	if(user.a_intent == INTENT_HARM)
 		return ..()
@@ -427,14 +436,14 @@
 	if(mind || !SSticker || !SSticker.mode)
 		return
 	var/list/candidates = SSghost_spawns.poll_candidates("Вы хотите сыграть за мышь, зараженную Блобом?", ROLE_BLOB, TRUE, source = /mob/living/simple_animal/mouse/blobinfected)
-	
+
 	if(QDELETED(src))
 		return
-	
+
 	if(!length(candidates))
 		log_and_message_admins("There were no players willing to play as a mouse infected with a blob.")
 		return
-		
+
 	var/mob/M = pick(candidates)
 	possess_by_player(M.key)
 	var/datum_type = mind.get_blob_infected_type()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -147,7 +147,7 @@
 	if(!Proj)
 		return -1
 
-	if(Proj?.original == src || Proj.firer.a_intent == INTENT_HARM)
+	if(Proj?.original == src || (Proj.firer && Proj.firer.a_intent == INTENT_HARM))
 		return ..()
 
 	return -1


### PR DESCRIPTION
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

<!-- Вы можете совмещать до 2-х тэгов, например, balance/tweak:
Список возможных тэгов для пр-а:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map: Вы меняете только карту.
- image: Вы добавляете/удаляете спрайты.
- sound: Вы добавляете/удаляете звуки.
- spellcheck: Вы исправили опечатку.
- local: Вы добавляете новый текст на русском или переводите на русский.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает

Мыши в стоячем положении теперь будут ловить проджектайлы если выстрел идет конкретно по ним или игрок находится в харм интенте

## Почему это хорошо для игры

Устраняет фрустрацию от попадания по мышам при перестрелках в техах, оставляет скиллозависимость, так как нужно переключать интенты

## Тестирование

Протестировал на локалке с разными видами проджектайлов
