### PR TITLE
balance+bugfix: Перемещение лазерных патронов 9 мм в протолат и фикс бага с печатью магазинов к Искре

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -729,13 +729,6 @@
 	build_path = /obj/item/ammo_box/enforcer/disabler
 	category = list(PRINTER_CATEGORY_INITIAL, AUTOLATHE_CATEGORY_SECURITY)
 
-/datum/design/enforcer/laser
-	id = "enforcer_laser"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 35000)
-	build_path = /obj/item/ammo_box/enforcer/laser
-	category = list(PRINTER_CATEGORY_HACKED, AUTOLATHE_CATEGORY_SECURITY)
-
 /datum/design/spectermag_disabler
 	id = "spectermag"
 	build_type = AUTOLATHE
@@ -756,7 +749,7 @@
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 3000)
 	build_path = /obj/item/ammo_box/magazine/sparkle_a12/empty
-	category = list("hacked", "Security")
+	category = list(PRINTER_CATEGORY_HACKED, AUTOLATHE_CATEGORY_SECURITY)
 
 /datum/design/buckshot_shell
 	id = "buckshot_shell"

--- a/code/modules/research/designs/protolathe/weapon_designs.dm
+++ b/code/modules/research/designs/protolathe/weapon_designs.dm
@@ -142,7 +142,7 @@
 /datum/design/hp45colt
 	id = "hp45colt"
 	req_tech = list(RESEARCH_TREE_COMBAT = 3, RESEARCH_TREE_MATERIALS = 3)
-	build_type = PROTOLATHE | AUTOLATHE
+	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 44500, MAT_SILVER = 3000)
 	build_path = /obj/item/ammo_box/expansive45colt
 	category = list(PROTOLATHE_CATEGORY_WEAPON)
@@ -150,7 +150,7 @@
 /datum/design/enforcer/laser
 	id = "enforcer_laser"
 	req_tech = list(RESEARCH_TREE_COMBAT = 2, RESEARCH_TREE_POWERSTORAGE = 3)
-	build_type = PROTOLATHE | AUTOLATHE
+	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 35000)
 	build_path = /obj/item/ammo_box/enforcer/laser
 	category = list(PROTOLATHE_CATEGORY_WEAPON)

--- a/code/modules/research/designs/protolathe/weapon_designs.dm
+++ b/code/modules/research/designs/protolathe/weapon_designs.dm
@@ -147,6 +147,14 @@
 	build_path = /obj/item/ammo_box/expansive45colt
 	category = list(PROTOLATHE_CATEGORY_WEAPON)
 
+/datum/design/enforcer/laser
+	id = "enforcer_laser"
+	req_tech = list(RESEARCH_TREE_COMBAT = 2, RESEARCH_TREE_POWERSTORAGE = 3)
+	build_type = PROTOLATHE | AUTOLATHE
+	materials = list(MAT_METAL = 35000)
+	build_path = /obj/item/ammo_box/enforcer/laser
+	category = list(PROTOLATHE_CATEGORY_WEAPON)
+
 /datum/design/lmag
 	id = "lmag"
 	build_type = PROTOLATHE | AUTOLATHE


### PR DESCRIPTION
## Что этот ПР делает

1. Перемещен дизайн лазерных патронов 9 мм в протолат за combat 2 и power 3.
2. Фикс бага с печатью магазина к пистолет-пулемету Искра.

## Почему это хорошо для игры

Лазерные патроны к баллистике раундстарт не очень балансно, у баллистики должен был быть минус, универсальность сделана без учета баланса. Если силньо надо - смогут напечатать в рнд.

Ну и фикс бага что нельзя было печатать магазины к Искре из-за бага, поправил.

## Тестирование

Проверил на локалке, все ок.
