### PR TITLE
bugfix: бесконечные сообщения о починке боргов в гостах

### DIFF
--- a/code/modules/mob/living/silicon/robot/update_status.dm
+++ b/code/modules/mob/living/silicon/robot/update_status.dm
@@ -28,7 +28,7 @@
 		update_icons()
 
 	else
-		if(health)
+		if(health > 0)
 			update_revive()
 			var/mob/dead/observer/ghost = get_ghost()
 


### PR DESCRIPTION
## Что этот ПР делает

Фикс бага https://discord.com/channels/617003227182792704/1459928750958444737
Раньше проверялось, является ли здоровье отличным от нуля, правда никто не учел, что оно уходит в минус. Тем самым, боргам с минусовым здоровьем присылало сообщение, что их чинят

## Почему это хорошо для игры

Нет раздражающего звука и тд

<!-- Как Вы тестировали свои изменения? Ведь тестировали? -->
на локалке