### PR TITLE
balance: Изменение размера КА и шахтерских сумок

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -129,7 +129,6 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "satchel"
 	origin_tech = "engineering=2"
-	slot_flags_2 = ITEM_FLAG_POCKET_LARGE
 	storage_slots = 10
 	max_combined_w_class = 200 //Doesn't matter what this is, so long as it's more or equal to storage_slots * ore.w_class
 	max_w_class = WEIGHT_CLASS_BULKY
@@ -199,11 +198,11 @@
 	desc = "Вы ожидали чего-то более стильного, как в мультфильмах про грабителей."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "gem_satchel"
-	slot_flags_2 = ITEM_FLAG_POCKET_LARGE
 	storage_slots = 48
 	max_combined_w_class = 48
 	max_w_class = WEIGHT_CLASS_NORMAL
 	can_hold = list(/obj/item/gem)
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/bag/gem/get_ru_names()
 	return list(

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -134,6 +134,7 @@
 	max_combined_w_class = 200 //Doesn't matter what this is, so long as it's more or equal to storage_slots * ore.w_class
 	max_w_class = WEIGHT_CLASS_BULKY
 	can_hold = list(/obj/item/stack/ore)
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/bag/ore/get_ru_names()
 	return list(

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -20,6 +20,7 @@
 	can_bayonet = TRUE
 	bayonet_x_offset = 20
 	bayonet_y_offset = 12
+	w_class = WEIGHT_CLASS_BULKY
 	/// Lazylist of installed modkits.
 	var/list/obj/item/borg/upgrade/modkit/modkits
 	/// Bitflags. Used to determine which modkits fit into the KA.


### PR DESCRIPTION
## Что этот ПР делает

Изменяет кинетическому акселератору, сумке для руды и сумке для драгоценных камней размер на bulky. Убирает обоим сумкам флаг, позволяющий положить их в карман.

## Почему это хорошо для игры

Тот кто менял размер всех сумок на булки по неизвестной причине пропустил шахту, исправляем и приводим сумки к одному размеру. Мотивирует шахту приносить руду на станцию сразу как заполнилась сумка, а не носить с собой по две-три сумки 40 минут.
А КА слишком мощный в разряженной атмосфере чтобы носить его в сумке, все еще можно носить в слоте баллона или на поясе.

## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>
</p>
</details>

## Тестирование

Локалка
