### PR TITLE
Fixes abandoned crate loot spawners

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/abandoned_crates/abandoned_crates_loot.dm
+++ b/code/game/objects/structures/crates_lockers/crates/abandoned_crates/abandoned_crates_loot.dm
@@ -10,7 +10,9 @@
 	var/list/loot
 
 /obj/effect/spawner/abandoned_crate/Initialize(mapload)
-	. = ..()
+	..()
+
+	. = INITIALIZE_HINT_QDEL
 
 	if(!length(loot))
 		return


### PR DESCRIPTION

## Что этот ПР делает

[Ссылка на баг](https://discord.com/channels/617003227182792704/1482177631607722054/1482177631607722054).

## Почему это хорошо для игры

Удаляет спавнер из ящика после его работы, очищая меню от разрабских / админских вещей.

## Список изменений
:cl:
bugfix: Спавнер из заброшенного ящика не показывается в ПКМ.
/:cl:
