### PR TITLE
Таурус больше не может стрелять в воздух

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -163,6 +163,7 @@
 		ATTACHMENT_SLOT_RAIL = list("x" = 6, "y" = 6),
 		ATTACHMENT_SLOT_UNDER = list("x" = 8, "y" = -6),
 	)
+	can_air_shoot = FALSE
 
 /obj/item/gun/projectile/revolver/taurus/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION

## Что этот ПР делает
Вовальвер Таурус больше не может стрелять в воздух
## Почему это хорошо для игры
Механика добавлена для уникального оружия в единичных экземплярах, а не для масс фабрикейтед гана с которым может бегать все СБ
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
tweak: Таурус больше не может стрелять в воздух
/:cl:
