### PR TITLE
Ребаланс вендомата Робо-Френдс

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -7,7 +7,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_BELT
 	origin_tech = "programming=3;powerstorage=2" // Or it will be cloned in the experimentor
-	custom_price = PAYCHECK_COMMAND
+	custom_price = 50
 	var/request_cooldown = 5 // five seconds
 	var/last_request
 	var/obj/item/radio/headset/radio
@@ -431,6 +431,7 @@
 	name = "PAI upgrade"
 	desc = "A data cartridge for portable AI."
 	icon = 'icons/obj/pda.dmi'
+	custom_price = 250
 	w_class = WEIGHT_CLASS_TINY
 	origin_tech = "programming=2;data=2"
 
@@ -445,6 +446,7 @@
 
 /obj/item/pai_cartridge/doorjack
 	name = "PAI doorjack upgrade cartridge"
+	custom_price = 100
 	icon_state = "pai-doorjack"
 	var/factor = -0.5
 

--- a/code/modules/vending/pai.dm
+++ b/code/modules/vending/pai.dm
@@ -19,7 +19,6 @@
 	default_price = PAYCHECK_CREW*2
 	default_premium_price = PAYCHECK_COMMAND*2
 
-	// ВАЖНО: следующие переменные должны быть с отступом (табуляцией) внутри типа!
 	product_categories = list(
 		list(
 			"name" = "Улучшения для ПИИ",
@@ -63,13 +62,11 @@
 			)
 		)
 	)
-
 	premium = list(
 		/obj/item/organ/internal/cyberimp/eyes/hud/medical = 1,
 		/obj/item/organ/internal/cyberimp/eyes/shield = 1,
 		/obj/item/organ/internal/cyberimp/arm/toolset = 1
 	)
-
 	contraband = list(
 		/obj/item/pai_cartridge/syndi_emote = 1,
 		/obj/item/pai_cartridge/snake = 1,

--- a/code/modules/vending/pai.dm
+++ b/code/modules/vending/pai.dm
@@ -1,6 +1,6 @@
 /obj/machinery/vending/pai
 	name = "RoboFriends"
-	desc = "Потрясающий продавец ПИИ-друзей!"
+	desc = "Потрясающий продавец ПИИ-друзей и всяких робо штучек!"
 	icon_state = "paivend_off"
 	panel_overlay = "paivend_panel"
 	screen_overlay = "paivend"
@@ -16,18 +16,60 @@
 	)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/pai
-	default_price = PAYCHECK_LOWER
-	default_premium_price = PAYCHECK_COMMAND
+	default_price = PAYCHECK_CREW*2
+	default_premium_price = PAYCHECK_COMMAND*2
 
-	products = list(
-		/obj/item/paicard = 10,
-		/obj/item/pai_cartridge/female = 10,
-		/obj/item/pai_cartridge/doorjack = 5,
-		/obj/item/pai_cartridge/memory = 5,
-		/obj/item/pai_cartridge/reset = 5,
-		/obj/item/robot_parts/l_arm = 1,
-		/obj/item/robot_parts/r_arm = 1,
+	// ВАЖНО: следующие переменные должны быть с отступом (табуляцией) внутри типа!
+	product_categories = list(
+		list(
+			"name" = "Улучшения для ПИИ",
+			"icon" = "code",
+			"products" = list(
+				/obj/item/paicard = 10,
+				/obj/item/pai_cartridge/female = 10,
+				/obj/item/pai_cartridge/doorjack = 5,
+				/obj/item/pai_cartridge/memory = 5,
+				/obj/item/pai_cartridge/reset = 5
+			)
+		),
+		list(
+			"name" = "Импланты",
+			"icon" = "eye",
+			"products" = list(
+				/obj/item/organ/internal/cyberimp/mouth/breathing_tube = 3,
+				/obj/item/organ/internal/cyberimp/eyes/meson = 3,
+				/obj/item/organ/internal/cyberimp/eyes/hud/diagnostic = 3,
+				/obj/item/organ/internal/cyberimp/eyes/hud/science = 3,
+				/obj/item/organ/internal/cyberimp/chest/nutriment = 3,
+				/obj/item/organ/internal/cyberimp/brain/clown_voice = 3,
+				/obj/item/organ/internal/cyberimp/arm/botanical = 2,
+				/obj/item/organ/internal/cyberimp/arm/janitorial = 2
+			)
+		),
+		list(
+			"name" = "Кибернетические органы",
+			"icon" = "wheelchair",
+			"products" = list(
+				/obj/item/robot_parts/l_arm = 3,
+				/obj/item/robot_parts/r_arm = 3,
+				/obj/item/robot_parts/r_leg = 3,
+				/obj/item/robot_parts/l_leg = 3,
+				/obj/item/organ/internal/lungs/cybernetic = 3,
+				/obj/item/organ/internal/liver/cybernetic = 3,
+				/obj/item/organ/internal/kidneys/cybernetic = 3,
+				/obj/item/organ/internal/heart/cybernetic = 3,
+				/obj/item/organ/internal/eyes/cybernetic = 3,
+				/obj/item/organ/internal/ears/cybernetic = 3
+			)
+		)
 	)
+
+	premium = list(
+		/obj/item/organ/internal/cyberimp/eyes/hud/medical = 1,
+		/obj/item/organ/internal/cyberimp/eyes/shield = 1,
+		/obj/item/organ/internal/cyberimp/arm/toolset = 1
+	)
+
 	contraband = list(
 		/obj/item/pai_cartridge/syndi_emote = 1,
 		/obj/item/pai_cartridge/snake = 1,

--- a/code/modules/vending/pai.dm
+++ b/code/modules/vending/pai.dm
@@ -42,7 +42,7 @@
 				/obj/item/organ/internal/cyberimp/chest/nutriment = 3,
 				/obj/item/organ/internal/cyberimp/brain/clown_voice = 3,
 				/obj/item/organ/internal/cyberimp/arm/botanical = 2,
-				/obj/item/organ/internal/cyberimp/arm/janitorial = 2
+				/obj/item/organ/internal/cyberimp/arm/janitorial = 2,
 			)
 		),
 		list(
@@ -58,14 +58,14 @@
 				/obj/item/organ/internal/kidneys/cybernetic = 3,
 				/obj/item/organ/internal/heart/cybernetic = 3,
 				/obj/item/organ/internal/eyes/cybernetic = 3,
-				/obj/item/organ/internal/ears/cybernetic = 3
+				/obj/item/organ/internal/ears/cybernetic = 3,
 			)
 		)
 	)
 	premium = list(
 		/obj/item/organ/internal/cyberimp/eyes/hud/medical = 1,
 		/obj/item/organ/internal/cyberimp/eyes/shield = 1,
-		/obj/item/organ/internal/cyberimp/arm/toolset = 1
+		/obj/item/organ/internal/cyberimp/arm/toolset = 1,
 	)
 	contraband = list(
 		/obj/item/pai_cartridge/syndi_emote = 1,

--- a/code/modules/vending/pai.dm
+++ b/code/modules/vending/pai.dm
@@ -16,7 +16,7 @@
 	)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/pai
-	default_price = PAYCHECK_CREW*2
+	default_price = PAYCHECK_CREW * 2
 	default_premium_price = PAYCHECK_COMMAND*2
 
 	product_categories = list(

--- a/code/modules/vending/pai.dm
+++ b/code/modules/vending/pai.dm
@@ -17,7 +17,7 @@
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/pai
 	default_price = PAYCHECK_CREW * 2
-	default_premium_price = PAYCHECK_COMMAND*2
+	default_premium_price = PAYCHECK_COMMAND * 2
 
 	product_categories = list(
 		list(


### PR DESCRIPTION

## Что этот ПР делает

Вендомат робо френдс стал разделен на 5 категорий
Улучшение пии - Название говорит за себя изменений нет
Импланты - Добавлены все гражданские импланты НЕ улучшенные + тулсет ботаника и уборщика.
Кибер органы - робо руки и ноги, а так же все не улучшенные кибер органы.
Премиум - велд щит, обычный тул сет, мед худ. Все предметы в этой категории в количестве 1 шутуки (800 кредитов за каждый)


## Почему это хорошо для игры

Большее влияние денег на игру и возможность куда то их слить. Позволяет не ждать долго РНД ради слабых и средних имплантов ценой переплаты кредитами. Предметов в веномате мало, улучшенные импланты все еще в НИО, у врачей будет больше работы. Одни плюсы.

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
balance: Произошёл ребаланс.
/:cl:
