### PR TITLE
fixes implant tracking

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_tracking.dm
+++ b/code/game/objects/items/weapons/implants/implant_tracking.dm
@@ -24,6 +24,7 @@
 	. = ..()
 	if(. && ispath(internal_gps, /obj/item/gps))
 		internal_gps = new internal_gps(src)
+		internal_gps.gpstag = gps_tag
 
 /obj/item/implant/tracking/removed(mob/target)
 	. = ..()


### PR DESCRIPTION

## Что этот ПР делает

Добавляет строчку в коде, что берёт у импланта трекинг переменную и даёт её GPS внутри импланта.

## Почему это хорошо для игры

Теперь механ работает как нужно. Легче отличать заключённых от шахтёров.

## Список изменений
:cl:
bugfix: Название GPS сигнала у трекинг импланта теперь можно изменить
/:cl:
