### PR TITLE
Уменьшение дальности струи у клинера

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -105,6 +105,9 @@
 	name = "space cleaner"
 	desc = "Распылитель, заполненный непенящимся средством для очистки поверхностей. Произведено компанией \"BLAM!\"."
 	list_reagents = list("cleaner" = 250)
+	amount_per_transfer_from_this = 10
+	spray_maxrange = 2
+	spray_currentrange = 2
 
 /obj/item/reagent_containers/spray/cleaner/get_ru_names()
 	return list(


### PR DESCRIPTION

## Что этот ПР делает

https://discord.com/channels/617003227182792704/1482886613582348288

Сделать, чтобы при юзе на 10 юнитов обычный клинер работал на 2 тайла(сейчас 1), при юзе на 5 юнитов на 1(сейчас 3).
## Почему это хорошо для игры
это актуализирует швабру, уборчный бэкпак, блюспейс клинер, мыло и так далее для уборки и уменьшит антаг юзабилити данного итема (станционные предметы доступные всем не должны иметь бОльшую вариативность в использовании чем антажеские редкие или за которые надо платить) (для особых гандончикiв бс распылитель в протолате).
## Список изменений
:cl:
tweak: Дальность струи клинера уменьшена с 3 до 2.
/:cl:
