### PR TITLE
bugfix: убрана возможность пинговать через тикеты

### DIFF
--- a/code/datums/discord.dm
+++ b/code/datums/discord.dm
@@ -41,7 +41,7 @@
 		sanitized_content = replacetext(sanitized_content, "&#64;everyone", "(Attempted atEveryone)")
 		sanitized_content = replacetext(sanitized_content, "&#64;here", "(Attempted atHere)")
 
-		var/list/replacement_list = list("<@", "<&#64;", "&#60;@", "&#60;&#64;", "&lt;&#64;", "&lt;&#64;", "&lt;@")
+		var/list/replacement_list = list("<@", "<&#64;", "&#60;@", "&#60;&#64;", "&lt;&#64;", "&lt;@")
 		for(var/to_replace in replacement_list)
 			sanitized_content = replacetext(sanitized_content, to_replace, "(Attempted ping)<")
 

--- a/code/datums/discord.dm
+++ b/code/datums/discord.dm
@@ -37,6 +37,14 @@
 		var/sanitized_content = webhook_content
 		sanitized_content = replacetext(sanitized_content, "@everyone", "(Attempted atEveryone)")
 		sanitized_content = replacetext(sanitized_content, "@here", "(Attempted atHere)")
+
+		sanitized_content = replacetext(sanitized_content, "&#64;everyone", "(Attempted atEveryone)")
+		sanitized_content = replacetext(sanitized_content, "&#64;here", "(Attempted atHere)")
+
+		var/list/replacement_list = list("<@", "<&#64;", "&#60;&#64;", "&lt;&#64;", "&lt;&#64;", "&lt;@")
+		for(var/to_replace in replacement_list)
+			sanitized_content = replacetext(sanitized_content, to_replace, "(Attempted ping)<")
+
 		// Fixes speech marks being replaced by invalid chars
 		// Note that we dont have to care about having to sanitize <> out, because discord handles that
 		sanitized_content = html_decode(sanitized_content)

--- a/code/datums/discord.dm
+++ b/code/datums/discord.dm
@@ -41,7 +41,7 @@
 		sanitized_content = replacetext(sanitized_content, "&#64;everyone", "(Attempted atEveryone)")
 		sanitized_content = replacetext(sanitized_content, "&#64;here", "(Attempted atHere)")
 
-		var/list/replacement_list = list("<@", "<&#64;", "&#60;&#64;", "&lt;&#64;", "&lt;&#64;", "&lt;@")
+		var/list/replacement_list = list("<@", "<&#64;", "&#60;@", "&#60;&#64;", "&lt;&#64;", "&lt;&#64;", "&lt;@")
 		for(var/to_replace in replacement_list)
 			sanitized_content = replacetext(sanitized_content, to_replace, "(Attempted ping)<")
 


### PR DESCRIPTION
## Что этот ПР делает

Убирает все доступные способы пинговать кого-либо через тикеты (по крайней мере, других я не вижу). Больше никаких евреваней, херов, пингов игроков и ролей (если честно их и не было, но это не значит, что не будет в будущем)

## Почему это хорошо для игры

Нет возможности тыкать менторов/админов по приколу. А учитывая что нет кд на тикеты - этим можно знатно проспамить

## Демонстрация изменений

<!-- Заполните, если Вы меняли спрайты, карту или ваши изменения требуют визуальной демонстрации изменений. -->
<details><summary>Демонстрации изменений</summary>
<p>

<img width="878" height="141" alt="Screenshot 2026-01-31 103300" src="https://github.com/user-attachments/assets/d38907d9-97b8-442f-8a27-bfeedfa557e6" />

Багу кстати 4 года☠️
<img width="866" height="278" alt="Screenshot 2026-01-31 103053" src="https://github.com/user-attachments/assets/0db5a4f5-a9b3-47b1-a021-9fe544921186" />

</p>
</details>

## Тестирование

локалка с вэбхуком на своем дс сервере
