### PR TITLE
bugfix: Исправление фичи с перерезанием горла

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -219,6 +219,10 @@
 	if(!do_after(attacker, neck_cut_delay, defender, max_interact_count = 1) || attacker.pulling != defender || attacker.grab_state < GRAB_NECK)
 		return FALSE
 
+	var/obj/item/organ/external/head = defender.get_organ(attacker.zone_selected)
+	if(!head.has_arterial_bleeding())
+		head.arterial_bleeding()
+
 	if(defender.blood_volume > BLOOD_VOLUME_SURVIVE)
 		defender.blood_volume = max(0, defender.blood_volume - 0.25 * (BLOOD_VOLUME_NORMAL - BLOOD_VOLUME_SURVIVE)) //-25% of max blood volume
 

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -220,7 +220,7 @@
 		return FALSE
 
 	var/obj/item/organ/external/head = defender.get_organ(attacker.zone_selected)
-	if(!head.has_arterial_bleeding())
+	if(head && !head.has_arterial_bleeding())
 		head.arterial_bleeding()
 
 	if(defender.blood_volume > BLOOD_VOLUME_SURVIVE)


### PR DESCRIPTION
## Что этот ПР делает

Исправил перерезание горла ножом, теперь оно снова дает артериалку в голову после применения.

## Почему это хорошо для игры

При очередном исправлении конфликта VSC поел говна и неправильно замерджил локализейшн саггест, а я ишшуй не проверил. Исправлено, теперь перерезание горла нормально накладывает артериалку.

## Демонстрация изменений

<!-- Заполните, если Вы меняли спрайты, карту или ваши изменения требуют визуальной демонстрации изменений. -->
<details><summary>Демонстрации изменений</summary>
<p>

<img width="343" height="192" alt="image" src="https://github.com/user-attachments/assets/79b75751-8c04-4a60-8143-d4159ab4ab2d" />

</p>
</details>

## Тестирование

Проверил на локалке, теперь точно работает.
