### PR TITLE
bugfix: Исправление бага с выкидыванием гильзы при стрельбе с револьверов

### DIFF
--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -110,7 +110,7 @@
 /obj/item/gun/projectile/bow/shoot_with_empty_chamber(mob/living/user)
 	return
 
-/obj/item/gun/projectile/bow/handle_chamber(eject_casing = FALSE, empty_chamber = TRUE)
+/obj/item/gun/projectile/bow/process_chamber(eject_casing = FALSE, empty_chamber = TRUE)
 	. = ..()
 	ready_to_fire = FALSE
 	update_state()

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -43,7 +43,7 @@
 	accuracy = GUN_ACCURACY_MINIMAL
 	fire_modes = GUN_MODE_SINGLE_ONLY
 
-/obj/item/gun/projectile/automatic/gyropistol/handle_chamber(eject_casing = 0, empty_chamber = 1)
+/obj/item/gun/projectile/automatic/gyropistol/process_chamber(eject_casing = FALSE, empty_chamber = TRUE)
 	..()
 
 /obj/item/gun/projectile/automatic/gyropistol/update_icon_state()
@@ -78,7 +78,7 @@
 		return TRUE
 	return FALSE
 
-/obj/item/gun/projectile/automatic/speargun/handle_chamber(eject_casing = FALSE, empty_chamber = TRUE)
+/obj/item/gun/projectile/automatic/speargun/process_chamber(eject_casing = FALSE, empty_chamber = TRUE)
 	. = ..()
 
 /obj/item/gun/projectile/automatic/speargun/attackby(obj/item/I, mob/user, params)
@@ -130,7 +130,7 @@
 		return TRUE
 	return FALSE
 
-/obj/item/gun/projectile/revolver/rocketlauncher/handle_chamber(eject_casing = FALSE, empty_chamber = TRUE)
+/obj/item/gun/projectile/revolver/rocketlauncher/process_chamber(eject_casing = FALSE, empty_chamber = TRUE)
 	. = ..()
 
 /obj/item/gun/projectile/revolver/rocketlauncher/chamber_round()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -31,7 +31,7 @@
 	. = ..()
 	chamber_round(TRUE)
 
-/obj/item/gun/projectile/revolver/handle_chamber(eject_casing = FALSE, empty_chamber = TRUE)
+/obj/item/gun/projectile/revolver/process_chamber(eject_casing = FALSE, empty_chamber = TRUE)
 	return ..()
 
 /obj/item/gun/projectile/revolver/attackby(obj/item/item, mob/user, params)


### PR DESCRIPTION
## Что этот ПР делает

Устраняет баг при котором револьверы каким то хуем выбрасывали гильзы при стрельбе.

## Почему это хорошо для игры

Чинит неприятный баг.

## Тестирование

Проверил на локалке, теперь не выбрасывает гильзы. Непонятно зачем надо было его ломать.
