### PR TITLE
Исправление бага с иконкой кровотечения после использования rejuvenate

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -863,6 +863,7 @@
 	update_fire()
 	regenerate_icons()
 	restore_blood()
+	clear_alert(ALERT_BLEEDING)
 	if(human_mob)
 		human_mob.update_eyes()
 		human_mob.update_dna()


### PR DESCRIPTION

## Что этот ПР делает
Принудительно очищает алерт кровотечения с худа игрока при использовании прока rejuvenate.
## Почему это хорошо для игры
Давно уже писали про это
## Список изменений
:cl:
bugfix: Удаление алерта кровотечения после rejuvenate
/:cl:
