### PR TITLE
bugfix: Экзорамы не устанавливаются в аугменты

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -471,6 +471,8 @@
 	if(!organ.is_robotic())
 		user.balloon_alert(user, "орган не кибернетический!")
 		return SURGERY_BEGINSTEP_SKIP
+	if(!organ.can_insert(user, target))
+		return SURGERY_BEGINSTEP_SKIP
 
 	if(target_zone != organ.parent_organ_zone || target.get_organ_slot(organ.slot))
 		user.balloon_alert(user, "нет места под орган!")

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -471,7 +471,9 @@
 	if(!organ.is_robotic())
 		user.balloon_alert(user, "орган не кибернетический!")
 		return SURGERY_BEGINSTEP_SKIP
+
 	if(!organ.can_insert(user, target))
+		user.balloon_alert(user, "нет места под орган!")
 		return SURGERY_BEGINSTEP_SKIP
 
 	if(target_zone != organ.parent_organ_zone || target.get_organ_slot(organ.slot))


### PR DESCRIPTION

## Что этот ПР делает
добавляет проверку на can_insert в роботические части тела, которой почему то не было, фиксит экзорамы в аугментах, вроде ничо не ломает

## Почему это хорошо для игры
был баг

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>



</p>
</details>
