### PR TITLE
bugfix: Блокировка интегралок по карте

### DIFF
--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -203,12 +203,12 @@
 		return
 
 	if(attached_circuit)
-		if(try_toggle_lock(source, item, attacker))
-			return COMPONENT_CANCEL_ATTACK_CHAIN
-
 		if(!attached_circuit.owner_id && is_id_card(item))
 			source.balloon_alert(attacker, UNLINT("ID-карта привязана к схеме"))
 			attached_circuit.owner_id = WEAKREF(item)
+			return COMPONENT_CANCEL_ATTACK_CHAIN
+
+		if(try_toggle_lock(source, item, attacker))
 			return COMPONENT_CANCEL_ATTACK_CHAIN
 
 		if(is_circuit_component(item))
@@ -237,7 +237,7 @@
 
 
 /datum/component/shell/proc/try_toggle_lock(atom/source, obj/item/id_card, mob/living/attacker)
-	if(is_id_card(id_card))
+	if(!is_id_card(id_card))
 		return FALSE
 
 	if(id_card != attached_circuit.owner_id?.resolve())

--- a/code/modules/wiremod/shell/dispenser.dm
+++ b/code/modules/wiremod/shell/dispenser.dm
@@ -235,4 +235,7 @@
 
 /obj/item/circuit_component/vendor_component/proc/on_set_locked(datum/source, new_value)
 	SIGNAL_HANDLER
+	if(!attached_bot)
+		return
+
 	attached_bot.locked = new_value

--- a/code/modules/wiremod/shell/dispenser.dm
+++ b/code/modules/wiremod/shell/dispenser.dm
@@ -210,6 +210,8 @@
 		return
 
 	attached_bot = shell
+	RegisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED, PROC_REF(on_set_locked))
+	attached_bot.locked = parent.locked
 
 /obj/item/circuit_component/vendor_component/unregister_shell(atom/movable/shell)
 	attached_bot = null

--- a/code/modules/wiremod/shell/dispenser.dm
+++ b/code/modules/wiremod/shell/dispenser.dm
@@ -215,6 +215,7 @@
 
 /obj/item/circuit_component/vendor_component/unregister_shell(atom/movable/shell)
 	attached_bot = null
+	UnregisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED, PROC_REF(on_set_locked))
 	return ..()
 
 /obj/item/circuit_component/vendor_component/populate_ports()

--- a/code/modules/wiremod/shell/dispenser.dm
+++ b/code/modules/wiremod/shell/dispenser.dm
@@ -214,8 +214,11 @@
 	attached_bot.locked = parent.locked
 
 /obj/item/circuit_component/vendor_component/unregister_shell(atom/movable/shell)
+	if(attached_bot)
+		attached_bot.locked = FALSE
+		UnregisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED)
+
 	attached_bot = null
-	UnregisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED)
 	return ..()
 
 /obj/item/circuit_component/vendor_component/populate_ports()

--- a/code/modules/wiremod/shell/dispenser.dm
+++ b/code/modules/wiremod/shell/dispenser.dm
@@ -230,3 +230,7 @@
 		return
 
 	attached_bot.remove_item(vending_item)
+
+/obj/item/circuit_component/vendor_component/proc/on_set_locked(datum/source, new_value)
+	SIGNAL_HANDLER
+	attached_bot.locked = new_value

--- a/code/modules/wiremod/shell/dispenser.dm
+++ b/code/modules/wiremod/shell/dispenser.dm
@@ -103,6 +103,7 @@
 
 /obj/structure/dispenser_bot/wrench_act(mob/living/user, obj/item/tool)
 	if(locked)
+		balloon_alert(user, "закрыто!")
 		return
 
 	set_anchored(!anchored)

--- a/code/modules/wiremod/shell/dispenser.dm
+++ b/code/modules/wiremod/shell/dispenser.dm
@@ -215,7 +215,7 @@
 
 /obj/item/circuit_component/vendor_component/unregister_shell(atom/movable/shell)
 	attached_bot = null
-	UnregisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED, PROC_REF(on_set_locked))
+	UnregisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED)
 	return ..()
 
 /obj/item/circuit_component/vendor_component/populate_ports()

