### PR TITLE
bugfix: trial admins vv delete button

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -837,7 +837,7 @@ ADMIN_VERB_ONLY_CONTEXT_MENU(debug_variables, R_ADMIN|R_VIEWRUNTIMES, "View Vari
 		offer_control(M)
 
 	else if(href_list["delete"])
-		if(!check_rights(R_ADMIN|R_DEBUG, FALSE))
+		if(!check_rights(R_ADMIN|R_DEBUG))
 			return
 
 		var/datum/D = locateUID(href_list["delete"])

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -837,7 +837,7 @@ ADMIN_VERB_ONLY_CONTEXT_MENU(debug_variables, R_ADMIN|R_VIEWRUNTIMES, "View Vari
 		offer_control(M)
 
 	else if(href_list["delete"])
-		if(!check_rights(R_DEBUG, FALSE))
+		if(!check_rights(R_ADMIN|R_DEBUG, FALSE))
 			return
 
 		var/datum/D = locateUID(href_list["delete"])


### PR DESCRIPTION
## Что этот ПР делает

Пофикшена проверка прав которая проверяла только наличие дебага(контрибуторы) вместо наличия админки/кодерки, из-за чего триалы не могли удалять через vv(обычное единичное удаление - массовые удаления всё ещё зависят от полноценных прав администратора)
Так же теперь пишется сообщение в случае если нет одного из доступов дебага или админки


## Тестирование

- [x] Проверено на локалке
