### PR TITLE
bugfix/code_imp: отвертки и кусачки корректно отображаются на поясе + greyscale_config_belt

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -262,11 +262,10 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	var/exists_skin_change = FALSE
 	//can you put this item in closets
 	var/can_put_in_closet = TRUE
+	/// Colored belt appearance for adding it as a belt overlay
+	var/icon/colored_belt_appearance
 
 /obj/item/Initialize(mapload)
-	if(!greyscale_config && greyscale_colors && (greyscale_config_worn || greyscale_config_belt || greyscale_config_inhand_right || greyscale_config_inhand_left))
-		update_greyscale()
-
 	. = ..()
 
 	/// marks all items in storage as being such
@@ -1271,6 +1270,8 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 		lefthand_file = SSgreyscale.get_colored_icon_by_type(greyscale_config_inhand_left, greyscale_colors)
 	if(greyscale_config_inhand_right)
 		righthand_file = SSgreyscale.get_colored_icon_by_type(greyscale_config_inhand_right, greyscale_colors)
+	if(greyscale_config_belt)
+		colored_belt_appearance = SSgreyscale.get_colored_icon_by_type(greyscale_config_belt, greyscale_colors)
 	return
 
 /obj/item/proc/add_tape()
@@ -1451,6 +1452,6 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 /// Returns the icon used for overlaying the object on a belt
 /obj/item/proc/get_belt_overlay()
 	var/icon_state_to_use = belt_icon || icon_state
-	if(greyscale_config_belt && greyscale_colors)
-		return mutable_appearance(SSgreyscale.get_colored_icon_by_type(greyscale_config_belt, greyscale_colors), icon_state_to_use)
+	if(colored_belt_appearance)
+		return mutable_appearance(colored_belt_appearance, icon_state_to_use)
 	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', icon_state_to_use)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -220,6 +220,8 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	var/greyscale_config_inhand_left
 	///The config type to use for greyscaled right inhand sprites. Both this and greyscale_colors must be assigned to work.
 	var/greyscale_config_inhand_right
+	///The config type to use for greyscaled belt overlays. Both this and greyscale_colors must be assigned to work.
+	var/greyscale_config_belt
 
 	//Tooltip vars
 	var/tip_timer = 0
@@ -262,6 +264,9 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	var/can_put_in_closet = TRUE
 
 /obj/item/Initialize(mapload)
+	if(!greyscale_config && greyscale_colors && (greyscale_config_worn || greyscale_config_belt || greyscale_config_inhand_right || greyscale_config_inhand_left))
+		update_greyscale()
+
 	. = ..()
 
 	/// marks all items in storage as being such
@@ -1445,6 +1450,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 
 /// Returns the icon used for overlaying the object on a belt
 /obj/item/proc/get_belt_overlay()
-	if(!belt_icon)
-		return
-	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', belt_icon)
+	var/icon_state_to_use = belt_icon || icon_state
+	if(greyscale_config_belt && greyscale_colors)
+		return mutable_appearance(SSgreyscale.get_colored_icon_by_type(greyscale_config_belt, greyscale_colors), icon_state_to_use)
+	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', icon_state_to_use)

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -41,8 +41,6 @@
 		"cyan" = "#18a2d5",
 		"yellow" = "#ffa500"
 	)
-	/// Colored belt appearance for adding it as a belt overlay
-	var/mutable_appearance/colored_belt_appearance
 
 /obj/item/screwdriver/get_ru_names()
 	return list(
@@ -54,10 +52,6 @@
 		PREPOSITIONAL = "отвёртке"
 	)
 
-/obj/item/screwdriver/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/surgery_initiator/robo)
-
 /obj/item/screwdriver/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] вонза[PLUR_ET_YUT(user)] [declent_ru(ACCUSATIVE)] себе в [pick("висок", "сердце")]! Это похоже на попытку самоубийства!"))
 	return BRUTELOSS
@@ -66,11 +60,12 @@
 	if(random_color)
 		var/our_color = param_color || pick(screwdriver_colors)
 		set_greyscale_colors(list(screwdriver_colors[our_color]))
-		colored_belt_appearance = mutable_appearance(SSgreyscale.get_colored_icon_by_type(/datum/greyscale_config/screwdriver_belt, greyscale_colors))
 	. = ..()
 	if(prob(75))
 		pixel_y = rand(0, 16)
 
+
+	AddComponent(/datum/component/surgery_initiator/robo)
 	AddElement(/datum/element/falling_hazard, damage = force, hardhat_safety = TRUE, crushes = FALSE, impact_sound = hitsound)
 
 /obj/item/screwdriver/attack(mob/living/target, mob/living/user, params, def_zone, skip_attack_anim = FALSE)

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -27,6 +27,7 @@
 	greyscale_config = /datum/greyscale_config/screwdriver
 	greyscale_config_inhand_left = /datum/greyscale_config/screwdriver_inhand_left
 	greyscale_config_inhand_right = /datum/greyscale_config/screwdriver_inhand_right
+	greyscale_config_belt = /datum/greyscale_config/screwdriver_belt
 	greyscale_colors = COLOR_TOOL_RED
 	/// If the item should be assigned a random color
 	var/random_color = TRUE
@@ -93,6 +94,7 @@
 	greyscale_config = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
+	greyscale_config_belt = null
 	greyscale_colors = null
 
 /obj/item/screwdriver/nuke/get_ru_names()
@@ -104,15 +106,6 @@
 		INSTRUMENTAL = "ультратонкой отвёрткой",
 		PREPOSITIONAL = "ультратонкой отвёртке"
 	)
