### PR TITLE
Баланс осколоков у снарядов миномета и осколочных гранат

### DIFF
--- a/code/game/objects/items/weapons/grenades/frag.dm
+++ b/code/game/objects/items/weapons/grenades/frag.dm
@@ -5,7 +5,7 @@
 	icon_state = "frag"
 	origin_tech = "materials=3;magnets=4"
 	det_time = 3 SECONDS
-	shrapnel_type = /obj/projectile/shrapnel
+	shrapnel_type = /obj/projectile/shrapnel/grenade
 	shrapnel_radius = 4
 	var/range = 5
 

--- a/code/game/objects/items/weapons/mortar_shells.dm
+++ b/code/game/objects/items/weapons/mortar_shells.dm
@@ -71,10 +71,9 @@
 	item_state = "mortar_ammo_frag"
 
 /obj/item/mortar_shell/frag/detonate(turf/detonate_turf, explosion_detonate = FALSE)
-	AddComponent(/datum/component/pellet_cloud, magnitude = 4)
+	AddComponent(/datum/component/pellet_cloud, projectile_type = /obj/projectile/shrapnel/m80mm, magnitude = 4)
 	. = ..()
-	sleep(2)
-	explosion(detonate_turf, devastation_range = 0, heavy_impact_range = 0, light_impact_range = 5)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), 0, 0, 5), 0.2 SECONDS)
 
 /obj/item/mortar_shell/incendiary
 	name = "80mm incendiary mortar shell"
@@ -114,11 +113,12 @@
 	item_state = "mortar_ammo_custom_locked"
 
 	materials = list(METAL = 18750) //5 sheets
+	locked = FALSE
+
 	var/obj/item/warhead/mortar/warhead
 	var/obj/item/reagent_containers/glass/beaker/fuel
 	var/fuel_requirement = 60
 	var/fuel_type = "hydrogen"
-	locked = FALSE
 
 /obj/item/mortar_shell/custom/examine(mob/user)
 	. = ..()

--- a/code/modules/projectiles/projectile/shrapnel.dm
+++ b/code/modules/projectiles/projectile/shrapnel.dm
@@ -2,11 +2,13 @@
 	name = "shrapnel"
 	icon = 'icons/obj/shards.dmi'
 	icon_state = null
-	throw_speed =  EMBED_THROWSPEED_THRESHOLD
+	throw_speed = EMBED_THROWSPEED_THRESHOLD
 	sharp = TRUE
 	range = 20
 	armour_penetration = 30
 	dismemberment = 5
+	tile_dropoff = 0.5
+	ricochets_max = 2
 	ricochet_chance = 70
 	var/embedded_type = /obj/item/embedded/shrapnel
 
@@ -36,13 +38,22 @@
 	target.hitby(shrapnel, skipcatch = TRUE)
 	qdel(src)
 
+/obj/projectile/shrapnel/grenade
+	range = 6
+
+/obj/projectile/shrapnel/m80mm
+	range = 8
+
+/obj/projectile/shrapnel/short_range
+	range = 5
+
 /obj/item/embedded/shrapnel
 	name = "shrapnel"
 	icon = 'icons/obj/shards.dmi'
 	throwforce = 10
-	throw_speed =  EMBED_THROWSPEED_THRESHOLD
-	embed_chance = 100
-	embedded_fall_chance = 0
+	throw_speed = EMBED_THROWSPEED_THRESHOLD
+	embed_chance = 70
+	embedded_fall_chance = 1
 	w_class = WEIGHT_CLASS_SMALL
 	sharp = TRUE
 	hitsound = 'sound/weapons/pierce.ogg'

--- a/code/modules/projectiles/projectile/shrapnel.dm
+++ b/code/modules/projectiles/projectile/shrapnel.dm
@@ -8,7 +8,6 @@
 	armour_penetration = 30
 	dismemberment = 5
 	tile_dropoff = 0.5
-	ricochets_max = 2
 	ricochet_chance = 70
 	var/embedded_type = /obj/item/embedded/shrapnel
 


### PR DESCRIPTION

## Список изменений
:cl:
balance: Уменьшен радиус поражения у осколков
balance: Добавлено падение урона осколков с расстоянием
balance: Уменьшен шанс застревания осколков
/:cl:
