### PR TITLE
различные фиксы МЭКов и не только

### DIFF
--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -50,6 +50,16 @@
 /obj/item/clothing/shoes/magboots/attack_self(mob/user)
 	toggle_magpulse(user)
 
+/obj/item/clothing/shoes/magboots/dropped(mob/living/user, slot, silent)
+	. = ..()
+	if(!ishuman(user) || slot != ITEM_SLOT_FEET)
+		return .
+
+	if(!magpulse)
+		return
+
+	toggle_magpulse(user, silent = TRUE)
+
 /obj/item/clothing/shoes/magboots/proc/toggle_magpulse(mob/user, silent = FALSE)
 	magpulse = !magpulse
 	if(magpulse)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -101,8 +101,7 @@
 	remove_verb(src, /mob/living/silicon/robot/verb/Namepick)
 	module = new /obj/item/robot_module/drone(src)
 
-	var/datum/action/innate/robot_magpulse/pulse = new()
-	pulse.Grant(src)
+	ADD_TRAIT(robot, TRAIT_NEGATES_GRAVITY, ROBOT_TRAIT)
 
 	//Allows Drones to hear the Engineering channel.
 	module.channels = list(ENG_FREQ_NAME = 1)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -101,8 +101,6 @@
 	remove_verb(src, /mob/living/silicon/robot/verb/Namepick)
 	module = new /obj/item/robot_module/drone(src)
 
-	ADD_TRAIT(robot, TRAIT_NEGATES_GRAVITY, ROBOT_TRAIT)
-
 	//Allows Drones to hear the Engineering channel.
 	module.channels = list(ENG_FREQ_NAME = 1)
 	radio.recalculate_channels()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1303,7 +1303,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 
 /mob/living/silicon/robot/verb/toggle_own_cover()
 	set category = VERB_CATEGORY_ROBOTCOMMANDS
-	set name = "Блокировку панели"
+	set name = "Блокировка панели"
 	set desc = "Toggles the lock on your cover."
 
 	if(can_lock_cover)

--- a/code/modules/mob/living/silicon/robot/robot_module_actions.dm
+++ b/code/modules/mob/living/silicon/robot/robot_module_actions.dm
@@ -41,24 +41,6 @@
 	button_icon = 'icons/obj/clothing/glasses.dmi'
 	button_icon_state = "meson"
 
-/datum/action/innate/robot_magpulse
-	name = "Магнитные захваты"
-	button_icon = 'icons/obj/clothing/shoes.dmi'
-	button_icon_state = "magboots0"
-	var/slowdown_active = 2 // Same as magboots
-
-/datum/action/innate/robot_magpulse/Activate()
-	ADD_TRAIT(owner, TRAIT_NEGATES_GRAVITY, ROBOT_TRAIT)
-	to_chat(owner, "Вы включаете магнитные захваты.")
-	owner.add_movespeed_modifier(/datum/movespeed_modifier/robot_magboots_on)
-	button_icon_state = "magboots1"
-	active = TRUE
-
-/datum/action/innate/robot_magpulse/Deactivate()
-	REMOVE_TRAIT(owner, TRAIT_NEGATES_GRAVITY, ROBOT_TRAIT)
-	to_chat(owner, "Вы выключаете магнитные захваты.")
-	owner.remove_movespeed_modifier(/datum/movespeed_modifier/robot_magboots_on)
-	button_icon_state = initial(button_icon_state)
 /datum/action/innate/robot_sight_hydro
 	name = "Гидропоническое зрение"
 	button_icon = 'icons/obj/clothing/glasses.dmi'

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -327,7 +327,7 @@
 	name = "Engineering"
 	module_type = "Engineer"
 	subsystems = list(/mob/living/silicon/proc/subsystem_power_monitor, /mob/living/silicon/proc/subsystem_blueprints)
-	module_actions = list(/datum/action/innate/robot_sight/meson, /datum/action/innate/robot_magpulse)
+	module_actions = list(/datum/action/innate/robot_sight/meson)
 	channels = list(ENG_FREQ_NAME = 1)
 	default_skin = /datum/robot_skin/basic/eng
 	borg_skins = list(
@@ -364,6 +364,8 @@
 /obj/item/robot_module/engineering/on_apply(mob/living/silicon/robot/robot)
 	if(robot.camera && ("Robots" in robot.camera.network))
 		LAZYADD(robot.camera.network, "Engineering")
+
+	ADD_TRAIT(robot, TRAIT_NEGATES_GRAVITY, ROBOT_TRAIT)
 
 	return TRUE
 
@@ -737,7 +739,7 @@
 	name = "Deathsquad"
 	name_disguise = "NT advanced combat"
 	module_type = "Malf"
-	module_actions = list(/datum/action/innate/robot_sight/thermal, /datum/action/innate/robot_magpulse)
+	module_actions = list(/datum/action/innate/robot_sight/thermal)
 	default_skin = /datum/robot_skin/deathsquad
 	borg_skins = list(/datum/robot_skin/deathsquad)
 	has_transform_animation = TRUE
@@ -916,7 +918,7 @@
 /obj/item/robot_module/destroyer
 	name = "Destroyer"
 	module_type = "Malf"
-	module_actions = list(/datum/action/innate/robot_sight/thermal, /datum/action/innate/robot_magpulse)
+	module_actions = list(/datum/action/innate/robot_sight/thermal)
 	channels = list(SEC_FREQ_NAME = 1)
 	default_skin = /datum/robot_skin/droidcombat
 	borg_skins = list(/datum/robot_skin/droidcombat)
@@ -947,7 +949,6 @@
 /obj/item/robot_module/combat
 	name = "Combat"
 	module_type = "Malf"
-	module_actions = list(/datum/action/innate/robot_magpulse)
 	default_skin = /datum/robot_skin/ertgamma
 	borg_skins = list(
 		/datum/robot_skin/ertgamma,

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -217,7 +217,7 @@
 				return
 		if(!carbon_mob.temporarily_remove_item_from_inventory(src, silent = TRUE))
 			return
-		carbon_mob.put_in_active_hand(src)
+		carbon_mob.put_in_any_hand_if_possible(src, TRUE)
 	else if(bag)
 		bag.forceMove(usr)
 		bag.show_to(usr)

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -1030,15 +1030,16 @@ please, keep this up to date
 			INSTRUMENTAL = part.ru_names[INSTRUMENTAL] + " [choosed_name]",
 			PREPOSITIONAL = part.ru_names[PREPOSITIONAL] + " [choosed_name]"
 			)
+
 	mod.theme.default_skin = choosed_skin
 	mod.theme.set_only_visual_skin(mod, choosed_skin)
+	// our little trick
+	mod.theme.default_skin = cached_default_skin
+	cached_default_skin = null
 
 /obj/item/mod/module/active_chameleon/on_deactivation(display_message = TRUE, deleting = FALSE)
 	playsound(loc, 'sound/items/screwdriver2.ogg', 50, TRUE)
 	balloon_alert_to_viewers("костюм преображается!", "маскировка снята")
-
-	mod.theme.default_skin = cached_default_skin
-	cached_default_skin = null
 
 	mod.theme.set_skin(mod, mod.theme.default_skin)
 	var/list/parts = mod.get_parts()

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -214,11 +214,6 @@
 	movetypes = GROUND
 	blacklisted_movetypes = (FLOATING|FLYING)
 
-/datum/movespeed_modifier/robot_magboots_on
-	multiplicative_slowdown = 2
-	movetypes = GROUND
-	blacklisted_movetypes = (FLOATING|FLYING)
-
 /datum/movespeed_modifier/timestop_modifier
 	multiplicative_slowdown = 25
 	flags = IGNORE_NOSLOW


### PR DESCRIPTION

## Что этот ПР делает
Исправлена логика модуля хамелеона для контрактника, теперь каждый уникальный контрактник не ломает следующих заспавненных.
Возвращена старая логика магбутов для боргов, ибо новые сломаны и я не хочу много думать.
Исправлен баг с исчезновением МЭКов в нульспейс при определенных обстоятельствах
Исправлен абуз со снятием магбутсов в космосе с сохранением защиты от поскальзывания
## Почему это хорошо для игры
меньше багов
## Список изменений
:cl:
bugfix: МЭК больше не пропадает при перемещении его в руку
bugfix: Возвращена старая логика магбутов у боргов
bugfix: Магбуты теперь корректно выключаются
bugfix: Исправлен баг с двумя и более контрактниками
/:cl:
