### PR TITLE
bugfix: Исправление шаттла доп целей

### DIFF
--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -310,7 +310,7 @@
 
 /datum/action/item_action/hands_free/update_button_status(atom/movable/screen/movable/action_button/button, force = FALSE)
 	var/obj/item/implant/implant = target
-	if(istype(implant))
+	if(istype(implant) && implant.cooldown_system)
 		status_text = implant.cooldown_system.cooldown_info()
 	. = ..()
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -622,7 +622,7 @@
 
 	mobile_port.unlockPortDoors(new_dock)
 	areaInstance.parallax_movedir = mobile_port.preferred_direction
-	SEND_SIGNAL(src, COMSIG_SHUTTLE_DOCK, new_dock)
+	SEND_SIGNAL(mobile_port, COMSIG_SHUTTLE_DOCK, new_dock)
 
 /obj/docking_port/mobile/proc/is_turf_blacklisted_for_transit(turf/T)
 	var/static/list/blacklisted_turf_types = typecacheof(GLOB.blacklisted_turf_types_for_transit)


### PR DESCRIPTION
## Что этот ПР делает

1. Исправляет мелкий баг с экшн кнопками без кд (*рантаймило*).
2. Исправляет шаттл доп целей, сигнал теперь отправляется куда надо.

## Почему это хорошо для игры

Баги это плохо.

## Тестирование

Локалка.