--- a/code/modules/wiremod/shell/manipulator.dm
+++ b/code/modules/wiremod/shell/manipulator.dm
@@ -63,6 +63,7 @@
 
 /obj/item/circuit_component/wiremod_manipulator/unregister_shell(atom/movable/shell)
 	attached_bot = null
+	UnregisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED)
 	return ..()
 
 /obj/item/circuit_component/wiremod_manipulator/input_received(datum/port/input/port)

--- a/code/modules/wiremod/shell/manipulator.dm
+++ b/code/modules/wiremod/shell/manipulator.dm
@@ -58,6 +58,8 @@
 		return
 
 	attached_bot = shell
+	RegisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED, PROC_REF(on_set_locked))
+	attached_bot.locked = parent.locked
 
 /obj/item/circuit_component/wiremod_manipulator/unregister_shell(atom/movable/shell)
 	attached_bot = null
@@ -105,4 +107,7 @@
 
 /obj/item/circuit_component/wiremod_manipulator/proc/on_set_locked(datum/source, new_value)
 	SIGNAL_HANDLER
+	if(!attached_bot)
+		return
+
 	attached_bot.locked = new_value

--- a/code/modules/wiremod/shell/manipulator.dm
+++ b/code/modules/wiremod/shell/manipulator.dm
@@ -13,6 +13,7 @@
 	density = TRUE
 	light_system = MOVABLE_LIGHT
 	light_on = FALSE
+	var/locked = FALSE
 
 /obj/structure/wiremod_manipulator/get_ru_names()
 	return list(

--- a/code/modules/wiremod/shell/manipulator.dm
+++ b/code/modules/wiremod/shell/manipulator.dm
@@ -101,3 +101,7 @@
 	tool.play_tool_sound(src)
 	balloon_alert(user, "[anchored ? "" : "не"]закреплено")
 	return TRUE
+
+/obj/item/circuit_component/wiremod_manipulator/proc/on_set_locked(datum/source, new_value)
+	SIGNAL_HANDLER
+	attached_bot.locked = new_value

--- a/code/modules/wiremod/shell/manipulator.dm
+++ b/code/modules/wiremod/shell/manipulator.dm
@@ -62,8 +62,11 @@
 	attached_bot.locked = parent.locked
 
 /obj/item/circuit_component/wiremod_manipulator/unregister_shell(atom/movable/shell)
+	if(attached_bot)
+		attached_bot.locked = FALSE
+		UnregisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED)
+
 	attached_bot = null
-	UnregisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED)
 	return ..()
 
 /obj/item/circuit_component/wiremod_manipulator/input_received(datum/port/input/port)

--- a/code/modules/wiremod/shell/manipulator.dm
+++ b/code/modules/wiremod/shell/manipulator.dm
@@ -93,6 +93,10 @@
 	target_atom.SpinAnimation(speed = 5, loops = 1, parallel = FALSE)
 
 /obj/structure/wiremod_manipulator/wrench_act(mob/living/user, obj/item/tool)
+	if(locked)
+		balloon_alert(user, "закрыто!")
+		return
+
 	set_anchored(!anchored)
 	tool.play_tool_sound(src)
 	balloon_alert(user, "[anchored ? "" : "не"]закреплено")

--- a/code/modules/wiremod/shell/moneybot.dm
+++ b/code/modules/wiremod/shell/moneybot.dm
@@ -41,6 +41,7 @@
 
 /obj/structure/money_bot/wrench_act(mob/living/user, obj/item/tool)
 	if(locked)
+		balloon_alert(user, "закрыто!")
 		return
 
 	set_anchored(!anchored)


### PR DESCRIPTION
## Что этот ПР делает

Исправляет баг, из за которого не работала блокировка интегральных схем по карте (лкм картой по корпусу с интегралкой внутри).
Корпуса манипулятора, денежного бота и бота раздатчика теперь нельзя открутить или прикрутить к полу, пока они заблокированы.

## Почему это хорошо для игры

меньше багов, теперь нельзя в наглую украсть чужую интегралку.

## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>
</p>
</details>

## Тестирование

Локалка
