### PR TITLE
bugfix: неправильная проверка нахождения рядом у объектов

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -71,7 +71,7 @@ Adjacency (to turf):
 		return TRUE
 
 	var/turf/corner_turf = loc
-	if(!corner_turf)
+	if(!istype(corner_turf))
 		return FALSE
 
 	if(!is_multi_tile_object(src))

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -77,10 +77,12 @@ Adjacency (to turf):
 	if(!is_multi_tile_object(src))
 		return corner_turf.Adjacent(neighbor, target = neighbor, mover = src)
 
-	// Check for all turfs we are currently occupying, checking bound_width / bound_height variables.
+	// Check for all turfs we are currently occupying, checking bound_width / bound_height variables
+	var/horizontal_turf_amount = bound_width / ICON_SIZE_X
+	var/vertical_turf_amount = bound_height / ICON_SIZE_Y
 	// We round to the nearest integer
-	var/horizontal_turf_amount = max(1, floor(bound_width / ICON_SIZE_X) + (fract(bound_width) >= 0.5))
-	var/vertical_turf_amount = max(1, floor(bound_height / ICON_SIZE_Y) + (fract(bound_height) >= 0.5))
+	horizontal_turf_amount = max(1, floor(horizontal_turf_amount) + (fract(horizontal_turf_amount) >= 0.5))
+	vertical_turf_amount = max(1, floor(vertical_turf_amount) + (fract(vertical_turf_amount) >= 0.5))
 	for(var/turf/our_turf as anything in CORNER_BLOCK(corner_turf, horizontal_turf_amount, vertical_turf_amount))
 		if(our_turf.Adjacent(neighbor, target = neighbor, mover = src))
 			return TRUE

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -69,11 +69,21 @@ Adjacency (to turf):
 		return TRUE
 	if(neighbor?.loc == src)
 		return TRUE
-	var/turf/T = loc
-	if(!istype(T))
+
+	var/turf/corner_turf = loc
+	if(!corner_turf)
 		return FALSE
-	if(T.Adjacent(neighbor,target = neighbor, mover = src))
-		return TRUE
+
+	if(!is_multi_tile_object(src))
+		return corner_turf.Adjacent(neighbor, target = neighbor, mover = src)
+
+	// Check for all turfs we are currently occupying, checking bound_width / bound_height variables.
+	// We round to the nearest integer
+	var/horizontal_turf_amount = max(1, floor(bound_width / ICON_SIZE_X) + (fract(bound_width) >= 0.5))
+	var/vertical_turf_amount = max(1, floor(bound_height / ICON_SIZE_Y) + (fract(bound_height) >= 0.5))
+	for(var/turf/our_turf as anything in CORNER_BLOCK(corner_turf, horizontal_turf_amount, vertical_turf_amount))
+		if(our_turf.Adjacent(neighbor, target = neighbor, mover = src))
+			return TRUE
 	return FALSE
 
 /// This is necessary for storage items not on your person.


### PR DESCRIPTION
## Что этот ПР делает

Теперь у мультитайл объектов (bound_width или bound_height > 32) при вычислении нахождения рядом будут считаться все тёрфы под объектом (с округлением размера к ближайшему числу).

## Почему это хорошо для игры

В под можно залезть со всех сторон.

## Тестирование

Потыкал мультитайл объекты, потыкал обычные объекты, изменял ввшкой размер, всё работает.
