### PR TITLE
bugfix: Вернул хил протоадреналам

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -951,6 +951,19 @@
 /datum/status_effect/adrenaline/on_remove()
 	owner.remove_status_effect_absorption(source = id, effect_type = list(STUN, WEAKEN, STAMCRIT, PARALYZE, KNOCKDOWN))
 
+/atom/movable/screen/alert/status_effect/adrenaline/prototype
+	desc = "Твоя стамина полностью восстановлена. Регенерация увеличена, а длительность станов уменьшена."
+
+/datum/status_effect/adrenaline/prototype
+	alert_type = /atom/movable/screen/alert/status_effect/adrenaline/prototype
+	var/heal_amount = 15
+
+/datum/status_effect/adrenaline/prototype/tick(seconds_between_ticks)
+	var/update = NONE
+	update |= owner.heal_overall_damage(heal_amount, heal_amount, updating_health = FALSE)
+	if(update)
+		owner.updatehealth("adrenaline")
+
 
 /atom/movable/screen/alert/status_effect/heal
 	name = "Лечение нанитами"

--- a/code/game/objects/items/weapons/implants/implant_adrenalin.dm
+++ b/code/game/objects/items/weapons/implants/implant_adrenalin.dm
@@ -100,7 +100,7 @@
 	imp_in.reagents.add_reagent("stimulative_agent", 5)
 	imp_in.reagents.add_reagent("adrenaline", 3)
 
-	imp_in.apply_status_effect(/datum/status_effect/adrenaline)
+	imp_in.apply_status_effect(/datum/status_effect/adrenaline/prototype)
 
 	if(!uses)
 		qdel(src)


### PR DESCRIPTION
## Что этот ПР делает

Возвращает хил 15/15 в тик для протоадренала.

## Почему это хорошо для игры

Случайно удалил хил у протоадренала когда удалял у обычных. Недоработку устранил

## Тестирование

Локалка
