### PR TITLE
Исправление звука харм атаки у телескопички

### DIFF
--- a/code/datums/components/transforming.dm
+++ b/code/datums/components/transforming.dm
@@ -48,7 +48,7 @@
 	throwforce_on = 0,
 	throw_speed_on = 2,
 	sharp_on = FALSE,
-	hitsound_on = 'sound/weapons/blade1.ogg',
+	hitsound_on,
 	hitsound_off,
 	w_class_on = WEIGHT_CLASS_BULKY,
 	item_state_on,

--- a/code/game/objects/items/weapons/batons.dm
+++ b/code/game/objects/items/weapons/batons.dm
@@ -335,7 +335,7 @@
 	AddComponent( \
 		/datum/component/transforming, \
 		force_on = src.extend_force, \
-		hitsound_on = src.hitsound, \
+		hitsound_on = on_stun_sound, \
 		hitsound_off = src.hitsound, \
 		w_class_on = WEIGHT_CLASS_NORMAL, \
 		item_state_on = src.extend_item_state, \


### PR DESCRIPTION

## Что этот ПР делает
Удаляет звук даблы при харм атаке телескопичкой.
## Почему это хорошо для игры
Чинит неприятный баг со звуком.
## Список изменений
:cl:
bugfix: Исправлен звук харм атаки телскопичкой.
/:cl:
