### PR TITLE
Возврат дизейблов под гитигрнор

### DIFF
--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -520,4 +520,16 @@ CACHE_ASSETS 0
 ## This config option limits the maximum chunk count for which the server will accept a payload, default is 32
 TGUI_MAX_CHUNK_COUNT 128
 
+## Disable the loading of "Taipan"
+#DISABLE_TAIPAN
+
+## Disable the loading of Lavaland
+#DISABLE_LAVALAND
+
+## Disable the loading of away missions
+#DISABLE_AWAY_MISSIONS
+
+## Disable the loading of space ruins
+#DISABLE_SPACE_RUINS
+
 ### INITIALIZATION SETTINGS END ###

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -32,15 +32,3 @@ EXTRA_SPACE_RUIN_LEVELS_MAX 8
 # spawn, while the converse is true. Alter this number to affect the amount
 # of ruins.
 LAVALAND_BUDGET 100
-
-## Disable the loading of "Taipan"
-#DISABLE_TAIPAN
-
-## Disable the loading of Lavaland
-#DISABLE_LAVALAND
-
-## Disable the loading of away missions
-#DISABLE_AWAY_MISSIONS
-
-## Disable the loading of space ruins
-#DISABLE_SPACE_RUINS


### PR DESCRIPTION

## Список изменений
:cl:
config: Теперь конфиги для отключения Тайпана, Лаваленда, Косморуин и Гейта снова под гитигнором.
/:cl:
