### PR TITLE
tweak: Карбоны с иммунитетом к высокой температуре могут поднимать горящие предметы

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -503,7 +503,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	if((resistance_flags & ON_FIRE) && !pickupfireoverride)
 		var/mob/living/carbon/human/H = user
 		if(istype(H))
-			if((H.gloves && (H.gloves.max_heat_protection_temperature > 360)) || H.heat_level_1 == INFINITY)
+			if((H.gloves && (H.gloves.max_heat_protection_temperature > 360)) || H.dna.species.heat_level_1 == INFINITY)
 				extinguish()
 				to_chat(user, span_notice("Вы тушите пламя на [declent_ru(PREPOSITIONAL)]."))
 				balloon_alert(user, "потушено")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -503,7 +503,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	if((resistance_flags & ON_FIRE) && !pickupfireoverride)
 		var/mob/living/carbon/human/H = user
 		if(istype(H))
-			if(H.gloves && (H.gloves.max_heat_protection_temperature > 360))
+			if((H.gloves && (H.gloves.max_heat_protection_temperature > 360)) || H.heat_level_1 == INFINITY)
 				extinguish()
 				to_chat(user, span_notice("Вы тушите пламя на [declent_ru(PREPOSITIONAL)]."))
 				balloon_alert(user, "потушено")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -503,7 +503,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	if((resistance_flags & ON_FIRE) && !pickupfireoverride)
 		var/mob/living/carbon/human/H = user
 		if(istype(H))
-			if((H.gloves && (H.gloves.max_heat_protection_temperature > 360)) || H.dna.species.heat_level_1 == INFINITY)
+			if((H.gloves && (H.gloves.max_heat_protection_temperature > 360)) || (H.dna && H.dna.species.heat_level_1 == INFINITY))
 				extinguish()
 				to_chat(user, span_notice("Вы тушите пламя на [declent_ru(PREPOSITIONAL)]."))
 				balloon_alert(user, "потушено")


### PR DESCRIPTION
## Что этот ПР делает

Карбоны, у которых минимальная температура для получения повреждений  равна INFINITY (големы, скелеты и т.п), могут подбирать горящие предметы как если бы были в огнеупорных перчатках.

## Почему это хорошо для игры

Почему я могу гореть сколь угодно долго без повреждений, но не могут подобрать горящую бумажку?

## Демонстрация изменений

<details><summary>Демонстрации изменений</summary>
<p>
</p>
</details>

## Тестирование

Локалка
