### PR TITLE
bugfix: Госты могут смотреть содержимое МЭКов

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -375,6 +375,11 @@
 	add_fingerprint(user)
 	return CLICK_ACTION_SUCCESS
 
+/obj/item/mod/control/attack_ghost(mob/user)
+	if(isobserver(user) && bag)
+		bag.show_to(user)
+	return ..()
+
 /obj/item/mod/control/proc/can_be_inserted(I, stop_messages)
 	if(bag)
 		return bag.can_be_inserted(I, stop_messages)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -378,6 +378,7 @@
 /obj/item/mod/control/attack_ghost(mob/user)
 	if(isobserver(user) && bag)
 		bag.show_to(user)
+		return
 	return ..()
 
 /obj/item/mod/control/proc/can_be_inserted(I, stop_messages)


### PR DESCRIPTION
## Что этот ПР делает

Госты могут через лкм заглядывать в хранилище МЭКа как в любое другое хранилище

## Почему это хорошо для игры

Раз госты могут смотреть содержимое всех хранилищ, то и хранилище МЭКа не должно быть исключением

## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>
</p>
</details>

## Тестирование

Локалка
