### PR TITLE
server: Disable neuroslope summary [ci skip]

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,6 @@
+code_review:
+  pull_request_opened:
+	# I hate neuroslope.
+    summary: false
+	# Comment out if you're completely fucked up.
+    #code_review: false


### PR DESCRIPTION
## Что этот ПР делает
Отключает автоматический комментарий нейрослопа после создания пр-а. Ревью всё ещё автоматическое, но я оставил заготовку, которую любой человек в любой момент может раскомментировать, чтобы отключить и его.

Нейрослоп составляет своё описание на основании описания пр-а, с тонной воды и чтобы польстить автору, и 5% основываясь на том, что он высмотрел в пр-е, но чего нет в описании. Он также срёт этим бредом в дискашн из-за чего стало невозможно отслеживать история общения между конрибьютерами, а вайбик приблизился к минимуму.

Я ненавижу нейрослоп и стыжусь того дня, когда подписал нас всех на это.