-
-/obj/item/screwdriver/get_belt_overlay()
-	if(random_color)
-		return colored_belt_appearance
-
-	if(!belt_icon)
-		return
-
-	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', belt_icon)
 
 /obj/item/screwdriver/brass
 	name = "brass screwdriver"
@@ -128,6 +121,7 @@
 	greyscale_config = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
+	greyscale_config_belt = null
 	greyscale_colors = null
 
 /obj/item/screwdriver/brass/get_ru_names()
@@ -155,6 +149,7 @@
 	greyscale_config = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
+	greyscale_config_belt = null
 	greyscale_colors = null
 
 /obj/item/screwdriver/abductor/get_ru_names()
@@ -197,6 +192,7 @@
 	greyscale_config = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
+	greyscale_config_belt = null
 	greyscale_colors = null
 	materials = list(MAT_METAL=150,MAT_SILVER=50,MAT_TITANIUM=25)
 	origin_tech = "materials=2;engineering=2" // done for balance reasons, making them high value for research, but harder to get

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -45,8 +45,6 @@
 		"cyan" = "#18a2d5",
 		"yellow" = "#d58c18"
 	)
-	/// Colored belt appearance for adding it as a belt overlay
-	var/mutable_appearance/colored_belt_appearance
 
 /obj/item/wirecutters/get_ru_names()
 	return list(
@@ -63,7 +61,6 @@
 		var/our_color = param_color || pick(wirecutter_colors)
 		set_greyscale_colors(list(wirecutter_colors[our_color]))
 		item_state = null
-		colored_belt_appearance = mutable_appearance(SSgreyscale.get_colored_icon_by_type(/datum/greyscale_config/wirecutters_belt, greyscale_colors))
 	. = ..()
 	AddElement(/datum/element/falling_hazard, damage = force, hardhat_safety = TRUE, crushes = FALSE, impact_sound = hitsound)
 

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -8,7 +8,7 @@
 	item_state = "cutters"
 	righthand_file = 'icons/mob/inhands/tools_righthand.dmi'
 	lefthand_file = 'icons/mob/inhands/tools_lefthand.dmi'
-	belt_icon = "wirecutters"
+	belt_icon = "cutters"
 	flags = CONDUCT
 	slot_flags = ITEM_SLOT_BELT
 	force = 6
@@ -31,6 +31,7 @@
 	greyscale_config = /datum/greyscale_config/wirecutters
 	greyscale_config_inhand_left = /datum/greyscale_config/wirecutters_inhand_left
 	greyscale_config_inhand_right = /datum/greyscale_config/wirecutters_inhand_right
+	greyscale_config_belt = /datum/greyscale_config/wirecutters_belt
 	greyscale_colors = COLOR_RED
 	/// If the item should be assigned a random color
 	var/random_color = TRUE
@@ -88,15 +89,6 @@
 	playsound(loc, usesound, 50, TRUE, -1)
 	return BRUTELOSS
 
-/obj/item/wirecutters/get_belt_overlay()
-	if(random_color)
-		return colored_belt_appearance
-
-	if(!belt_icon)
-		return
-
-	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', belt_icon)
-
 /obj/item/wirecutters/brass
 	name = "brass wirecutters"
 	desc = "Инструмент, предназначенный для перекусывания различных материалов. \
@@ -108,6 +100,7 @@
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
 	greyscale_colors = null
+	greyscale_config_belt = null
 	toolspeed = 0.5
 	random_color = FALSE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
@@ -136,6 +129,7 @@
 	greyscale_config = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
+	greyscale_config_belt = null
 	greyscale_colors = null
 
 /obj/item/wirecutters/abductor/get_ru_names()
@@ -177,6 +171,7 @@
 	greyscale_config = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
+	greyscale_config_belt = null
 	greyscale_colors = null
 	origin_tech = "materials=2;engineering=2"
 	materials = list(MAT_METAL=150,MAT_SILVER=50,MAT_TITANIUM=25)

--- a/code/tests/test_greyscale_config.dm
+++ b/code/tests/test_greyscale_config.dm
@@ -12,3 +12,8 @@
 		var/datum/greyscale_config/righthand = SSgreyscale.configurations["[initial(item_path.greyscale_config_inhand_right)]"]
 		if(righthand && !righthand.icon_states[held_icon_state])
 			TEST_FAIL("[righthand.debug_name()] is missing a sprite for the held righthand for [item_path]. Expected icon state: '[held_icon_state]'")
+
+		var/datum/greyscale_config/belt = SSgreyscale.configurations["[initial(item_path.greyscale_config_belt)]"]
+		var/belt_icon = initial(item_path.belt_icon) || initial(item_path.icon_state)
+		if(belt && !belt.icon_states[belt_icon])
+			TEST_FAIL("[belt.debug_name()] is missing a sprite for the belt overlay for [item_path]. Expected icon state: '[belt_icon]'")


### PR DESCRIPTION
## Что этот ПР делает

Чинит баг, из-за которого собранные ГАГСом оверлеи кусачек и отверток для пояса не отображались.
Также выносит сборку belt_icon ГАГСом в obj/item/proc/get_belt_overlay() , убирая этот прок у wirecutter и screwdriver.

## Почему это хорошо для игры

Баг исправлен + теперь легче сделать belt_icon через ГАГС.

## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>

![dreamseeker_Qp5R9sO58A](https://github.com/user-attachments/assets/0a38156d-cbac-4171-a007-0c5a8c70ef89)


</p>
</details>

## Тестирование

Да.