### PR TITLE
bugfix: исправление позиции глушителей и компенсов на револьверах

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -687,7 +687,8 @@
 		gun.zoom(owner, FALSE)
 
 /datum/action/toggle_scope_zoom/Remove(mob/living/L)
-	gun.zoom(L, FALSE)
+	if(gun)
+		gun.zoom(L, FALSE)
 	..()
 
 /datum/action/toggle_scope_zoom/Destroy()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -140,6 +140,7 @@
 	fire_sound = 'sound/weapons/gunshots/1rev38.ogg'
 	accuracy = GUN_ACCURACY_PISTOL
 	recoil = GUN_RECOIL_MEDIUM
+	attachable_allowed = GUN_MODULE_CLASS_NONE
 
 /obj/item/gun/projectile/revolver/detective/ComponentInitialize()
 	. = ..()
@@ -194,6 +195,7 @@
 	needs_permit = FALSE //go away beepsky
 	var/obj/effect/proc_holder/spell/mime/fingergun/parent_spell
 	accuracy = GUN_ACCURACY_DEFAULT
+	attachable_allowed = GUN_MODULE_CLASS_NONE
 
 /obj/item/gun/projectile/revolver/fingergun/Initialize(mapload, new_parent_spell)
 	. = ..()
@@ -241,6 +243,9 @@
 	icon_state = "mateba"
 	accuracy = GUN_ACCURACY_PISTOL
 	recoil = GUN_RECOIL_HIGH
+	attachable_offset = list(
+		ATTACHMENT_SLOT_MUZZLE = list("x" = 18, "y" = 2),
+	)
 
 /obj/item/gun/projectile/revolver/ga12
 	name = "Tkach Ya-Sui GA 12 revolver"
@@ -252,6 +257,9 @@
 	accuracy = new /datum/gun_accuracy/pistol/extends_spread()
 	accuracy = GUN_ACCURACY_PISTOL
 	recoil = GUN_RECOIL_HIGH
+	attachable_offset = list(
+		ATTACHMENT_SLOT_MUZZLE = list("x" = 16, "y" = 2),
+	)
 
 /obj/item/gun/projectile/revolver/golden
 	name = "golden revolver"
@@ -261,6 +269,7 @@
 	accuracy = new /datum/gun_accuracy/pistol/extends_spread()
 	accuracy = GUN_ACCURACY_PISTOL_UPLINK
 	recoil = GUN_RECOIL_MEGA
+	attachable_allowed = GUN_MODULE_CLASS_NONE
 
 /obj/item/gun/projectile/revolver/nagant
 	name = "nagant revolver"
@@ -270,6 +279,9 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev762
 	accuracy = GUN_ACCURACY_PISTOL_UPLINK
 	recoil = GUN_RECOIL_MEDIUM
+	attachable_offset = list(
+		ATTACHMENT_SLOT_MUZZLE = list("x" = 17, "y" = 3),
+	)
 
 /obj/item/gun/projectile/revolver/c36
 	name = ".36 revolver"
@@ -279,6 +291,7 @@
 	fire_sound = 'sound/weapons/gunshots/1rev38.ogg'
 	accuracy = GUN_ACCURACY_PISTOL
 	recoil = GUN_RECOIL_MEDIUM
+	attachable_allowed = GUN_MODULE_CLASS_NONE
 
 // A gun to play Russian Roulette!
 // You can spin the chamber to randomize the position of the bullet.
@@ -291,6 +304,9 @@
 	accuracy = GUN_ACCURACY_PISTOL
 	recoil = GUN_RECOIL_MEDIUM
 	can_air_shoot = FALSE
+	attachable_offset = list(
+		ATTACHMENT_SLOT_MUZZLE = list("x" = 19, "y" = 3),
+	)
 
 /obj/item/gun/projectile/revolver/russian/Initialize(mapload)
 	. = ..()
@@ -408,6 +424,9 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/cap
 	accuracy = GUN_ACCURACY_PISTOL
 	recoil = GUN_RECOIL_MEDIUM
+	attachable_offset = list(
+		ATTACHMENT_SLOT_MUZZLE = list("x" = 19, "y" = 3),
+	)
 
 /obj/item/gun/projectile/revolver/improvised
 	name = "improvised revolver"
@@ -420,6 +439,7 @@
 	var/obj/item/weaponcrafting/revolverbarrel/barrel
 	accuracy = GUN_ACCURACY_MINIMAL
 	recoil = GUN_RECOIL_MEGA
+	attachable_allowed = GUN_MODULE_CLASS_NONE
 
 /obj/item/gun/projectile/revolver/improvised/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## Что этот ПР делает

Исправлено позиция наложения оверлея наствольного модуля для револьверов.
Некоторым револьверам запретил возможность крепить глушитель и пламегаситель.

## Почему это хорошо для игры

Кто-то разрешил глушители и компенсы на револьверы на базовом уровне `/obj/item/gun/projectile/revolver/` и не расставил точки крепления для самих револьверов, исправляю.

## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>

короче скриншот не прикрепляется, я хуй знает

</p>
</details>

## Тестирование

Проверил на локалке.
