### PR TITLE
bugfix: Карго шаттл снова работает

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -80,11 +80,11 @@
 	. = ..()
 	if(.)	return .
 
-	buy()
-	sell()
+	buy(S1)
+	sell(S1)
 
-/obj/docking_port/mobile/supply/proc/buy()
-	if(!is_station_level(z))		//we only buy when we are -at- the station
+/obj/docking_port/mobile/supply/proc/buy(obj/docking_port/stationary/destination)
+	if(!is_station_level(destination.z))
 		return 1
 
 	if(!length(SSshuttle.shoppinglist))
@@ -136,8 +136,8 @@
 
 	SSshuttle.shoppinglist.Cut()
 
-/obj/docking_port/mobile/supply/proc/sell()
-	if(z != level_name_to_num(CENTCOMM))		//we only sell when we are -at- centcomm
+/obj/docking_port/mobile/supply/proc/sell(obj/docking_port/stationary/destination)
+	if(destination.z != level_name_to_num(CENTCOMM))		//we only sell when we are -at- centcomm
 		return TRUE
 
 	var/crate_count = 0


### PR DESCRIPTION
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

<!-- Вы можете совмещать до 2-х тэгов, например, balance/tweak:
Список возможных тэгов для пр-а:
- add: Вы добавляете что-то новое.
- admin: Вы меняете что-то связанное с администрацией. (кнопки, управление, панели, щитспавн и т.д.)
- balance: Вы производите балансировку в игре.
- bugfix: Вы исправили некий баг.
- code_imp: Вы имплементируете новое для билда, не меняя при этом ничего в самой игре.
- config: Вы меняете конфиг или работу SQL.
- del: Вы удаляете что-то из игры.
- experiment: Ваш ПР сделан с целью какого-то эксперимента.
- map: Вы меняете только карту.
- image: Вы добавляете/удаляете спрайты.
- sound: Вы добавляете/удаляете звуки.
- spellcheck: Вы исправили опечатку.
- local: Вы добавляете новый текст на русском или переводите на русский.
- tweak: Вы внесли незначительную правку.
- refactor: Вы полностью переписали старый код, улучшив его, НО не изменив функционал.
- server: Вы меняете что-то связанное с серверной частью или Github.
- wip: Ваш PR в драфте и планируется длительная разработка. -->

## Что этот ПР делает
Заменяет проверки на текущий z уровень при продаже / покупке, на проверки на целевой для стыковки.
<!-- Опишите, что делает ваш пулл-реквест, укажите основные изменения. -->
<!-- В случае исправления бага, укажите ссылку на канал в #баг-репорты-v2. В ином случае, опишите баг и его воспроизведение. -->

## Почему это хорошо для игры
Из за нового атмоса перемещение шаттла происходит в безопасном контексте миллы, из-за чего к моменту проверки не продажу/покупку шаттл еще не переместился, что ломает проверки при покупке/продаже. Этот пр заменяет проверку на проверку целевого порта, который не зависит от положения шаттла.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в билд. -->
