### PR TITLE
Очистка карт от tag и pixel_x/y = 0 [MDB IGNORE]

### DIFF
--- a/_maps/map_files/Delta/Lavaland.dmm
+++ b/_maps/map_files/Delta/Lavaland.dmm
@@ -1064,8 +1064,7 @@
 	network = list("Labor    Camp")
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/mine/laborcamp)
 "dq" = (
@@ -1323,8 +1322,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/mine/living_quarters)
 "eo" = (
@@ -1341,8 +1339,7 @@
 "ep" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (NORTHEAST)"
+	icon_state = "whitegreen"
 	},
 /area/mine/living_quarters)
 "eq" = (
@@ -1630,8 +1627,7 @@
 /obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/mine/living_quarters)
 "fw" = (
@@ -1860,8 +1856,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHWEST)"
+	icon_state = "whitegreen"
 	},
 /area/mine/living_quarters)
 "gt" = (
@@ -1870,8 +1865,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/mine/living_quarters)
 "gu" = (
@@ -1886,8 +1880,7 @@
 "gw" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (SOUTHEAST)"
+	icon_state = "whitegreen"
 	},
 /area/mine/living_quarters)
 "gx" = (
@@ -2730,8 +2723,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (WEST)"
+	icon_state = "whitegreen"
 	},
 /area/mine/living_quarters)
 "kW" = (
@@ -3529,8 +3521,7 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitegreenfull"
 	},
 /area/mine/living_quarters)
 "oN" = (
@@ -4335,8 +4326,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/mime,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/mine/laborcamp)
 "ug" = (
@@ -5648,8 +5638,7 @@
 /area/mine/living_quarters)
 "CY" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -5714,8 +5703,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/mine/laborcamp)
 "Dg" = (
@@ -6002,8 +5990,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bedsheet/patriot,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/mine/laborcamp)
 "Fq" = (
@@ -7072,8 +7059,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	icon_state = "whitegreen"
 	},
 /area/mine/living_quarters)
 "Ma" = (
@@ -7286,8 +7272,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/mine/laborcamp)
 "NE" = (
@@ -8498,8 +8483,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/mine/laborcamp)
 "VO" = (

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -547,8 +547,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "aeG" = (
@@ -1347,8 +1346,7 @@
 /area/engineering/mechanic_workshop/expedition)
 "amQ" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
@@ -2622,8 +2620,7 @@
 /area/engineering/controlroom)
 "awU" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	tag = "icon-propulsion (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/arrival/station)
@@ -2918,8 +2915,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "azf" = (
@@ -3009,8 +3005,7 @@
 "aAa" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/shuttle/plating,
@@ -9530,8 +9525,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "bsB" = (
@@ -13694,8 +13688,7 @@
 /area/medical/research)
 "bNJ" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
@@ -18861,8 +18854,7 @@
 /area/clownoffice)
 "cpP" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/tourist)
 "cpQ" = (
@@ -21743,8 +21735,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "cEn" = (
@@ -23413,8 +23404,7 @@
 	},
 /obj/effect/turf_decal/siding/white/end,
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/noslip,
 /area/engineering/controlroom)
@@ -25775,8 +25765,7 @@
 "cXD" = (
 /obj/machinery/door/window/southleft{
 	name = "Bar Delivery";
-	req_access = list(25);
-	tag = "icon-left (WEST)"
+	req_access = list(25)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -26507,8 +26496,7 @@
 "dbm" = (
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dust,
@@ -27761,8 +27749,7 @@
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "dgY" = (
@@ -28064,8 +28051,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "die" = (
@@ -31954,8 +31940,7 @@
 /obj/effect/landmark/start/captain,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 6;
-	tag = "icon-shower (EAST)"
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -34571,8 +34556,7 @@
 	},
 /obj/machinery/kitchen_machine/grill,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/starboard)
 "dNm" = (
@@ -34637,8 +34621,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "dNv" = (
@@ -37529,8 +37512,7 @@
 /area/crew_quarters/kitchen)
 "ebt" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plasteel{
@@ -37860,8 +37842,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "eeD" = (
@@ -38059,8 +38040,7 @@
 "egO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/tourist)
 "egR" = (
@@ -39080,8 +39060,7 @@
 /obj/structure/table/glass,
 /obj/item/twohanded/required/kirbyplants{
 	layer = 5.1;
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreencorner"
@@ -39909,8 +39888,7 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "eBF" = (
@@ -41451,8 +41429,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "eTE" = (
@@ -42086,8 +42063,7 @@
 	pixel_y = -12
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/crew_quarters/theatre)
 "fat" = (
@@ -43224,8 +43200,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/engineering)
 "foZ" = (
@@ -43403,8 +43378,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "frJ" = (
@@ -43935,8 +43909,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/starboard)
 "fye" = (
@@ -45613,8 +45586,7 @@
 	},
 /obj/machinery/light,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
@@ -46118,8 +46090,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/confetti,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/crew_quarters/theatre)
 "fZj" = (
@@ -46570,8 +46541,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "gfO" = (
@@ -46997,8 +46967,7 @@
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "gmi" = (
@@ -47470,8 +47439,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "gre" = (
@@ -47712,8 +47680,7 @@
 "gue" = (
 /obj/effect/landmark/spawner/ninja_teleport,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
@@ -49845,15 +49812,13 @@
 /area/maintenance/tourist)
 "gPC" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/tourist)
 "gPJ" = (
@@ -50300,8 +50265,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/eastright{
 	name = "Hydroponics Delivery";
-	req_access = list(35);
-	tag = "icon-right"
+	req_access = list(35)
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -50440,8 +50404,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "gWu" = (
@@ -50760,8 +50723,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "gZC" = (
@@ -50790,7 +50752,6 @@
 /area/library)
 "gZP" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/white/end,
@@ -53201,8 +53162,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "hDv" = (
@@ -53834,8 +53794,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "hKL" = (
@@ -54700,8 +54659,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "hVw" = (
@@ -54831,8 +54789,7 @@
 /area/medical/virology)
 "hWA" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/tourist)
 "hWB" = (
@@ -57201,8 +57158,7 @@
 "izG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/crew_quarters/theatre)
 "izL" = (
@@ -57500,8 +57456,7 @@
 	pixel_x = -28
 	},
 /obj/machinery/shower{
-	dir = 4;
-	tag = "icon-shower (EAST)"
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/white/end{
 	dir = 1
@@ -58416,8 +58371,7 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "iOo" = (
@@ -58703,8 +58657,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "iSO" = (
@@ -59453,8 +59406,7 @@
 /obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
@@ -59580,8 +59532,7 @@
 /mob/living/simple_animal/hostile/lizard/croco/Gena,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -60516,8 +60467,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "jnj" = (
@@ -66878,8 +66828,7 @@
 "kNU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/tourist)
 "kOi" = (
@@ -69702,8 +69651,7 @@
 /area/toxins/test_area)
 "lym" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/structure/sign/poster/contraband/communist_state{
 	pixel_x = 33
@@ -69906,8 +69854,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "lAL" = (
@@ -70484,8 +70431,7 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
@@ -70933,8 +70879,7 @@
 	id = "vir_work_zone1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "lPb" = (
@@ -72522,8 +72467,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "miw" = (
@@ -72965,8 +72909,7 @@
 /area/maintenance/asmaint)
 "mna" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /obj/effect/landmark/spawner/ninja_teleport,
 /turf/simulated/floor/plasteel{
@@ -73518,8 +73461,7 @@
 /area/maintenance/kitchen)
 "msz" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-25";
-	tag = "icon-plant-25"
+	icon_state = "plant-25"
 	},
 /turf/simulated/floor/carpet/red,
 /area/crew_quarters/bar/atrium)
@@ -74497,8 +74439,7 @@
 /area/hallway/secondary/entry/commercial)
 "mDr" = (
 /obj/item/twohanded/required/kirbyplants{
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /obj/structure/table,
 /obj/machinery/status_display{
@@ -74864,8 +74805,7 @@
 	dir = 1
 	},
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/noslip,
 /area/engineering/controlroom)
@@ -76183,8 +76123,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "mVw" = (
@@ -76449,8 +76388,7 @@
 "mYF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -77303,8 +77241,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "njf" = (
@@ -78475,8 +78412,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "nvQ" = (
@@ -79784,8 +79720,7 @@
 /obj/effect/spawner/random_spawners/grille_50,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "nLF" = (
@@ -81912,8 +81847,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "olS" = (
@@ -83400,8 +83334,7 @@
 /obj/effect/spawner/random_spawners/blood_5,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "oCo" = (
@@ -84587,8 +84520,7 @@
 "oRQ" = (
 /mob/living/simple_animal/moth,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/tourist)
 "oRS" = (
@@ -84816,8 +84748,7 @@
 /obj/item/chair,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "oUP" = (
@@ -86090,8 +86021,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "pkp" = (
@@ -86343,8 +86273,7 @@
 	pixel_y = 5
 	},
 /obj/item/twohanded/required/kirbyplants{
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -90074,8 +90003,7 @@
 /area/atmos/control)
 "qcw" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/curtain/open/shower,
 /obj/machinery/door_control{
@@ -91384,8 +91312,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "qqO" = (
@@ -91637,8 +91564,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "qsM" = (
@@ -91775,8 +91701,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "qtz" = (
@@ -94172,8 +94097,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "qVc" = (
@@ -94975,8 +94899,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "reH" = (
@@ -95036,8 +94959,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "rfj" = (
@@ -95054,8 +94976,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "rfm" = (
@@ -97818,8 +97739,7 @@
 /area/maintenance/kitchen)
 "rLr" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -98135,8 +98055,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "rPc" = (
@@ -99824,8 +99743,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "sja" = (
@@ -102455,8 +102373,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "sNQ" = (
@@ -105395,8 +105312,7 @@
 /obj/item/soap,
 /obj/machinery/light,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/tourist)
 "txq" = (
@@ -106314,8 +106230,7 @@
 /area/engineering/supermatter)
 "tGG" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -107058,8 +106973,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "tOc" = (
@@ -108471,8 +108385,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/trading)
 "udT" = (
@@ -109194,8 +109107,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
@@ -111537,8 +111449,7 @@
 /obj/effect/decal/warning_stripes/blue,
 /obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
@@ -112850,8 +112761,7 @@
 /obj/structure/curtain/open/shower,
 /obj/effect/landmark/spawner/blob,
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -113807,8 +113717,7 @@
 /obj/item/vending_refill/youtool,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "vmX" = (
@@ -113936,8 +113845,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "voL" = (
@@ -114670,16 +114578,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"vwX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
-	},
-/area/maintenance/engineering)
 "vwY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -115440,8 +115338,7 @@
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "vDi" = (
@@ -117095,8 +116992,7 @@
 /area/quartermaster/sorting)
 "vXZ" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -117309,8 +117205,7 @@
 /obj/effect/spawner/random_spawners/grille_13,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "waS" = (
@@ -117986,8 +117881,7 @@
 /obj/random/tool,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "wjU" = (
@@ -119086,8 +118980,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "wuY" = (
@@ -120706,8 +120599,7 @@
 /area/crew_quarters/kitchen)
 "wNZ" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-25";
-	tag = "icon-plant-25"
+	icon_state = "plant-25"
 	},
 /obj/effect/spawner/new_year/garland/east,
 /turf/simulated/floor/carpet/red,
@@ -125385,8 +125277,7 @@
 "xNb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -156690,7 +156581,7 @@ gMw
 iKD
 srk
 euu
-vwX
+euu
 wkZ
 eTz
 yhX

--- a/_maps/map_files/Delta/submaps/botany_room.dmm
+++ b/_maps/map_files/Delta/submaps/botany_room.dmm
@@ -26,8 +26,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "bp" = (
@@ -259,8 +258,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "kb" = (
@@ -300,8 +298,7 @@
 "nc" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/maintenance/garden)
 "nf" = (
@@ -439,8 +436,7 @@
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "uj" = (
@@ -473,8 +469,7 @@
 	},
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "vu" = (
@@ -519,8 +514,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "xb" = (
@@ -593,8 +587,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "An" = (
@@ -604,8 +597,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "AH" = (
@@ -651,8 +643,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "Df" = (
@@ -701,8 +692,7 @@
 	},
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/garden)
 "GT" = (
@@ -710,8 +700,7 @@
 /obj/effect/spawner/random_spawners/cobweb_left_rare,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "Hd" = (
@@ -779,8 +768,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "Jg" = (
@@ -818,8 +806,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light/small,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/garden)
 "Lo" = (
@@ -874,8 +861,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/crowbar,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "MB" = (
@@ -939,8 +925,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/eastright,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "SJ" = (
@@ -963,8 +948,7 @@
 /area/template_noop)
 "Tk" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/garden)
@@ -1003,8 +987,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/garden)
 "Vl" = (

--- a/_maps/map_files/Delta/submaps/dorm_maints_near_toilet.dmm
+++ b/_maps/map_files/Delta/submaps/dorm_maints_near_toilet.dmm
@@ -483,8 +483,7 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/template_noop)
 "yu" = (
@@ -514,8 +513,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/template_noop)
 "yT" = (
@@ -720,8 +718,7 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/template_noop)
 "DP" = (
@@ -808,8 +805,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/coatrack,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/template_noop)
 "Gj" = (
@@ -851,8 +847,7 @@
 /area/template_noop)
 "HD" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/template_noop)
 "Ih" = (

--- a/_maps/map_files/Delta/submaps/old_sm_room.dmm
+++ b/_maps/map_files/Delta/submaps/old_sm_room.dmm
@@ -87,8 +87,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dust,
 /obj/effect/landmark/spawner/ninja_teleport,
@@ -979,8 +978,7 @@
 /area/template_noop)
 "uv" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1444,8 +1442,7 @@
 	},
 /obj/item/ammo_casing/shotgun,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/template_noop)
 "Jh" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_green.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_green.dmm
@@ -245,8 +245,7 @@
 /area/ruin/powered/green_bio)
 "rp" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /turf/simulated/floor/wood,
 /area/ruin/powered/green_bio)
@@ -306,8 +305,7 @@
 /area/ruin/powered/green_bio)
 "vh" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-17";
-	tag = "icon-plant-17"
+	icon_state = "plant-17"
 	},
 /turf/simulated/floor/wood,
 /area/ruin/powered/green_bio)
@@ -541,8 +539,7 @@
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/wood,
 /area/ruin/powered/green_bio)
@@ -613,8 +610,7 @@
 	dir = 8
 	},
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/item/soap/syndie,
 /turf/simulated/floor/plasteel{
@@ -629,8 +625,7 @@
 /area/ruin/powered/green_bio)
 "Oy" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-6";
-	tag = "icon-plant-6"
+	icon_state = "plant-6"
 	},
 /turf/simulated/floor/wood,
 /area/ruin/powered/green_bio)
@@ -683,8 +678,7 @@
 /area/ruin/powered/green_bio)
 "Wg" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-32";
-	tag = "icon-plant-32"
+	icon_state = "plant-32"
 	},
 /turf/simulated/floor/wood,
 /area/ruin/powered/green_bio)

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_winter.dmm
@@ -125,8 +125,7 @@
 /area/ruin/powered/snow_biodome)
 "aA" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/ruin/powered/snow_cabin)
 "aB" = (
@@ -462,8 +461,7 @@
 /area/ruin/powered/snow_cabin)
 "Jl" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/powered/snow_cabin)
 "JZ" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
@@ -16,8 +16,7 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "f" = (
@@ -34,8 +33,7 @@
 "i" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "k" = (
@@ -84,8 +82,7 @@
 	broken = 1
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "u" = (
@@ -116,15 +113,13 @@
 /area/ruin/unpowered/misc_lavaruin)
 "B" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "C" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "F" = (
@@ -195,8 +190,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/book/manual/chef_recipes,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "W" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -10,8 +10,7 @@
 "aJ" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
@@ -419,8 +418,7 @@
 "xd" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
@@ -481,8 +479,7 @@
 /area/shuttle/freegolem)
 "zc" = (
 /obj/structure/sign/mining/survival{
-	dir = 1;
-	tag = "icon-survival (NORTH)"
+	dir = 1
 	},
 /turf/simulated/wall/mineral/titanium/survival/pod,
 /area/shuttle/freegolem)
@@ -640,8 +637,7 @@
 "Ku" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pirateship.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pirateship.dmm
@@ -244,8 +244,7 @@
 "gO" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/machinery/power/terminal{
 	dir = 1
@@ -1055,8 +1054,7 @@
 /area/lavaland/surface/outdoors)
 "yd" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/structure/window/reinforced{
@@ -1316,8 +1314,7 @@
 /area/ruin/powered/pirateship)
 "CX" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/machinery/power/terminal{
 	dir = 1
@@ -1847,8 +1844,7 @@
 "Oe" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/machinery/power/terminal{
 	dir = 1
@@ -2229,8 +2225,7 @@
 /area/lavaland/surface/outdoors)
 "Uj" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/machinery/power/terminal{
 	dir = 1
@@ -2342,8 +2337,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /turf/simulated/floor/pod/dark/lavaland_air,
 /area/ruin/powered/pirateship)

--- a/_maps/map_files/RandomRuins/SpaceRuins/USSP_gorky17.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/USSP_gorky17.dmm
@@ -1275,8 +1275,7 @@
 /area/ruin/space/USSP_gorky17/utility)
 "fb" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/ruin/space/USSP_gorky17/dinning)
 "fe" = (
@@ -7635,8 +7634,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/ruin/space/USSP_gorky17/dinning)
 "Ck" = (
@@ -8703,8 +8701,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/ruin/space/USSP_gorky17/dinning)
 "FP" = (
@@ -11079,8 +11076,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/ruin/space/USSP_gorky17/dinning)
 "Om" = (
@@ -12611,8 +12607,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/ruin/space/USSP_gorky17/dinning)
 "TT" = (
@@ -12647,8 +12642,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/ruin/space/USSP_gorky17/dinning)
 "TX" = (
@@ -13149,8 +13143,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/ruin/space/USSP_gorky17/dinning)
 "VT" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/USSP_gorky17_collapsed.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/USSP_gorky17_collapsed.dmm
@@ -47,8 +47,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/flasher_button{
 	id = "g17flash1";
@@ -105,8 +104,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -165,8 +163,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/common)
 "aC" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced,
@@ -284,8 +281,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -326,8 +322,7 @@
 "bl" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "bm" = (
@@ -350,8 +345,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "br" = (
@@ -384,8 +378,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/dorms)
 "bv" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/computer/security/old_frame{
 	name = "Gorky17 security camera console";
@@ -395,25 +388,13 @@
 	icon_state = "darkbluefull"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
-"bx" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
-	},
-/turf/space,
-/area/ruin/space/USSP_gorky17/collapsed/solars)
 "bA" = (
 /turf/simulated/wall/r_wall,
 /area/ruin/space/USSP_gorky17/collapsed/check1)
 "bC" = (
 /obj/structure/table,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/computer/old_frame/macintosh{
 	layer = 3.15;
@@ -493,8 +474,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -517,8 +497,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -612,8 +591,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "bW" = (
@@ -691,8 +669,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/solmaintsouth)
 "cj" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -786,8 +763,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -795,8 +771,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "cB" = (
@@ -833,8 +808,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -865,8 +839,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Gorky17 secure";
@@ -959,8 +932,7 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1017,8 +989,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/angar)
 "do" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -1081,8 +1052,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "dH" = (
@@ -1162,8 +1132,7 @@
 	start_charge = 0
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -1194,8 +1163,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/wood/airless,
@@ -1271,8 +1239,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -1358,8 +1325,7 @@
 	},
 /obj/structure/table/tray,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1454,8 +1420,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "eD" = (
@@ -1463,8 +1428,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor{
 	id_tag = "g17extlock";
@@ -1581,8 +1545,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/gate)
 "eX" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/computer/crew/old_frame,
 /turf/simulated/floor/plasteel{
@@ -1663,8 +1626,7 @@
 "fi" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
@@ -1685,8 +1647,7 @@
 "fk" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1918,8 +1879,7 @@
 /area/template_noop)
 "fV" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/space,
 /area/ruin/space/USSP_gorky17/collapsed/solars)
@@ -1973,8 +1933,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Gorky17 operating";
@@ -2051,8 +2010,7 @@
 "gp" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -2103,8 +2061,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "gx" = (
@@ -2211,8 +2168,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/engineering)
 "gN" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/vault,
@@ -2234,8 +2190,7 @@
 	},
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/clothing/suit/space/nasavoid/old{
 	name = "Cosmonaut suit"
@@ -2260,8 +2215,7 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -2338,8 +2292,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/gun/projectile/automatic/aksu/rusted,
 /turf/simulated/floor/plating,
@@ -2349,8 +2302,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2404,8 +2356,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2521,8 +2472,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
@@ -2634,8 +2584,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "hV" = (
@@ -2699,8 +2648,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/gate)
 "if" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -2809,8 +2757,7 @@
 	req_access = list(124,125,126)
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2876,8 +2823,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -2960,8 +2906,7 @@
 "jd" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -2998,8 +2943,7 @@
 	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/USSP_gorky17/collapsed/medbay)
@@ -3098,8 +3042,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Gorky17 engineering hatch";
@@ -3224,15 +3167,13 @@
 /area/ruin/space/USSP_gorky17/collapsed/dorms)
 "jU" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/pen/multi,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "jX" = (
@@ -3320,8 +3261,7 @@
 "kh" = (
 /obj/structure/chair/office/dark,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -3539,8 +3479,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -3763,8 +3702,7 @@
 "lB" = (
 /obj/structure/table,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/stack/sheet/glass{
 	amount = 20
@@ -3779,8 +3717,7 @@
 "lC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
@@ -3849,8 +3786,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -3900,8 +3836,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/security/glass{
 	locked = 1;
@@ -3947,8 +3882,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/dorms)
 "ma" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -4253,8 +4187,7 @@
 /obj/item/gun/projectile/revolver/nagant,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "mY" = (
@@ -4269,8 +4202,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/space,
 /area/ruin/space/USSP_gorky17/collapsed/solars)
@@ -4297,8 +4229,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "ng" = (
@@ -4306,8 +4237,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/security{
 	locked = 1;
@@ -4467,8 +4397,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -4523,8 +4452,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/gate)
 "nP" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
@@ -4674,8 +4602,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -4806,8 +4733,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/arrival)
@@ -4875,12 +4801,10 @@
 	dir = 2
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/common)
@@ -4897,8 +4821,7 @@
 "oP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4994,8 +4917,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/engineering)
 "pk" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/damaged,
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
@@ -5006,8 +4928,7 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/zombie/whiteship{
@@ -5047,8 +4968,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/damaged,
@@ -5222,8 +5142,7 @@
 "qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal,
@@ -5292,8 +5211,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -5338,8 +5256,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -5393,8 +5310,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/damaged,
 /area/ruin/space/USSP_gorky17/collapsed/engineering)
@@ -5517,8 +5433,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "qW" = (
@@ -5555,16 +5470,14 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "rb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor/border_only/closed{
@@ -5623,8 +5536,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -5719,8 +5631,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "rx" = (
@@ -5739,8 +5650,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -5834,8 +5744,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
@@ -5944,8 +5853,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5996,8 +5904,7 @@
 /area/template_noop)
 "sg" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/light/small{
@@ -6024,8 +5931,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "sl" = (
@@ -6038,12 +5944,10 @@
 "sm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/space,
 /area/ruin/space/USSP_gorky17/collapsed/solars)
@@ -6147,8 +6051,7 @@
 	dir = 10
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -6189,8 +6092,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "sQ" = (
@@ -6213,8 +6115,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/check1)
@@ -6360,8 +6261,7 @@
 /area/template_noop)
 "tm" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -6409,8 +6309,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/shard{
 	icon_state = "medium"
@@ -6473,8 +6372,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/airless,
 /area/ruin/space/USSP_gorky17/collapsed/dorms)
@@ -6605,8 +6503,7 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/engineering)
@@ -6620,18 +6517,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/kitchen)
-"ua" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
-	},
-/obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
-	},
-/turf/space,
-/area/ruin/space/USSP_gorky17/collapsed/solars)
 "ub" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
@@ -6729,8 +6614,7 @@
 "up" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -6903,8 +6787,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "uP" = (
@@ -7009,12 +6892,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -7082,8 +6963,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decorative_structures/corpse{
@@ -7252,8 +7132,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/arrival)
 "vX" = (
@@ -7350,8 +7229,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "wj" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/shard{
 	icon_state = "small"
@@ -7379,8 +7257,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "wm" = (
@@ -7542,8 +7419,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7621,8 +7497,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "wY" = (
@@ -7705,15 +7580,13 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/trash/spentcasing{
 	icon_state = "762-casing";
@@ -7868,8 +7741,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "xN" = (
@@ -7972,8 +7844,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/gate)
 "yb" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/airless,
@@ -8009,8 +7880,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "yi" = (
@@ -8048,8 +7918,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/common)
 "ym" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /mob/living/simple_animal/hostile/zombie/whiteship{
 	health = 150;
@@ -8132,8 +8001,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "yz" = (
@@ -8154,8 +8022,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
@@ -8396,8 +8263,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -8532,8 +8398,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -8700,8 +8565,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/common)
@@ -8717,8 +8581,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "Ad" = (
@@ -8747,8 +8610,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "Af" = (
@@ -8773,8 +8635,7 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -8782,8 +8643,7 @@
 "Aj" = (
 /obj/structure/table,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/reagent_containers/food/snacks/boiledpelmeni,
 /turf/simulated/floor/plating,
@@ -8814,8 +8674,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/snacks/boiledbuckwheat,
@@ -8826,8 +8685,7 @@
 "An" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "Ao" = (
@@ -8877,20 +8735,11 @@
 	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/gate)
-"Av" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/space,
-/area/ruin/space/USSP_gorky17/collapsed/solars)
 "Aw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/zombie/whiteship{
@@ -8975,12 +8824,10 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/camera/autoname{
 	dir = 4;
@@ -9070,8 +8917,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -9329,8 +9175,7 @@
 "BP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -9395,8 +9240,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -9519,8 +9363,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -9586,8 +9429,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -9602,8 +9444,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
@@ -10204,8 +10045,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_construct/small{
@@ -10300,8 +10140,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/dorms)
 "EB" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/simulated/floor/plating,
@@ -10316,17 +10155,6 @@
 	icon_state = "whitered"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/medbay)
-"EE" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
-	},
-/turf/space,
-/area/ruin/space/USSP_gorky17/collapsed/solars)
 "EF" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/machinery/camera/autoname{
@@ -10335,8 +10163,7 @@
 	network = list("USSP_gorky17")
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/alarm{
 	alarm_frequency = 1520;
@@ -10463,8 +10290,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/door/poddoor{
 	id_tag = "g17extlock";
@@ -10614,8 +10440,7 @@
 "Fo" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10641,8 +10466,7 @@
 	dir = 10
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -10849,8 +10673,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "FY" = (
@@ -10888,8 +10711,7 @@
 "Gc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11003,8 +10825,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
@@ -11040,8 +10861,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/solars)
 "Gx" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -11129,8 +10949,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/zombie/whiteship{
@@ -11142,8 +10961,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "GH" = (
@@ -11197,8 +11015,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "GT" = (
@@ -11229,8 +11046,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/space,
 /area/ruin/space/USSP_gorky17/collapsed/solars)
@@ -11287,8 +11103,7 @@
 	dir = 10
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/USSP_gorky17/collapsed/medbay)
@@ -11408,8 +11223,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "HP" = (
@@ -11426,15 +11240,6 @@
 	icon_state = "white"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/kitchen)
-"HQ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/item/shard,
-/turf/space,
-/area/ruin/space/USSP_gorky17/collapsed/solars)
 "HS" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
@@ -11462,8 +11267,7 @@
 	pixel_y = 3
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/USSP_gorky17/collapsed/medbay)
@@ -11499,8 +11303,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -11517,8 +11320,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/door_assembly/door_assembly_shuttle,
@@ -11530,8 +11332,7 @@
 /obj/item/megaphone,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "Ih" = (
@@ -11555,8 +11356,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/airless,
@@ -11675,8 +11475,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/spentcasing{
@@ -11692,8 +11491,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/spentcasing{
@@ -11767,8 +11565,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "IL" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -11785,8 +11582,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/angar)
@@ -11853,8 +11649,7 @@
 /area/template_noop)
 "IW" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -11951,8 +11746,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "Jj" = (
@@ -11983,8 +11777,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard{
@@ -12132,8 +11925,7 @@
 "JG" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -12160,8 +11952,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/angar)
@@ -12243,8 +12034,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/angar)
 "JY" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/shard{
 	icon_state = "medium"
@@ -12296,8 +12086,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -12332,8 +12121,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/decal/warning_stripes/southwest,
 /obj/effect/decal/cleanable/dirt,
@@ -12354,8 +12142,7 @@
 	dir = 2
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard{
@@ -12769,8 +12556,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/space,
 /area/ruin/space/USSP_gorky17/collapsed/solars)
@@ -12821,12 +12607,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/arrival)
@@ -12892,8 +12676,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless{
@@ -12987,8 +12770,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "Mq" = (
@@ -13048,8 +12830,7 @@
 /area/template_noop)
 "Mz" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable,
 /obj/machinery/computer/monitor/secret/old_frame,
@@ -13086,8 +12867,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
@@ -13116,8 +12896,7 @@
 "MK" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -13212,8 +12991,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -13237,8 +13015,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/common)
@@ -13294,8 +13071,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
@@ -13331,12 +13107,10 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
@@ -13496,8 +13270,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -13610,8 +13383,7 @@
 "Oc" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -13711,8 +13483,7 @@
 /obj/structure/table_frame,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "Or" = (
@@ -13731,8 +13502,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/engineering)
 "Ov" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -13989,8 +13759,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/check2)
 "Pc" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/USSP_gorky17/collapsed/dinning)
@@ -14069,8 +13838,7 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1
@@ -14166,8 +13934,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "PI" = (
@@ -14193,8 +13960,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /mob/living/simple_animal/hostile/zombie/whiteship{
 	health = 150;
@@ -14402,8 +14168,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/item/shard{
 	icon_state = "small"
@@ -14561,8 +14326,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
@@ -14587,8 +14351,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/spentcasing{
@@ -14656,8 +14419,7 @@
 	req_access = list(122,123,124,125,126)
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull"
@@ -14714,8 +14476,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -14808,8 +14569,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -14865,8 +14625,7 @@
 	pixel_x = 12
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -14942,14 +14701,6 @@
 	},
 /turf/space,
 /area/template_noop)
-"RR" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
-	},
-/turf/space,
-/area/ruin/space/USSP_gorky17/collapsed/solars)
 "RT" = (
 /obj/item/stack/cable_coil{
 	amount = 3
@@ -14996,8 +14747,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/dorms)
 "Sh" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
@@ -15134,8 +14884,7 @@
 "SJ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -15186,8 +14935,7 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -15298,8 +15046,7 @@
 "Tj" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -15430,8 +15177,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /mob/living/simple_animal/hostile/zombie/whiteship{
 	health = 150;
@@ -15459,15 +15205,13 @@
 /area/ruin/space/USSP_gorky17/collapsed/common)
 "TI" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dust,
 /obj/structure/door_assembly/door_assembly_com,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "TJ" = (
@@ -15598,8 +15342,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor{
 	id_tag = "g17extlock";
@@ -15618,8 +15361,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/solmaintnorth)
 "Ue" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -15664,8 +15406,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/zombie/whiteship{
@@ -15774,8 +15515,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/gate)
 "UO" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -15820,8 +15560,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
@@ -15888,8 +15627,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -15959,8 +15697,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -15975,8 +15712,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/engineering)
 "Vr" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/projectile/automatic/aksu/rusted,
@@ -16000,8 +15736,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "Vv" = (
@@ -16124,8 +15859,7 @@
 "VK" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -16205,8 +15939,7 @@
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -16216,8 +15949,7 @@
 "VZ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -16247,8 +15979,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/bridge)
 "Wd" = (
@@ -16301,8 +16032,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/dorms)
 "Wn" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/tank/internals/anesthetic,
 /turf/simulated/floor/plating,
@@ -16326,8 +16056,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -16379,8 +16108,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16399,8 +16127,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "Ww" = (
@@ -16427,12 +16154,10 @@
 "WB" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16471,8 +16196,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -16484,8 +16208,7 @@
 "WK" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -16599,12 +16322,10 @@
 /area/ruin/space/USSP_gorky17/collapsed/engineering)
 "Xh" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/vault,
@@ -16690,16 +16411,14 @@
 /area/ruin/space/USSP_gorky17/collapsed/utility)
 "Xt" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/shard{
 	icon_state = "small"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "Xu" = (
@@ -16776,8 +16495,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "XH" = (
@@ -16795,8 +16513,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -16874,8 +16591,7 @@
 "XW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -16889,8 +16605,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/ruin/space/USSP_gorky17/collapsed/rnd)
 "Ya" = (
@@ -16994,8 +16709,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/solmaintnorth)
 "Yz" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/plating,
@@ -17040,8 +16754,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -17149,14 +16862,6 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plating,
 /area/ruin/space/USSP_gorky17/collapsed/engineering)
-"Ze" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
-	},
-/turf/space,
-/area/ruin/space/USSP_gorky17/collapsed/solars)
 "Zf" = (
 /turf/simulated/wall/r_wall,
 /area/ruin/space/USSP_gorky17/collapsed/medbay)
@@ -17203,8 +16908,7 @@
 "Zr" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -17288,15 +16992,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/security/glass{
 	locked = 1;
@@ -17327,8 +17029,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -17343,8 +17044,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor{
 	id_tag = "g17extlock";
@@ -17408,8 +17108,7 @@
 /area/ruin/space/USSP_gorky17/collapsed/common)
 "ZQ" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/airless,
 /area/ruin/space/USSP_gorky17/collapsed/dorms)
@@ -28243,9 +27942,9 @@ DZ
 JZ
 Ao
 WB
-ua
+mZ
 Xm
-ua
+mZ
 hs
 fB
 wZ
@@ -29053,7 +28752,7 @@ yq
 WB
 WB
 WB
-ua
+mZ
 JZ
 fB
 fB
@@ -30445,11 +30144,11 @@ wZ
 fB
 JZ
 Be
-EE
+MV
 IS
 Xi
 Be
-EE
+MV
 dV
 JZ
 fB
@@ -31259,7 +30958,7 @@ Db
 ee
 ji
 ee
-Ze
+lG
 fB
 fB
 fB
@@ -31863,7 +31562,7 @@ oP
 Gu
 JZ
 qZ
-RR
+Tb
 KB
 Db
 fB
@@ -38795,7 +38494,7 @@ Qv
 OD
 JZ
 Be
-EE
+MV
 IS
 JZ
 fB
@@ -39598,14 +39297,14 @@ fB
 fB
 fB
 zu
-Av
+ee
 Zr
-Av
-Av
+ee
+ee
 WO
 Zr
-Av
-Ze
+ee
+lG
 fB
 xi
 fB
@@ -39786,19 +39485,19 @@ ci
 rO
 sX
 eo
-bx
+sm
 ee
-Av
-Av
-Av
-Av
-Av
-Av
+ee
+ee
+ee
+ee
+ee
+ee
 Db
 Db
 CR
-Av
-Av
+ee
+ee
 mZ
 Db
 HY
@@ -39808,9 +39507,9 @@ Ho
 JZ
 Db
 JT
-Av
-Av
-Av
+ee
+ee
+ee
 ue
 JZ
 wZ
@@ -40002,12 +39701,12 @@ fB
 fB
 fB
 pN
-HQ
+XK
 sm
-Av
-Av
-Av
-Ze
+ee
+ee
+ee
+lG
 JZ
 Ao
 fB
@@ -40815,7 +40514,7 @@ VZ
 IS
 JZ
 Be
-RR
+Tb
 Xm
 Ho
 fB
@@ -46044,7 +45743,7 @@ wZ
 wZ
 JZ
 JT
-HQ
+XK
 GW
 LI
 Gp
@@ -46053,7 +45752,7 @@ Kz
 Fo
 Gc
 Gc
-RR
+Tb
 ev
 wZ
 yI
@@ -46852,14 +46551,14 @@ yI
 wZ
 JZ
 JT
-Av
+ee
 tr
 GW
 op
 JZ
 Kz
 WB
-ua
+mZ
 rB
 Ho
 EG

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_banya.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_banya.dmm
@@ -1,11 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ar" = (
-/obj/effect/decal/cleanable/dust,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
-	},
-/area/ruin/USSP_SpaceBanya)
 "as" = (
 /obj/effect/decal/cleanable/dust,
 /mob/living/simple_animal/moth,
@@ -19,8 +12,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /obj/item/soap/deluxe,
 /obj/item/bikehorn/rubberducky,
@@ -97,8 +89,7 @@
 /area/ruin/USSP_SpaceBanya)
 "dX" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/USSP_SpaceBanya)
 "ef" = (
@@ -115,8 +106,7 @@
 /area/ruin/USSP_SpaceBanya)
 "eu" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/ruin/USSP_SpaceBanya)
 "ev" = (
@@ -267,8 +257,7 @@
 /obj/effect/decal/cleanable/dust,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/USSP_SpaceBanya)
 "lE" = (
@@ -281,8 +270,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/USSP_SpaceBanya)
 "mh" = (
@@ -314,8 +302,7 @@
 "op" = (
 /obj/item/flag/ussp,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/ruin/USSP_SpaceBanya)
 "ow" = (
@@ -461,8 +448,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/USSP_SpaceBanya)
 "sP" = (
@@ -606,8 +592,7 @@
 /area/ruin/USSP_SpaceBanya)
 "xE" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/ruin/USSP_SpaceBanya)
 "xH" = (
@@ -674,8 +659,7 @@
 "AJ" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/ruin/USSP_SpaceBanya)
 "AU" = (
@@ -754,8 +738,7 @@
 "EO" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/ruin/USSP_SpaceBanya)
 "Fa" = (
@@ -777,8 +760,7 @@
 /area/ruin/USSP_SpaceBanya)
 "Gi" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/ruin/USSP_SpaceBanya)
 "Gv" = (
@@ -847,16 +829,14 @@
 "JI" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/USSP_SpaceBanya)
 "Lc" = (
 /obj/item/trash/popcorn,
 /obj/structure/table_frame/wood,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/USSP_SpaceBanya)
 "Ld" = (
@@ -895,8 +875,7 @@
 /area/ruin/USSP_SpaceBanya)
 "NP" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/wood,
 /area/ruin/USSP_SpaceBanya)
@@ -1106,8 +1085,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/ruin/USSP_SpaceBanya)
 "WZ" = (
@@ -1151,8 +1129,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /obj/item/soap,
 /obj/item/clothing/shoes/ducky,
@@ -1928,7 +1905,7 @@ jv
 vo
 yJ
 xl
-ar
+Nr
 Jl
 Dd
 nD

--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_storage.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_storage.dmm
@@ -675,8 +675,6 @@
 /area/ruin/unpowered)
 "kO" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	pixel_x = 0;
 	pixel_y = 20
 	},
 /obj/structure/curtain/open/shower,
@@ -1549,8 +1547,7 @@
 /area/ruin/unpowered)
 "Av" = (
 /obj/machinery/shower{
-	dir = 1;
-	tag = "icon-shower (WEST)"
+	dir = 1
 	},
 /obj/structure/curtain/open/shower,
 /obj/effect/decal/cleanable/dirt,
@@ -2146,12 +2143,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pickaxe/silver,
 /obj/item/pickaxe/silver{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/item/pickaxe/silver{
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/anomalyship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/anomalyship.dmm
@@ -518,8 +518,7 @@
 "nv" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater2x2";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater2x2"
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -675,8 +674,7 @@
 "qv" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater2x2";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater2x2"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -701,8 +699,7 @@
 "ro" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater2x2_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater2x2_side"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -724,8 +721,7 @@
 "rX" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater2x2_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater2x2_side"
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{

--- a/_maps/map_files/RandomRuins/SpaceRuins/clownmime.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/clownmime.dmm
@@ -4,8 +4,7 @@
 /area/template_noop)
 "c" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/shuttle/plating,
@@ -125,8 +124,7 @@
 /area/space/nearstation)
 "A" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 4;
-	tag = "icon-heater (EAST)"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -136,13 +134,11 @@
 "B" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (WEST)"
+	icon_state = "propulsion_l"
 	},
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "burst_r";
-	tag = "icon-burst_r (WEST)"
+	icon_state = "burst_r"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/space/nearstation)
@@ -157,8 +153,7 @@
 "E" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (WEST)"
+	icon_state = "propulsion_l"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/space/nearstation)
@@ -211,8 +206,7 @@
 /area/space/nearstation)
 "M" = (
 /turf/simulated/wall/shuttle{
-	icon_state = "swall_f5";
-	tag = "icon-swall_f5"
+	icon_state = "swall_f5"
 	},
 /area/space/nearstation)
 "N" = (
@@ -240,13 +234,11 @@
 "R" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (WEST)"
+	icon_state = "propulsion_l"
 	},
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (WEST)"
+	icon_state = "propulsion_l"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/space/nearstation)

--- a/_maps/map_files/RandomRuins/SpaceRuins/crashedipcship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/crashedipcship.dmm
@@ -128,8 +128,7 @@
 /area/ruin/space/crashedipcship/aft)
 "cj" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal{
 	dir = 6;
@@ -279,8 +278,7 @@
 /area/ruin/space/crashedipcship/asteroid)
 "eb" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/item/tank/internals/plasma/full{
 	pixel_y = -3;
@@ -449,8 +447,7 @@
 /area/ruin/space/crashedipcship/aft)
 "hZ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/spacevine,
 /obj/machinery/door/airlock/hatch{
@@ -460,8 +457,7 @@
 /area/ruin/space/crashedipcship/middle)
 "ij" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/spacevine,
 /obj/effect/mob_spawn/headcrab,
@@ -570,8 +566,7 @@
 "kP" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater2x2_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater2x2_side"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -687,12 +682,10 @@
 /area/ruin/space/crashedipcship/middle)
 "lZ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/ash,
@@ -835,8 +828,7 @@
 /area/ruin/space/crashedipcship/asteroid)
 "nW" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -879,8 +871,7 @@
 /area/ruin/space/crashedipcship/asteroid)
 "oI" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/item/stock_parts/capacitor,
 /obj/effect/decal/cleanable/dirt,
@@ -888,8 +879,7 @@
 /area/ruin/space/crashedipcship/engine)
 "oS" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/spacevine,
 /obj/structure/spacevine,
@@ -922,8 +912,7 @@
 /area/ruin/space/crashedipcship/engine)
 "pJ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1501,8 +1490,7 @@
 "yy" = (
 /obj/machinery/computer/sm_monitor,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/crashedipcship/engine)
@@ -1529,8 +1517,7 @@
 /area/ruin/space/crashedipcship/middle)
 "yN" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/circuitboard/smes,
 /obj/item/stock_parts/cell/high/empty,
@@ -1658,8 +1645,7 @@
 "AC" = (
 /obj/item/book/manual/ripley_build_and_repair,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal{
 	dir = 1;
@@ -1761,8 +1747,7 @@
 /area/ruin/space/crashedipcship/middle)
 "Cu" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/hatch{
 	color = "lightblue"
@@ -1950,8 +1935,7 @@
 /area/ruin/space/crashedipcship/aft)
 "FX" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/hatch{
 	color = "lightblue"
@@ -1987,8 +1971,7 @@
 /area/ruin/space/crashedipcship/asteroid)
 "Gm" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -1997,8 +1980,7 @@
 "GK" = (
 /obj/item/circuitboard/cyborgrecharger,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass,
 /area/ruin/space/crashedipcship/middle)
@@ -2020,8 +2002,7 @@
 /area/ruin/space/crashedipcship/middle)
 "GW" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
 	color = "lightblue"
@@ -2257,8 +2238,7 @@
 "Kw" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater2x2";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater2x2"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -2272,8 +2252,7 @@
 /area/ruin/space/crashedipcship/engine)
 "KS" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/mineral/titanium,
@@ -2767,8 +2746,7 @@
 "TQ" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/mob_spawn/human/corpse/ipc,
 /obj/effect/turf_decal{
@@ -2826,8 +2804,7 @@
 /area/ruin/space/crashedipcship/engine)
 "Vs" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2931,8 +2908,7 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/item/tank/internals/plasma/full{
 	pixel_y = -3;
@@ -2944,12 +2920,10 @@
 /obj/item/tank/internals/plasma/empty,
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/crashedipcship/engine)
@@ -3037,8 +3011,7 @@
 /area/ruin/space/crashedipcship/aft)
 "ZK" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal{
 	dir = 4;
@@ -3069,8 +3042,7 @@
 /area/ruin/space/crashedipcship/aft)
 "ZW" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/item/tank/internals/plasma/empty{
 	pixel_x = 5

--- a/_maps/map_files/RandomRuins/SpaceRuins/debris1.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/debris1.dmm
@@ -98,8 +98,7 @@
 /area/space)
 "D" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/burnt,
 /area/space)

--- a/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -337,14 +337,12 @@
 "aH" = (
 /obj/machinery/vending/clothesmate,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/ruin/unpowered)
 "aI" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken2";
-	tag = "icon-wood-broken2"
+	icon_state = "wood-broken2"
 	},
 /area/ruin/unpowered)
 "aJ" = (
@@ -405,8 +403,7 @@
 "aQ" = (
 /obj/structure/closet/wardrobe/pink,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken2";
-	tag = "icon-wood-broken2"
+	icon_state = "wood-broken2"
 	},
 /area/ruin/unpowered)
 "aR" = (
@@ -415,8 +412,7 @@
 "aS" = (
 /obj/structure/bed,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/ruin/unpowered)
 "aT" = (
@@ -468,15 +464,13 @@
 /area/ruin/unpowered)
 "aZ" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/ruin/unpowered)
 "ba" = (
 /obj/structure/bed,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken2";
-	tag = "icon-wood-broken2"
+	icon_state = "wood-broken2"
 	},
 /area/ruin/unpowered)
 "bb" = (
@@ -725,8 +719,7 @@
 /area/ruin/unpowered)
 "bP" = (
 /obj/structure/chair/office/dark{
-	dir = 4;
-	tag = "icon-officechair_dark (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered)
@@ -793,8 +786,7 @@
 "bZ" = (
 /obj/machinery/door/poddoor{
 	id_tag = "bunker1";
-	name = "Bunker Door";
-	tag = "inner"
+	name = "Bunker Door"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered)
@@ -816,8 +808,7 @@
 "cd" = (
 /obj/machinery/door/poddoor{
 	id_tag = "bunker2";
-	name = "Bunker Door";
-	tag = "outer"
+	name = "Bunker Door"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict2.dmm
@@ -4,7 +4,6 @@
 /area/template_noop)
 "b" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
 	dir = 4
 	},
 /turf/space,
@@ -15,18 +14,15 @@
 /area/ruin/powered)
 "d" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (WEST)";
 	dir = 8
 	},
 /turf/space,
 /area/space/nearstation)
 "e" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (EAST)";
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (WEST)";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -41,7 +37,6 @@
 /area/ruin/powered)
 "h" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (NORTH)";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
@@ -51,7 +46,6 @@
 /area/ruin/powered)
 "j" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -63,14 +57,12 @@
 "l" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/ruin/powered)
 "m" = (
 /obj/structure/chair{
-	tag = "icon-chair (EAST)";
 	dir = 4
 	},
 /obj/effect/decal/remains/human,
@@ -91,7 +83,6 @@
 /area/ruin/powered)
 "o" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	dir = 8
 	},
 /obj/effect/decal/remains/human,
@@ -99,14 +90,12 @@
 /area/ruin/powered)
 "p" = (
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	dir = 1
 	},
 /turf/space,
 /area/space/nearstation)
 "q" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict4.dmm
@@ -28,8 +28,7 @@
 /area/ruin/unpowered)
 "i" = (
 /obj/structure/window/reinforced{
-	dir = 8;
-	tag = "icon-rwindow (WEST)"
+	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/titanium/blue/airless,
@@ -47,8 +46,7 @@
 /area/ruin/unpowered)
 "l" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 4;
-	tag = "icon-propulsion (WEST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/unpowered)
@@ -75,8 +73,7 @@
 /area/ruin/unpowered)
 "r" = (
 /obj/structure/window/reinforced{
-	dir = 8;
-	tag = "icon-rwindow (WEST)"
+	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 1

--- a/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
@@ -208,8 +208,7 @@
 "bc" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
-	dir = 4;
-	tag = "icon-shower (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -443,8 +443,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -798,8 +797,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/gasthelizards/viewzone)
@@ -1099,8 +1097,7 @@
 	specialfunctions = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/gasthelizards/viewzone)
@@ -1316,8 +1313,7 @@
 	},
 /obj/machinery/atmospherics/meter,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/_maps/map_files/RandomRuins/SpaceRuins/graveyard.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/graveyard.dmm
@@ -286,8 +286,7 @@
 /area/ruin/space/graveyard/graves)
 "hA" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/wood/oak,
 /area/ruin/space/graveyard/graves)
@@ -473,8 +472,7 @@
 "ls" = (
 /obj/effect/decal/cleanable/dust,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "lightdark"
@@ -799,8 +797,7 @@
 /area/ruin/space/graveyard/church)
 "sR" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-30";
-	tag = "icon-plant-30"
+	icon_state = "plant-30"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "lightdark"
@@ -809,8 +806,7 @@
 "te" = (
 /obj/machinery/door/airlock/multi_tile/glass,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/oak,
 /area/ruin/space/graveyard/graves)
@@ -834,8 +830,7 @@
 	icon_state = "2-4"
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "lightdark"
@@ -1495,8 +1490,7 @@
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "lightdark"
@@ -1578,8 +1572,7 @@
 "IW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/oak,
 /area/ruin/space/graveyard/church)
@@ -1765,8 +1758,7 @@
 "NR" = (
 /obj/effect/decal/cleanable/dust,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-30";
-	tag = "icon-plant-30"
+	icon_state = "plant-30"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1822,8 +1814,7 @@
 "Py" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-17";
-	tag = "icon-plant-17"
+	icon_state = "plant-17"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "lightdark"
@@ -1911,8 +1902,7 @@
 /area/ruin/space/graveyard/church)
 "Rl" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-17";
-	tag = "icon-plant-17"
+	icon_state = "plant-17"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "lightdark"
@@ -1928,8 +1918,7 @@
 	amount = 20
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/flashlight/lantern,
 /obj/item/flashlight/lantern,
@@ -2268,8 +2257,7 @@
 /area/ruin/space/graveyard/church)
 "Xr" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "lightdark"
@@ -2364,8 +2352,7 @@
 	name = "grass"
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "applebush";
-	tag = "icon-applebush"
+	icon_state = "applebush"
 	},
 /turf/simulated/floor/wood/oak,
 /area/ruin/space/graveyard/graves)
@@ -2420,8 +2407,7 @@
 /area/ruin/space/graveyard/church)
 "Zi" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-30";
-	tag = "icon-plant-30"
+	icon_state = "plant-30"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -2460,8 +2446,7 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "lightdark"

--- a/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -7,8 +7,7 @@
 /area/ruin/powered)
 "e" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/powered)
@@ -17,8 +16,7 @@
 	dir = 4
 	},
 /obj/structure/shuttle/engine/heater{
-	dir = 8;
-	tag = "icon-heater (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/powered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -274,7 +274,6 @@
 /area/ruin/powered)
 "Q" = (
 /obj/machinery/shower{
-	tag = "icon-shower (WEST)";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -288,7 +287,6 @@
 /area/ruin/powered)
 "S" = (
 /obj/structure/toilet{
-	tag = "icon-toilet00 (WEST)";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/RandomRuins/SpaceRuins/lonelypod.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/lonelypod.dmm
@@ -210,8 +210,7 @@
 	dir = 4
 	},
 /obj/structure/shuttle/engine/heater{
-	dir = 8;
-	tag = "icon-heater (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/unpowered)
@@ -398,8 +397,7 @@
 /area/ruin/unpowered)
 "QG" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/magestavern.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/magestavern.dmm
@@ -560,8 +560,7 @@
 "Aa" = (
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/ruin/unpowered)
 "Al" = (
@@ -736,12 +735,6 @@
 /obj/structure/table/wood/fancy/purple,
 /obj/machinery/chem_dispenser/beer,
 /turf/simulated/floor/carpet/purple,
-/area/ruin/unpowered)
-"Ij" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
-	},
 /area/ruin/unpowered)
 "It" = (
 /obj/structure/mineral_door/iron,
@@ -1595,7 +1588,7 @@ jR
 zB
 ez
 Kn
-Ij
+zy
 gJ
 ez
 tB
@@ -1684,7 +1677,7 @@ ua
 ez
 Ql
 dm
-Ij
+zy
 ez
 zY
 Fo

--- a/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -158,8 +158,7 @@
 "A" = (
 /obj/machinery/door/poddoor{
 	id_tag = "mecha cargo";
-	name = "Cargo Bay Door";
-	tag = ""
+	name = "Cargo Bay Door"
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3";

--- a/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
@@ -417,7 +417,6 @@
 /area/ruin/onehalf/hallway)
 "be" = (
 /obj/structure/disposalpipe/broken{
-	tag = "icon-pipe-b (EAST)";
 	dir = 4
 	},
 /obj/item/stack/cable_coil/cut{
@@ -460,7 +459,6 @@
 /area/ruin/onehalf/hallway)
 "bi" = (
 /obj/structure/disposalpipe/broken{
-	tag = "icon-pipe-b (EAST)";
 	dir = 4
 	},
 /obj/effect/mapping_helpers/turfs/damage,
@@ -807,7 +805,6 @@
 	dir = 4
 	},
 /obj/item/shard{
-	tag = "icon-small";
 	icon_state = "small"
 	},
 /turf/space,
@@ -834,7 +831,6 @@
 /area/ruin/onehalf/bridge)
 "cq" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -844,7 +840,6 @@
 /area/ruin/onehalf/bridge)
 "cs" = (
 /obj/structure/chair{
-	tag = "icon-chair (NORTH)";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
@@ -893,7 +888,6 @@
 "cy" = (
 /obj/structure/lattice,
 /obj/item/shard{
-	tag = "icon-medium";
 	icon_state = "medium"
 	},
 /turf/space,
@@ -954,11 +948,9 @@
 "cH" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/broken{
-	tag = "icon-pipe-b (NORTH)";
 	dir = 1
 	},
 /obj/structure/disposalpipe/broken{
-	tag = "icon-pipe-b (WEST)";
 	dir = 8
 	},
 /turf/space,
@@ -1000,7 +992,6 @@
 /area/ruin/onehalf/bridge)
 "cN" = (
 /obj/structure/chair/comfy/black{
-	tag = "icon-comfychair (EAST)";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -1156,7 +1147,6 @@
 	icon_state = "4-8"
 	},
 /obj/item/shard{
-	tag = "icon-medium";
 	icon_state = "medium"
 	},
 /turf/space,

--- a/_maps/map_files/RandomRuins/SpaceRuins/space_bloodship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/space_bloodship.dmm
@@ -57,8 +57,7 @@
 /area/ruin/unpowered)
 "vK" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/plasmareinforced,
 /turf/simulated/floor/plating,
@@ -295,8 +294,7 @@
 /area/ruin/unpowered)
 "UX" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	tag = "icon-propulsion (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -143,8 +143,7 @@
 /area/ruin/powered/space_bar)
 "aV" = (
 /obj/structure/chair{
-	dir = 4;
-	tag = "icon-chair (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/powered/space_bar)
@@ -201,8 +200,7 @@
 /area/ruin/powered/space_bar)
 "bk" = (
 /obj/structure/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/powered/space_bar)
@@ -520,8 +518,7 @@
 /area/ruin/powered/space_bar)
 "AN" = (
 /obj/structure/chair{
-	dir = 4;
-	tag = "icon-chair (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/ruin/powered/space_bar)

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebotany.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebotany.dmm
@@ -647,8 +647,7 @@
 /obj/structure/spacevine,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/space/spacebotany/Med)
 "if" = (
@@ -901,8 +900,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/space/spacebotany/Med)
 "lh" = (
@@ -974,8 +972,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/space/spacebotany/Med)
 "mG" = (
@@ -3249,8 +3246,7 @@
 /obj/effect/decal/ants,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/space/spacebotany/Med)
 "QX" = (
@@ -3328,8 +3324,7 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/space/spacebotany/Med)
 "Rm" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
@@ -138,8 +138,7 @@
 /area/ruin)
 "pb" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless,
@@ -210,12 +209,10 @@
 /area/ruin/unpowered)
 "tz" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -232,8 +229,7 @@
 /area/space)
 "uF" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/ruin/unpowered)
@@ -254,8 +250,7 @@
 /area/space)
 "yU" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless,
@@ -312,8 +307,7 @@
 	name = "EVA Storage"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/airless,
@@ -323,8 +317,7 @@
 /area/ruin/unpowered)
 "BI" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -401,8 +394,7 @@
 /area/ruin/space)
 "JI" = (
 /obj/structure/chair/office/dark{
-	dir = 4;
-	tag = "icon-officechair_dark (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
@@ -738,8 +738,7 @@
 /area/syndicate_depot/core)
 "ce" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/mineral/silver,
 /area/syndicate_depot/core)

--- a/_maps/map_files/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -55,7 +55,6 @@
 /area/ruin/unpowered)
 "n" = (
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -234,8 +234,7 @@
 /area/derelict/bridge)
 "aI" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
@@ -317,8 +316,7 @@
 /area/derelict/bridge)
 "aR" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -336,8 +334,7 @@
 "aU" = (
 /obj/machinery/photocopier,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -611,8 +608,7 @@
 /area/derelict/bridge)
 "bF" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dust,
 /obj/structure/safe,
@@ -745,8 +741,7 @@
 /area/derelict/security)
 "bV" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/derelict/bridge)
 "bW" = (
@@ -832,8 +827,7 @@
 /area/derelict/bridge)
 "ch" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
@@ -858,8 +852,7 @@
 /area/derelict/crew_quarters)
 "ck" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/curtain/open/shower,
 /obj/effect/decal/cleanable/dirt,
@@ -1063,8 +1056,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_x = 5;
-	tag = "icon-shower (EAST)"
+	pixel_x = 5
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1104,12 +1096,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
@@ -1227,8 +1217,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
@@ -1298,8 +1287,7 @@
 "dt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -1466,8 +1454,7 @@
 "dN" = (
 /obj/structure/closet,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/item/clothing/head/ushanka,
 /obj/item/clothing/head/ushanka,
@@ -1484,8 +1471,7 @@
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -1521,15 +1507,6 @@
 	icon_state = "darkred"
 	},
 /area/derelict/security)
-"dV" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/derelict/security)
 "dW" = (
 /turf/simulated/wall/mineral/titanium,
 /area/derelict/annex)
@@ -1540,8 +1517,7 @@
 "dY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/derelict/common)
@@ -1593,8 +1569,7 @@
 /area/derelict/security)
 "eh" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/item/flag/ussp,
 /turf/simulated/floor/plasteel{
@@ -1613,8 +1588,7 @@
 /area/derelict/engineer_area)
 "ej" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flag/ussp,
@@ -1781,8 +1755,7 @@
 "eC" = (
 /obj/structure/chair/wood,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/derelict/crew_quarters)
 "eD" = (
@@ -1799,8 +1772,7 @@
 "eF" = (
 /obj/structure/chair/sofa/right,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/sign/poster/contraband/rebels_unite{
 	pixel_x = -1;
@@ -1816,8 +1788,7 @@
 	},
 /obj/item/spentcasing,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/derelict/crew_quarters)
 "eH" = (
@@ -1852,8 +1823,7 @@
 	name = "Security Wing Lockdown"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -2177,8 +2147,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/derelict/crew_quarters)
 "fx" = (
@@ -2202,8 +2171,7 @@
 "fz" = (
 /obj/structure/mopbucket,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/derelict/crew_quarters)
 "fA" = (
@@ -2215,8 +2183,7 @@
 /area/derelict/security)
 "fB" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/item/spentcasing/rifle,
 /turf/simulated/floor/plasteel{
@@ -2233,8 +2200,7 @@
 /area/derelict/security)
 "fD" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/item/spentcasing,
 /turf/simulated/floor/plasteel{
@@ -2334,12 +2300,10 @@
 /area/derelict/engineer_area)
 "fP" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2525,8 +2489,7 @@
 "gn" = (
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/derelict/crew_quarters)
 "go" = (
@@ -2594,8 +2557,7 @@
 	dir = 1
 	},
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plasteel{
@@ -2638,8 +2600,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -3113,8 +3074,7 @@
 "hS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -3123,8 +3083,7 @@
 "hT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -3186,8 +3145,7 @@
 /area/derelict/dock)
 "ib" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/closet/secure_closet{
 	name = "Reagents locker";
@@ -3412,8 +3370,7 @@
 /area/derelict/arrival)
 "iz" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -3636,18 +3593,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/derelict/common)
-"je" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/derelict/church)
 "jf" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
@@ -3656,8 +3601,7 @@
 /area/derelict/church)
 "jg" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -3821,8 +3765,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/derelict/engineer_area)
 "jH" = (
@@ -4139,8 +4082,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/derelict/engineer_area)
 "kx" = (
@@ -4448,8 +4390,7 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/derelict/engineer_area)
 "lj" = (
@@ -4636,8 +4577,7 @@
 /area/derelict/dining)
 "lG" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -4663,8 +4603,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "white"
@@ -4768,8 +4707,7 @@
 /obj/structure/closet/crate/can,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/item/trash/tastybread,
 /obj/effect/decal/cleanable/dirt,
@@ -4791,8 +4729,7 @@
 /area/derelict/church)
 "lX" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -4913,8 +4850,7 @@
 "ms" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "chapel"
@@ -5170,8 +5106,7 @@
 /area/derelict/garden)
 "ne" = (
 /obj/machinery/shower{
-	dir = 4;
-	tag = "icon-shower (EAST)"
+	dir = 4
 	},
 /obj/structure/curtain/open/shower,
 /obj/effect/decal/cleanable/dirt,
@@ -5365,8 +5300,7 @@
 /obj/structure/rack,
 /obj/item/beach_ball/holoball,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -5386,8 +5320,7 @@
 /area/derelict/garden)
 "nH" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "white"
@@ -5918,8 +5851,7 @@
 /obj/structure/table,
 /obj/item/storage/box/cups,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -6016,8 +5948,7 @@
 /area/derelict/common)
 "pu" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/mop,
@@ -6090,8 +6021,7 @@
 /area/derelict/common)
 "pD" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/structure/spider/stickyweb,
@@ -6123,8 +6053,7 @@
 /area/derelict/med)
 "pI" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/derelict/crew_quarters)
@@ -6153,8 +6082,7 @@
 /area/derelict/common)
 "pN" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
@@ -6235,8 +6163,7 @@
 /area/derelict/common)
 "pX" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -6271,8 +6198,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/derelict/arrival)
@@ -6291,8 +6217,7 @@
 /area/derelict/common)
 "qe" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -6348,8 +6273,7 @@
 "qo" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /obj/structure/kitchenspike,
 /turf/simulated/floor/plasteel{
@@ -6359,13 +6283,6 @@
 "qp" = (
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/wall/mineral/titanium,
-/area/derelict/med)
-"qr" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plating/airless,
 /area/derelict/med)
 "qs" = (
 /obj/structure/sign/nosmoking_2,
@@ -6412,8 +6329,7 @@
 /area/derelict/arrival)
 "qz" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
@@ -6533,8 +6449,7 @@
 /area/derelict/arrival)
 "qN" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
@@ -6557,8 +6472,7 @@
 "qQ" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/leafybush,
@@ -6598,8 +6512,7 @@
 "qV" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
@@ -6635,8 +6548,7 @@
 /area/derelict/med)
 "ra" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -6715,8 +6627,7 @@
 	},
 /obj/effect/decal/cleanable/spiderling_remains,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -6797,8 +6708,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/grass,
 /area/derelict/arrival)
@@ -6870,8 +6780,7 @@
 	pixel_y = 5
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/grass,
@@ -6970,8 +6879,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -7063,8 +6971,7 @@
 /area/derelict/arrival)
 "rW" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -7385,16 +7292,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/derelict/arrival)
-"uR" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/effect/decal/cleanable/dust,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/derelict/security)
 "uZ" = (
 /obj/machinery/door/poddoor{
 	id_tag = "usspchapelgun";
@@ -7461,8 +7358,7 @@
 "vK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/derelict/bridge)
 "vR" = (
@@ -7476,8 +7372,7 @@
 "vS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "white"
@@ -7572,8 +7467,7 @@
 	},
 /obj/effect/decal/ants,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/derelict/crew_quarters)
 "xo" = (
@@ -7621,8 +7515,7 @@
 /area/derelict/rnd)
 "xN" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Капитанская";
@@ -7633,14 +7526,6 @@
 	icon_state = "wood"
 	},
 /area/derelict/bridge)
-"xP" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/space,
-/area/space)
 "xT" = (
 /obj/structure/computerframe{
 	desc = "This computer is a husk of what it once was. Time and decay has worn its cheap circuitry to dust.";
@@ -7713,8 +7598,7 @@
 	req_access = list(128,129,130,131)
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -7745,8 +7629,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/derelict/rnd)
@@ -7867,16 +7750,6 @@
 /obj/machinery/r_n_d/destructive_analyzer,
 /turf/simulated/floor/plasteel,
 /area/derelict/rnd)
-"At" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/derelict/security)
 "Aw" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -7892,8 +7765,7 @@
 /area/ruin/unpowered/no_grav)
 "AB" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7975,8 +7847,7 @@
 "BT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -7988,8 +7859,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/space,
 /area/space)
@@ -8132,8 +8002,7 @@
 "Dp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Бар";
@@ -8270,8 +8139,7 @@
 /area/derelict/garden)
 "Ei" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/light_construct{
 	dir = 4
@@ -8541,8 +8409,7 @@
 	},
 /obj/effect/decal/cleanable/dust,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/derelict/arrival)
@@ -8573,8 +8440,7 @@
 "Hk" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/derelict/bridge)
 "Hl" = (
@@ -8865,8 +8731,7 @@
 "KG" = (
 /obj/effect/decal/cleanable/dust,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8941,8 +8806,7 @@
 "Ll" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Церковь выбрасывательная";
@@ -9162,8 +9026,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
@@ -9300,8 +9163,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -9322,14 +9184,6 @@
 	icon_state = "wood"
 	},
 /area/derelict/crew_quarters)
-"PF" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space)
 "PL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9374,8 +9228,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/space,
 /area/space)
@@ -9456,8 +9309,7 @@
 /area/derelict/common)
 "RJ" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
@@ -9472,16 +9324,6 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
-"RR" = (
-/obj/effect/decal/cleanable/dust,
-/obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/derelict/dining)
 "RX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/cigarette{
@@ -9511,8 +9353,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -9528,8 +9369,7 @@
 /area/derelict/common)
 "Sq" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/curtain/open/shower,
 /obj/effect/decal/cleanable/dirt,
@@ -9875,8 +9715,7 @@
 /obj/structure/window/full/shuttle,
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -9977,8 +9816,7 @@
 /area/derelict/bridge)
 "Yb" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/spiderling_remains,
 /mob/living/simple_animal/hostile/poison/giant_spider,
@@ -10024,8 +9862,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/derelict/engineer_area)
@@ -15642,11 +15479,11 @@ ac
 cq
 cq
 Du
-dV
-At
-uR
+fX
+PL
+LP
 eK
-At
+PL
 fD
 fY
 dn
@@ -16534,8 +16371,8 @@ mU
 pH
 nJ
 mS
-qr
-qr
+nZ
+nZ
 qB
 tk
 tk
@@ -19690,7 +19527,7 @@ Oo
 Oo
 ww
 jj
-RR
+vx
 Ec
 no
 np
@@ -21759,8 +21596,8 @@ iK
 lI
 tS
 yy
-je
-je
+tS
+tS
 lX
 ms
 hT
@@ -22973,17 +22810,17 @@ ac
 ac
 ac
 Qp
-xP
-xP
-xP
-xP
-PF
-xP
-PF
-xP
-xP
-xP
-xP
+Ot
+Ot
+Ot
+Ot
+mF
+Ot
+mF
+Ot
+Ot
+Ot
+Ot
 BW
 ac
 ac

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp_laboratory.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp_laboratory.dmm
@@ -56,8 +56,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "bT" = (
@@ -82,8 +81,7 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "bV" = (
@@ -157,8 +155,7 @@
 	layer = 2.9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/ruin/ussp_xeno/medbay)
 "dh" = (
@@ -233,14 +230,12 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "dQ" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/ruin/ussp_xeno/out)
 "ef" = (
@@ -333,8 +328,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "fL" = (
@@ -414,8 +408,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/ruin/ussp_xeno/medbay)
 "gG" = (
@@ -456,8 +449,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/ruin/ussp_xeno/medbay)
 "gW" = (
@@ -506,8 +498,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "hr" = (
@@ -691,8 +682,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "jC" = (
@@ -754,8 +744,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/ruin/ussp_xeno/medbay)
 "kR" = (
@@ -798,8 +787,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/ruin/ussp_xeno/medbay)
 "lt" = (
@@ -894,8 +882,7 @@
 /area/ruin/ussp_xeno/out)
 "no" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/ruin/ussp_xeno/out)
 "nq" = (
@@ -1055,8 +1042,7 @@
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/ruin/ussp_xeno/medbay)
 "qb" = (
@@ -1088,8 +1074,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "qy" = (
@@ -1214,8 +1199,7 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "sG" = (
@@ -1259,8 +1243,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
-	frequency = 1379;
-	tag = "SSSP_Xeno_pump"
+	frequency = 1379
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -1447,8 +1430,7 @@
 /obj/item/organ/internal/brain/xeno,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/ruin/ussp_xeno/medbay)
 "vL" = (
@@ -1603,8 +1585,7 @@
 /obj/machinery/smartfridge/secure/extract,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whitebluecorner"
 	},
 /area/ruin/ussp_xeno/medbay)
 "wO" = (
@@ -1632,8 +1613,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "xi" = (
@@ -1890,8 +1870,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "ramptop";
-	tag = "icon-stage_stairs"
+	icon_state = "ramptop"
 	},
 /area/ruin/ussp_xeno/gym_ussp)
 "AX" = (
@@ -2055,13 +2034,11 @@
 "CV" = (
 /obj/item/reagent_containers/glass/beaker,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8;
-	tag = "SSSP_Xeno_pump"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whitebluecorner"
 	},
 /area/ruin/ussp_xeno/medbay)
 "CX" = (
@@ -2152,8 +2129,7 @@
 	},
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Fd" = (
@@ -2285,8 +2261,7 @@
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/ruin/ussp_xeno/medbay)
 "GC" = (
@@ -2316,8 +2291,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/ruin/ussp_xeno/out)
 "GH" = (
@@ -2402,8 +2376,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
-	frequency = 1379;
-	tag = "SSSP_Xeno_pump"
+	frequency = 1379
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
@@ -2415,8 +2388,7 @@
 /obj/structure/alien/egg/burst,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Hi" = (
@@ -2441,14 +2413,12 @@
 /obj/item/clothing/head/ushanka,
 /obj/item/clothing/mask/gas,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/ruin/ussp_xeno/medbay)
 "HV" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/ruin/ussp_xeno/out)
 "HW" = (
@@ -2723,8 +2693,7 @@
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Mg" = (
@@ -2748,8 +2717,7 @@
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Mn" = (
@@ -2823,17 +2791,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHWEST)"
-	},
-/area/ruin/ussp_xeno/medbay)
-"Nf" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/alien/weeds,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Nh" = (
@@ -2882,8 +2840,7 @@
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "NL" = (
@@ -2896,8 +2853,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whitebluecorner"
 	},
 /area/ruin/ussp_xeno/medbay)
 "NO" = (
@@ -2927,8 +2883,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Oa" = (
@@ -2968,8 +2923,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Ol" = (
@@ -3136,8 +3090,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Qa" = (
@@ -3174,8 +3127,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Qi" = (
@@ -3198,8 +3150,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Rl" = (
@@ -3301,8 +3252,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Tr" = (
@@ -3382,8 +3332,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/ruin/ussp_xeno/medbay)
 "TX" = (
@@ -3421,8 +3370,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Un" = (
@@ -3434,8 +3382,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "UM" = (
@@ -3631,8 +3578,7 @@
 	},
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/ruin/ussp_xeno/medbay)
 "Ym" = (
@@ -4678,7 +4624,7 @@ kr
 wb
 Jt
 BA
-Nf
+Xd
 GB
 kr
 KY

--- a/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
@@ -7,8 +7,7 @@
 /obj/effect/decal/warning_stripes/blue/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/abandoned)
 "aN" = (
@@ -90,8 +89,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/shuttle/abandoned)
 "bQ" = (
@@ -178,8 +176,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/abandoned)
 "dA" = (
@@ -333,8 +330,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/shuttle/abandoned)
 "gD" = (
@@ -565,8 +561,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/abandoned)
 "lZ" = (
@@ -607,8 +602,7 @@
 /area/shuttle/abandoned)
 "mA" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	tag = "icon-propulsion (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/abandoned)
@@ -645,8 +639,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/abandoned)
 "nv" = (
@@ -677,8 +670,7 @@
 /obj/item/clothing/shoes/color/blue,
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/shuttle/abandoned)
 "oy" = (
@@ -790,8 +782,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/shuttle/abandoned)
 "re" = (
@@ -975,8 +966,7 @@
 /obj/effect/decal/warning_stripes/blue/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/abandoned)
 "tQ" = (
@@ -1000,8 +990,7 @@
 	},
 /obj/machinery/door/airlock/medical,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/shuttle/abandoned)
 "ux" = (
@@ -1248,8 +1237,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/abandoned)
 "zf" = (
@@ -1395,8 +1383,7 @@
 	},
 /obj/item/clothing/under/rank/medical/purple,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/shuttle/abandoned)
 "CD" = (
@@ -1440,8 +1427,7 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/machinery/door/airlock/medical/glass,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/shuttle/abandoned)
 "DO" = (
@@ -1565,8 +1551,7 @@
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/abandoned)
 "GK" = (
@@ -1627,8 +1612,7 @@
 /area/shuttle/abandoned)
 "Il" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/shuttle/abandoned)
 "IA" = (
@@ -1689,8 +1673,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/shuttle/abandoned)
 "Jw" = (
@@ -1709,8 +1692,7 @@
 /area/shuttle/abandoned)
 "JI" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (NORTH)"
+	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/abandoned)
@@ -1959,9 +1941,7 @@
 	},
 /area/shuttle/abandoned)
 "Op" = (
-/obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (NORTH)"
-	},
+/obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
 /area/shuttle/abandoned)
 "Oq" = (
@@ -1976,8 +1956,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/shuttle/abandoned)
 "Oy" = (
@@ -2053,8 +2032,7 @@
 /area/shuttle/abandoned)
 "RU" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 4;
-	tag = "icon-propulsion (NORTH)"
+	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/abandoned)
@@ -2081,8 +2059,7 @@
 	name = "Легендарная монтировка"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/shuttle/abandoned)
 "Sm" = (
@@ -2197,8 +2174,7 @@
 /obj/effect/decal/warning_stripes/blue/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/abandoned)
 "UZ" = (
@@ -2272,8 +2248,7 @@
 /obj/machinery/power/smes,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/shuttle/abandoned)
 "WZ" = (
@@ -2311,15 +2286,13 @@
 	health = 45
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/shuttle/abandoned)
 "XH" = (
 /obj/machinery/door/airlock/medical/glass,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull";
-	tag = "icon-whitebluefull"
+	icon_state = "whitebluefull"
 	},
 /area/shuttle/abandoned)
 "XK" = (
@@ -2454,8 +2427,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/abandoned)
 

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -17,8 +17,7 @@
 	icon_state = "small"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/unpowered)
 "ae" = (
@@ -27,14 +26,12 @@
 "af" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/unpowered)
 "ag" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/ruin/unpowered)
 "ah" = (
@@ -44,8 +41,7 @@
 	},
 /obj/item/shard,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/unpowered)
 "ai" = (
@@ -101,8 +97,7 @@
 	in_use = 1
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/unpowered)
 "as" = (
@@ -136,8 +131,7 @@
 /area/ruin/unpowered)
 "ax" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/ruin/unpowered)
 "ay" = (
@@ -152,8 +146,7 @@
 /area/ruin/unpowered)
 "aA" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/ruin/unpowered)
 "aB" = (
@@ -177,8 +170,7 @@
 "aF" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/ruin/unpowered)
 "aG" = (
@@ -271,8 +263,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/ruin/unpowered)
 "aX" = (

--- a/_maps/map_files/RandomZLevels/academy.dmm
+++ b/_maps/map_files/RandomZLevels/academy.dmm
@@ -166,8 +166,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/headmaster)
 "aS" = (
@@ -308,8 +307,7 @@
 /area/awaymission/academy/headmaster)
 "bz" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	tag = "icon-vault"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "bB" = (
@@ -371,8 +369,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	tag = "icon-vault"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "bR" = (
@@ -415,8 +412,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/headmaster)
 "ca" = (
@@ -453,8 +449,7 @@
 "cl" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/headmaster)
 "cn" = (
@@ -491,8 +486,7 @@
 /obj/item/caution,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green (EAST)"
+	icon_state = "green"
 	},
 /area/awaymission/academy/academyaft)
 "cx" = (
@@ -643,8 +637,7 @@
 /obj/item/twohanded/toy/chainsaw,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "dh" = (
@@ -711,8 +704,7 @@
 /obj/machinery/portable_atmospherics/scrubber/huge/stationary,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/headmaster)
 "dr" = (
@@ -963,14 +955,12 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "green";
-	tag = "icon-green (SOUTHWEST)"
+	icon_state = "green"
 	},
 /area/awaymission/academy/classrooms)
 "en" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/awaymission/academy/classrooms)
 "ep" = (
@@ -1356,15 +1346,13 @@
 	faction = list("faithless")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	tag = "icon-vault"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "fP" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	icon_state = "vault";
-	tag = "icon-vault"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "fS" = (
@@ -1443,8 +1431,7 @@
 "gg" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "gh" = (
@@ -1463,8 +1450,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "gj" = (
@@ -1472,8 +1458,7 @@
 /obj/item/storage/belt/security,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "gk" = (
@@ -1570,8 +1555,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "gF" = (
@@ -1602,8 +1586,7 @@
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "gM" = (
@@ -1636,8 +1619,7 @@
 /obj/item/gun/energy/floragun,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "gU" = (
@@ -1698,13 +1680,6 @@
 	icon_state = "escape"
 	},
 /area/awaymission/academy/classrooms)
-"hn" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green";
-	tag = "icon-green (EAST)"
-	},
-/area/awaymission/academy/academyaft)
 "ho" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -2101,8 +2076,7 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "iJ" = (
@@ -2177,8 +2151,7 @@
 /area/awaymission/academy/academyaft)
 "iV" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l"
+	icon_state = "propulsion_l"
 	},
 /turf/space,
 /area/awaymission/academy/academyaft)
@@ -2188,8 +2161,7 @@
 /area/awaymission/academy/academyaft)
 "iX" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r"
+	icon_state = "propulsion_r"
 	},
 /turf/space,
 /area/awaymission/academy/academyaft)
@@ -2496,8 +2468,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "kx" = (
@@ -2615,8 +2586,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/headmaster)
 "kX" = (
@@ -2758,8 +2728,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/headmaster)
 "lM" = (
@@ -2864,8 +2833,7 @@
 "mD" = (
 /obj/effect/decal/remains/xeno,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/awaymission/academy/classrooms)
 "mM" = (
@@ -3137,8 +3105,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "pQ" = (
@@ -3553,8 +3520,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/headmaster)
 "ud" = (
@@ -3945,8 +3911,7 @@
 /area/awaymission/academy/classrooms)
 "xF" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/carpet/black,
 /area/awaymission/academy/headmaster)
@@ -4189,8 +4154,7 @@
 /area/awaymission/academy/academyaft)
 "zQ" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-6";
-	tag = "icon-plant-6"
+	icon_state = "plant-6"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -4418,8 +4382,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "CW" = (
@@ -5099,8 +5062,7 @@
 /obj/machinery/portable_atmospherics/scrubber/huge/stationary,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/headmaster)
 "Kp" = (
@@ -5122,8 +5084,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "Kv" = (
@@ -5150,8 +5111,7 @@
 /area/awaymission/academy/academyaft)
 "KC" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-28";
-	tag = "icon-plant-28"
+	icon_state = "plant-28"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/academyaft)
@@ -5236,8 +5196,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "Lk" = (
@@ -5281,8 +5240,7 @@
 /obj/item/restraints/handcuffs,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "LO" = (
@@ -5384,8 +5342,7 @@
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "MJ" = (
@@ -5454,8 +5411,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/skeleton/head,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/awaymission/academy/classrooms)
 "Ob" = (
@@ -5574,8 +5530,7 @@
 /area/awaymission/academy/classrooms)
 "Pe" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /turf/simulated/floor/carpet/black,
 /area/awaymission/academy/headmaster)
@@ -5756,8 +5711,7 @@
 /obj/machinery/light_construct,
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/awaymission/academy/classrooms)
 "Ro" = (
@@ -5808,8 +5762,7 @@
 /obj/item/kitchen/rollingpin,
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/classrooms)
 "RH" = (
@@ -5935,8 +5888,7 @@
 /area/awaymission/academy/classrooms)
 "SI" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/academyaft)
@@ -5959,8 +5911,7 @@
 /area/awaymission/academy/headmaster)
 "SU" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-32";
-	tag = "icon-plant-32"
+	icon_state = "plant-32"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/headmaster)
@@ -6157,8 +6108,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "vault"
 	},
 /area/awaymission/academy/classrooms)
 "Uk" = (
@@ -6422,8 +6372,7 @@
 "Xa" = (
 /obj/structure/glowshroom,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/awaymission/academy/classrooms)
 "Xb" = (
@@ -6481,8 +6430,7 @@
 	name = "Human remains"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/awaymission/academy/classrooms)
 "Xu" = (
@@ -6584,8 +6532,7 @@
 /area/awaymission/academy/academyaft)
 "YI" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-28";
-	tag = "icon-plant-28"
+	icon_state = "plant-28"
 	},
 /turf/simulated/floor/carpet/black,
 /area/awaymission/academy/headmaster)
@@ -6641,8 +6588,7 @@
 /area/awaymission/academy/academyaft)
 "Zi" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/awaymission/academy/classrooms)
@@ -11846,7 +11792,7 @@ cA
 hH
 ho
 cw
-hn
+My
 WO
 hH
 ZD

--- a/_maps/map_files/RandomZLevels/beach.dmm
+++ b/_maps/map_files/RandomZLevels/beach.dmm
@@ -114,9 +114,7 @@
 /turf/simulated/floor/indestructible/beach/water/deep/wood_floor,
 /area/awaymission/undersea)
 "aC" = (
-/obj/structure/mineral_door/wood{
-	tag = "icon-wood"
-	},
+/obj/structure/mineral_door/wood,
 /turf/simulated/floor/indestructible/beach/water/deep/wood_floor,
 /area/awaymission/undersea)
 "aD" = (
@@ -145,15 +143,13 @@
 /area/awaymission/undersea)
 "aI" = (
 /obj/structure/chair/wood/wings{
-	dir = 4;
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/indestructible/beach/water/deep/wood_floor,
 /area/awaymission/undersea)
 "aJ" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/indestructible/beach/water/deep/wood_floor,
 /area/awaymission/undersea)
@@ -229,9 +225,7 @@
 /turf/simulated/floor/indestructible/beach/water/deep/sand_floor,
 /area/awaymission/undersea)
 "aY" = (
-/obj/structure/mineral_door/wood{
-	tag = "icon-wood"
-	},
+/obj/structure/mineral_door/wood,
 /turf/simulated/floor/indestructible/beach/water/deep/sand_floor,
 /area/awaymission/undersea)
 "aZ" = (
@@ -252,8 +246,7 @@
 /obj/structure/flora/ausbushes/leafybush,
 /obj/effect/decal/snow/sand/edge{
 	dir = 9;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTHWEST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -264,8 +257,7 @@
 "be" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 5;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTHEAST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -276,8 +268,7 @@
 "bg" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 8;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (WEST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -285,8 +276,7 @@
 /obj/structure/flora/ausbushes/leafybush,
 /obj/effect/decal/snow/sand/edge{
 	dir = 4;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (EAST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -302,24 +292,21 @@
 "bk" = (
 /obj/effect/decal/snow/sand/surround{
 	dir = 1;
-	name = "rough sand";
-	tag = "icon-gravsnow_surround (NORTH)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
 "bl" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 4;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (EAST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
 "bm" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 9;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTHWEST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -332,8 +319,7 @@
 "bo" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 10;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (SOUTHWEST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/grass,
 /area/awaymission/beach)
@@ -346,24 +332,21 @@
 "bq" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 6;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (SOUTHEAST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/grass,
 /area/awaymission/beach)
 "br" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 6;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (SOUTHEAST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
 "bs" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 10;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (SOUTHWEST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -375,16 +358,14 @@
 /obj/structure/flora/ausbushes/leafybush,
 /obj/effect/decal/snow/sand/edge{
 	dir = 9;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTHWEST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand/dense,
 /area/awaymission/beach)
 "bv" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 5;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTHEAST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand/dense,
 /area/awaymission/beach)
@@ -396,16 +377,14 @@
 /obj/effect/overlay/palmtree_r,
 /obj/effect/decal/snow/sand/edge{
 	dir = 9;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTHWEST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
 "by" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 1;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTH)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -417,8 +396,7 @@
 /obj/structure/flora/ausbushes/genericbush,
 /obj/effect/decal/snow/sand/edge{
 	dir = 1;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTH)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -426,8 +404,7 @@
 /obj/effect/overlay/palmtree_r,
 /obj/effect/decal/snow/sand/edge{
 	dir = 1;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTH)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -435,8 +412,7 @@
 /obj/effect/overlay/palmtree_r,
 /obj/effect/decal/snow/sand/edge{
 	dir = 4;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (EAST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -461,16 +437,14 @@
 /obj/effect/overlay/palmtree_r,
 /obj/effect/decal/snow/sand/edge{
 	dir = 8;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (WEST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
 "bI" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 4;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (EAST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand/dense,
 /area/awaymission/beach)
@@ -478,8 +452,7 @@
 /obj/effect/overlay/palmtree_l,
 /obj/effect/decal/snow/sand/edge{
 	dir = 1;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTH)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -496,8 +469,7 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/effect/decal/snow/sand/edge{
 	dir = 1;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTH)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -601,8 +573,7 @@
 /obj/effect/overlay/coconut,
 /obj/effect/decal/snow/sand/edge{
 	dir = 1;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTH)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -668,8 +639,7 @@
 /obj/structure/flora/ausbushes/reedbush,
 /obj/effect/decal/snow/sand/edge{
 	dir = 5;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTHEAST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -709,8 +679,7 @@
 "cB" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 4;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (EAST)"
+	name = "rough sand"
 	},
 /obj/effect/overlay/palmtree_r,
 /turf/simulated/floor/indestructible/beach/sand,
@@ -723,16 +692,14 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/decal/snow/sand/edge{
 	dir = 8;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (WEST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
 "cJ" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 4;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (EAST)"
+	name = "rough sand"
 	},
 /obj/structure/closet/athletic_mixed,
 /turf/simulated/floor/indestructible/beach/sand,
@@ -740,23 +707,19 @@
 "cK" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 8;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (WEST)"
+	name = "rough sand"
 	},
 /obj/effect/overlay/palmtree_l,
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
 "cL" = (
-/obj/structure/mineral_door/wood{
-	tag = "icon-wood"
-	},
+/obj/structure/mineral_door/wood,
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
 "cN" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 4;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (EAST)"
+	name = "rough sand"
 	},
 /obj/item/clothing/shoes/sandal,
 /obj/item/clothing/shoes/sandal,
@@ -891,8 +854,7 @@
 "do" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 1;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTH)"
+	name = "rough sand"
 	},
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/indestructible/beach/sand,
@@ -934,15 +896,12 @@
 /obj/effect/overlay/palmtree_r,
 /obj/effect/decal/snow/sand/edge{
 	dir = 10;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (SOUTHWEST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
 "dA" = (
-/obj/structure/mineral_door/wood{
-	tag = "icon-wood"
-	},
+/obj/structure/mineral_door/wood,
 /turf/simulated/floor/indestructible{
 	icon_state = "wood"
 	},
@@ -983,8 +942,7 @@
 "dH" = (
 /obj/effect/decal/snow/sand/edge{
 	dir = 1;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (NORTH)"
+	name = "rough sand"
 	},
 /obj/structure/chair/stool/bar,
 /turf/simulated/floor/indestructible/beach/sand,
@@ -1033,8 +991,7 @@
 /obj/effect/overlay/palmtree_r,
 /obj/effect/decal/snow/sand/edge{
 	dir = 6;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (SOUTHEAST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)
@@ -1067,8 +1024,7 @@
 /obj/effect/overlay/palmtree_l,
 /obj/effect/decal/snow/sand/edge{
 	dir = 8;
-	name = "rough sand";
-	tag = "icon-gravsnow_corner (WEST)"
+	name = "rough sand"
 	},
 /turf/simulated/floor/indestructible/beach/sand,
 /area/awaymission/beach)

--- a/_maps/map_files/RandomZLevels/blackmarketpackers.dmm
+++ b/_maps/map_files/RandomZLevels/blackmarketpackers.dmm
@@ -97,8 +97,7 @@
 "aw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /mob/living/simple_animal/hostile/poison/giant_spider{
 	health = 250;
@@ -122,13 +121,6 @@
 	icon_state = "wood-broken3"
 	},
 /area/awaymission/BMPship/CommonArea)
-"az" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/BMPship/Engines)
 "aA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -173,8 +165,7 @@
 "aF" = (
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/power/smes/magical{
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit.";
@@ -206,8 +197,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -323,8 +313,7 @@
 	on = 0
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/awaymission/BMPship/Fore)
 "bm" = (
@@ -344,8 +333,7 @@
 /area/awaymission/BMPship/Fore)
 "bo" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /mob/living/simple_animal/lizard,
 /obj/effect/decal/warning_stripes/red/partial{
@@ -355,8 +343,7 @@
 /area/awaymission/BMPship/Gate)
 "bp" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel,
@@ -374,8 +361,7 @@
 "bs" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -383,8 +369,7 @@
 "bt" = (
 /obj/machinery/door/airlock/silver,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/restraints/legcuffs/beartrap{
 	armed = 1
@@ -444,8 +429,7 @@
 	},
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -488,8 +472,7 @@
 "bJ" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/closet/crate/large,
 /obj/effect/decal/cleanable/dirt,
@@ -510,8 +493,7 @@
 /obj/item/clothing/suit/xenos,
 /obj/item/clothing/head/xenos,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/instrument/xylophone,
 /turf/simulated/floor/plasteel,
@@ -557,8 +539,7 @@
 /area/awaymission/BMPship/Fore)
 "bR" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/pen/multi/gold,
@@ -570,8 +551,7 @@
 	layer = 2.8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/awaymission/BMPship/Fore)
 "bT" = (
@@ -589,8 +569,7 @@
 "bU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/awaymission/BMPship/Containment)
@@ -622,8 +601,7 @@
 	locked = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 3.3
@@ -673,14 +651,12 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "carpetside";
-	tag = "icon-carpetside (NORTH)"
+	icon_state = "carpetside"
 	},
 /area/awaymission/BMPship/Fore)
 "ch" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -718,8 +694,7 @@
 /area/awaymission/BMPship/Armory)
 "cq" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -790,8 +765,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -846,8 +820,7 @@
 /obj/item/trash/popcorn,
 /obj/item/trash/popcorn,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/TurretsSouth)
@@ -879,8 +852,7 @@
 /area/awaymission/BMPship/Containment)
 "cM" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/computerframe,
@@ -932,15 +904,13 @@
 /area/awaymission/BMPship/Containment)
 "cS" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/vault,
 /area/awaymission/BMPship/Buffer)
@@ -985,8 +955,7 @@
 /area/awaymission/BMPship/Kitchen)
 "cY" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plating/airless,
@@ -1098,8 +1067,7 @@
 "dr" = (
 /obj/structure/alien/weeds,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship/Fore)
@@ -1120,8 +1088,7 @@
 	pixel_y = 1
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
 /area/awaymission/BMPship/Buffer)
@@ -1196,8 +1163,7 @@
 	opened = 1
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -1313,8 +1279,7 @@
 "dO" = (
 /obj/machinery/door/airlock/silver,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 2.8
@@ -1446,8 +1411,7 @@
 /area/awaymission/BMPship/Containment)
 "ek" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/spider/cocoon,
 /obj/effect/decal/cleanable/dirt,
@@ -1493,8 +1457,7 @@
 	layer = 3.1
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/awaymission/BMPship/Fore)
 "en" = (
@@ -1586,8 +1549,7 @@
 "eD" = (
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/awaymission/BMPship/CommonArea)
 "eE" = (
@@ -1609,8 +1571,7 @@
 /obj/item/clothing/head/chicken,
 /obj/item/laser_pointer,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/instrument/trombone,
 /turf/simulated/floor/plasteel,
@@ -1633,8 +1594,7 @@
 /area/awaymission/BMPship/CommonArea)
 "eL" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 4;
-	tag = "icon-heater (EAST)"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1699,8 +1659,7 @@
 /obj/item/storage/bag/fish,
 /obj/item/storage/firstaid/aquatic_kit/full,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -1715,12 +1674,10 @@
 /area/awaymission/BMPship/Gate)
 "eV" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/BMPship/Bath)
@@ -1749,8 +1706,7 @@
 /area/awaymission/BMPship/Fore)
 "eZ" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/alien/weeds,
 /obj/structure/alien/resin,
@@ -1779,15 +1735,13 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/Buffer)
 "fe" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/Buffer)
@@ -1796,16 +1750,13 @@
 /area/awaymission/BMPship/Buffer)
 "fg" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/BMPship/Engines)
@@ -1849,8 +1800,7 @@
 /area/awaymission/BMPship/CommonArea)
 "fk" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
 /area/awaymission/BMPship/Buffer)
@@ -1877,8 +1827,7 @@
 /area/awaymission/BMPship/CommonArea)
 "fp" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1918,14 +1867,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "barber";
-	tag = "icon-barber"
+	icon_state = "barber"
 	},
 /area/awaymission/BMPship/Kitchen)
 "fu" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/alien/weeds,
 /obj/structure/spider/stickyweb,
@@ -1960,8 +1907,7 @@
 "fx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -1989,8 +1935,7 @@
 /area/awaymission/BMPship/CommonArea)
 "fA" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor{
 	layer = 2.71;
@@ -2022,12 +1967,10 @@
 /area/awaymission/BMPship/Containment)
 "fE" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -2065,8 +2008,7 @@
 /area/awaymission/BMPship/Fore)
 "fJ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/Gate)
@@ -2091,8 +2033,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_construct/small,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/awaymission/BMPship/Containment)
@@ -2123,8 +2064,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "barber";
-	tag = "icon-barber"
+	icon_state = "barber"
 	},
 /area/awaymission/BMPship/Kitchen)
 "fT" = (
@@ -2136,12 +2076,10 @@
 /area/awaymission/BMPship/CommonArea)
 "fU" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/cocoon,
@@ -2160,8 +2098,7 @@
 /area/awaymission)
 "fY" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/alien/weeds,
 /obj/item/gun/syringe{
@@ -2176,8 +2113,7 @@
 /area/awaymission/BMPship/Fore)
 "fZ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plating/airless,
@@ -2246,8 +2182,7 @@
 /area/awaymission/BMPship/Fore)
 "gi" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/titanium{
 	locked = 1
@@ -2257,8 +2192,7 @@
 /area/awaymission/BMPship/Fore)
 "gk" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -2290,8 +2224,7 @@
 /area/awaymission/BMPship/Engines)
 "gn" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/gateway{
 	dir = 4
@@ -2314,8 +2247,7 @@
 /area/awaymission/BMPship/Gate)
 "gr" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/alien/weeds/node,
 /obj/structure/alien/resin,
@@ -2327,8 +2259,7 @@
 /area/awaymission/BMPship/Fore)
 "gt" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating/airless,
@@ -2375,15 +2306,13 @@
 	icon_state = "small"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship/Fore)
 "gC" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/item/stack/tile/plasteel,
 /turf/simulated/floor/plating/airless,
@@ -2413,8 +2342,7 @@
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/awaymission/BMPship/Containment)
@@ -2450,8 +2378,7 @@
 "gL" = (
 /obj/machinery/processor,
 /turf/simulated/floor/plasteel{
-	icon_state = "barber";
-	tag = "icon-barber"
+	icon_state = "barber"
 	},
 /area/awaymission/BMPship/Kitchen)
 "gM" = (
@@ -2471,8 +2398,7 @@
 /area/awaymission)
 "gQ" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/stack/tile/plasteel,
 /turf/simulated/floor/plating/airless,
@@ -2589,8 +2515,7 @@
 /area/awaymission)
 "hk" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/silver,
 /turf/simulated/floor/plating/airless,
@@ -2612,12 +2537,10 @@
 /obj/effect/mapping_helpers/turfs/burn,
 /obj/structure/spider/stickyweb,
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "barber";
-	tag = "icon-barber"
+	icon_state = "barber"
 	},
 /area/awaymission/BMPship/Kitchen)
 "ht" = (
@@ -2656,8 +2579,7 @@
 /area/awaymission/BMPship/Dormitories)
 "hy" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/silver{
 	locked = 1
@@ -2670,8 +2592,7 @@
 /area/awaymission/BMPship/Fore)
 "hz" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/reagent_containers/food/snacks/monstermeat/spiderleg,
@@ -2757,8 +2678,7 @@
 "hR" = (
 /obj/item/hand_labeler,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/stack/sheet/wood,
 /obj/item/stack/sheet/wood,
@@ -2781,8 +2701,7 @@
 /obj/item/trash/raisins,
 /obj/item/trash/raisins,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/TurretsSouth)
@@ -2800,12 +2719,10 @@
 /area/awaymission/BMPship/Fore)
 "hV" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/red/partial{
 	dir = 8
@@ -2899,8 +2816,7 @@
 /area/awaymission/BMPship/Engines)
 "il" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/airless,
@@ -3161,8 +3077,7 @@
 /area/awaymission/BMPship/Engines)
 "jh" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes/red/partial{
 	dir = 8
@@ -3177,8 +3092,7 @@
 /area/awaymission/BMPship/MedBay)
 "jj" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/closet/crate/large/schrodinger,
 /turf/simulated/floor/plating,
@@ -3240,8 +3154,7 @@
 /area/awaymission/BMPship/Engines)
 "jw" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
 	locked = 1
@@ -3267,8 +3180,7 @@
 /obj/item/reagent_containers/food/snacks/candy/confectionery/caramel_nougat,
 /obj/item/reagent_containers/food/snacks/candy/confectionery/toffee,
 /turf/simulated/floor/plasteel{
-	icon_state = "barber";
-	tag = "icon-barber"
+	icon_state = "barber"
 	},
 /area/awaymission/BMPship/Kitchen)
 "jF" = (
@@ -3308,8 +3220,7 @@
 	locked = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 2.8
@@ -3345,8 +3256,7 @@
 /area/awaymission/BMPship/Bath)
 "kc" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -3384,8 +3294,7 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/awaymission/BMPship/Containment)
@@ -3424,8 +3333,7 @@
 "kK" = (
 /obj/machinery/door/airlock/silver,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -3436,8 +3344,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/cocoon,
@@ -3556,8 +3463,7 @@
 /area/awaymission/BMPship/TurretsNorth)
 "lR" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/TurretsNorth)
@@ -3661,8 +3567,7 @@
 "mA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/machinery/light_construct/small{
 	dir = 1
@@ -3704,12 +3609,10 @@
 "mY" = (
 /obj/machinery/light_construct/small,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/Buffer)
@@ -3732,8 +3635,7 @@
 /area/awaymission/BMPship/Gate)
 "nB" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/TurretsNorth)
@@ -3760,8 +3662,7 @@
 /area/awaymission/BMPship/TraderShuttle)
 "nH" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/spider/stickyweb,
 /obj/structure/cable{
@@ -3786,8 +3687,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_construct/small,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -3826,12 +3726,10 @@
 /area/awaymission/BMPship/Gate)
 "oe" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -3861,8 +3759,7 @@
 "op" = (
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
-	icon_state = "barber";
-	tag = "icon-barber"
+	icon_state = "barber"
 	},
 /area/awaymission/BMPship/Kitchen)
 "or" = (
@@ -3874,8 +3771,7 @@
 /area/awaymission/BMPship/Gate)
 "os" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -4019,8 +3915,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/spider/stickyweb,
 /obj/machinery/power/apc/noalarm{
@@ -4111,8 +4006,7 @@
 /obj/structure/alien/weeds,
 /obj/structure/alien/resin,
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship/Fore)
@@ -4177,13 +4071,11 @@
 /area/awaymission/BMPship/Fore)
 "qC" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/power/smes/magical{
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit.";
@@ -4194,8 +4086,7 @@
 /area/awaymission/BMPship/Engines)
 "qF" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -4288,8 +4179,7 @@
 /area/awaymission/BMPship/CommonArea)
 "rB" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/TurretsSouth)
@@ -4331,8 +4221,7 @@
 /area/awaymission)
 "sa" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -4350,8 +4239,7 @@
 	anchored = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -4367,8 +4255,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/BMPship/Bath)
@@ -4418,8 +4305,7 @@
 /area/awaymission/BMPship/MedBay)
 "sP" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -4467,12 +4353,10 @@
 /area/awaymission/BMPship/Bath)
 "tb" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/BMPship/Bath)
@@ -4484,18 +4368,9 @@
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/mineral/plastitanium/red/airless,
 /area/awaymission/BMPship/TraderShuttle)
-"tf" = (
-/obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/awaymission/BMPship/Containment)
 "tt" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -4510,8 +4385,7 @@
 "tx" = (
 /obj/effect/decal/warning_stripes/white/partial,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -4523,8 +4397,7 @@
 /area/awaymission/BMPship/Dormitories)
 "ty" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 4;
-	tag = "icon-propulsion (WEST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/awaymission/BMPship/Gate)
@@ -4555,8 +4428,7 @@
 /area/awaymission/BMPship/Containment)
 "tM" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -4635,8 +4507,7 @@
 /area/awaymission/BMPship/Dormitories)
 "uB" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/rack,
 /obj/item/storage/belt/utility/full,
@@ -4679,8 +4550,7 @@
 "uS" = (
 /obj/machinery/door/airlock/titanium,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 2.8
@@ -4693,8 +4563,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -4727,8 +4596,7 @@
 	layer = 2.6
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/awaymission/BMPship/Armory)
 "vl" = (
@@ -4778,30 +4646,19 @@
 "vL" = (
 /obj/effect/spawner/random_spawners/rodent,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellowalt"
 	},
 /area/awaymission/BMPship/Dormitories)
-"vO" = (
-/obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/awaymission/BMPship/Containment)
 "vV" = (
 /obj/machinery/door/airlock/titanium{
 	locked = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 3.3
@@ -5073,8 +4930,7 @@
 /area/awaymission/BMPship/Containment)
 "xQ" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -5210,12 +5066,10 @@
 /area/awaymission/BMPship/CommonArea)
 "zs" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
@@ -5292,8 +5146,7 @@
 /area/awaymission/BMPship/Shelter)
 "Af" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -5328,8 +5181,7 @@
 /area/space)
 "Az" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -5419,8 +5271,7 @@
 	layer = 2.8
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/vault,
 /area/awaymission/BMPship/Fore)
@@ -5459,8 +5310,7 @@
 /area/awaymission/BMPship/Kitchen)
 "BL" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/spider/cocoon,
 /obj/effect/decal/cleanable/dirt,
@@ -5477,8 +5327,7 @@
 /area/awaymission/BMPship/Engines)
 "BS" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -5487,8 +5336,7 @@
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/awaymission/BMPship/Containment)
@@ -5497,8 +5345,7 @@
 	locked = 1
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 3.3
@@ -5512,8 +5359,7 @@
 /area/awaymission/BMPship/Gate)
 "Ck" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
@@ -5533,8 +5379,7 @@
 "Cy" = (
 /obj/effect/spawner/random_spawners/rodent,
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
@@ -5568,8 +5413,7 @@
 /area/awaymission/BMPship/CommonArea)
 "Dh" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -5631,8 +5475,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "barber";
-	tag = "icon-barber"
+	icon_state = "barber"
 	},
 /area/awaymission/BMPship/Kitchen)
 "Dx" = (
@@ -5727,8 +5570,7 @@
 /area/awaymission/BMPship/Kitchen)
 "Eo" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plating,
@@ -5738,12 +5580,10 @@
 /obj/item/trash/fried_vox,
 /mob/living/basic/cockroach,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "barber";
-	tag = "icon-barber"
+	icon_state = "barber"
 	},
 /area/awaymission/BMPship/Kitchen)
 "Et" = (
@@ -5752,8 +5592,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/awaymission/BMPship/Containment)
@@ -5790,8 +5629,7 @@
 "EB" = (
 /obj/item/stack/cable_coil,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/TurretsNorth)
@@ -5913,8 +5751,7 @@
 /area/awaymission/BMPship/Dormitories)
 "FL" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 4;
-	tag = "icon-heater (EAST)"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5947,8 +5784,7 @@
 /area/awaymission/BMPship/Armory)
 "Gj" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/Gate)
@@ -5993,8 +5829,7 @@
 /area/awaymission/BMPship/Containment)
 "Gv" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/TurretsSouth)
@@ -6069,8 +5904,7 @@
 "GV" = (
 /obj/structure/closet/crate/large,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/Gate)
@@ -6098,14 +5932,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/Gate)
-"Hg" = (
-/obj/machinery/door/airlock/silver,
-/obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/BMPship/CommonArea)
 "Hl" = (
 /obj/item/stack/tile/plasteel,
 /obj/effect/decal/cleanable/dirt,
@@ -6126,8 +5952,7 @@
 /area/awaymission/BMPship/CommonArea)
 "Hu" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
@@ -6202,8 +6027,7 @@
 /area/awaymission/BMPship/Containment)
 "Io" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/storage/box,
 /obj/structure/cable{
@@ -6216,8 +6040,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
@@ -6296,8 +6119,7 @@
 "IJ" = (
 /obj/effect/decal/warning_stripes/white/partial,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -6313,8 +6135,7 @@
 "IX" = (
 /obj/item/healthanalyzer/advanced,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship/MedBay)
@@ -6325,8 +6146,7 @@
 /obj/structure/alien/weeds/node,
 /obj/structure/alien/weeds,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /mob/living/simple_animal/hostile/alien/sentinel{
 	health = 250;
@@ -6391,8 +6211,7 @@
 "Kd" = (
 /obj/machinery/door/airlock/titanium,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 2.8
@@ -6481,8 +6300,7 @@
 /area/awaymission/BMPship/Engines)
 "Ll" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
@@ -6496,16 +6314,14 @@
 /area/awaymission/BMPship/Bath)
 "Lt" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship/Engines)
 "Lu" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer,
@@ -6562,20 +6378,17 @@
 /area/awaymission)
 "Mi" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 4;
-	tag = "icon-propulsion (WEST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/awaymission/BMPship/Bath)
 "Ms" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/spider/stickyweb,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -6681,8 +6494,7 @@
 	anchored = 1
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/awaymission/BMPship/Containment)
@@ -6756,8 +6568,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -6820,8 +6631,7 @@
 /area/space)
 "PL" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/plasteel{
@@ -6867,8 +6677,7 @@
 /obj/item/clothing/suit/corgisuit,
 /obj/item/laser_pointer,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/instrument/accordion,
 /turf/simulated/floor/plasteel,
@@ -6902,8 +6711,7 @@
 "Qk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -6945,8 +6753,7 @@
 /area/awaymission/BMPship/TraderShuttle)
 "QO" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/spawner/random_spawners/rodent,
 /obj/structure/spider/stickyweb,
@@ -6997,8 +6804,7 @@
 "Ra" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -7040,8 +6846,7 @@
 /area/awaymission/BMPship/TraderShuttle)
 "RF" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -7054,8 +6859,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/vault,
 /area/awaymission/BMPship/Buffer)
@@ -7120,8 +6924,7 @@
 /area/awaymission/BMPship/Armory)
 "SF" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 4;
-	tag = "icon-propulsion (WEST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/awaymission/BMPship/Engines)
@@ -7182,8 +6985,7 @@
 /area/awaymission/BMPship/TurretsNorth)
 "TI" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter{
@@ -7205,8 +7007,7 @@
 /area/awaymission/BMPship/MedBay)
 "TU" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -7309,8 +7110,7 @@
 /area/awaymission/BMPship/TurretsNorth)
 "UZ" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/south,
 /obj/effect/decal/cleanable/dirt,
@@ -7458,14 +7258,12 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green (EAST)"
+	icon_state = "green"
 	},
 /area/awaymission/BMPship/Kitchen)
 "Wi" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/stock_parts/cell/empty,
 /turf/simulated/floor/engine,
@@ -7476,8 +7274,7 @@
 /area/awaymission/BMPship/Gate)
 "WC" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 4;
-	tag = "icon-heater (EAST)"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -7513,8 +7310,7 @@
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/awaymission/BMPship/Containment)
@@ -7547,8 +7343,7 @@
 /area/awaymission/BMPship/MedBay)
 "Xj" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/hand_labeler,
 /turf/simulated/floor/plating,
@@ -7566,8 +7361,7 @@
 /area/awaymission/BMPship/Fore)
 "XB" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/alien/weeds,
 /obj/structure/alien/resin,
@@ -7592,12 +7386,10 @@
 /area/awaymission/BMPship/CommonArea)
 "XJ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -7609,8 +7401,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_construct/small,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -7645,8 +7436,7 @@
 /area/awaymission/BMPship/Armory)
 "XY" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/BMPship/Engines)
@@ -7701,8 +7491,7 @@
 "YL" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -7725,8 +7514,7 @@
 "YU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -7780,8 +7568,7 @@
 /area/awaymission/BMPship/Mining)
 "ZM" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -16058,8 +15845,8 @@ Gq
 Vd
 UQ
 VG
-vO
-vO
+MN
+MN
 NZ
 UQ
 va
@@ -16838,7 +16625,7 @@ er
 er
 mA
 ej
-vO
+MN
 MN
 VD
 nO
@@ -17098,7 +16885,7 @@ Pu
 xO
 ej
 ej
-tf
+Ue
 bU
 qK
 gd
@@ -17488,7 +17275,7 @@ Tv
 er
 PO
 kn
-tf
+Ue
 ku
 kn
 kn
@@ -17618,7 +17405,7 @@ Dr
 oy
 kn
 kn
-tf
+Ue
 Ue
 kn
 kn
@@ -18658,7 +18445,7 @@ XQ
 XQ
 XQ
 XQ
-Hg
+Sd
 Sd
 XQ
 XQ
@@ -21126,7 +20913,7 @@ Eh
 jg
 OI
 DT
-az
+Uy
 qC
 Uy
 vH

--- a/_maps/map_files/RandomZLevels/centcomAway.dmm
+++ b/_maps/map_files/RandomZLevels/centcomAway.dmm
@@ -66,7 +66,6 @@
 "al" = (
 /obj/structure/closet/chefcloset,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -74,7 +73,6 @@
 "am" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -83,7 +81,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -93,7 +90,6 @@
 /obj/item/reagent_containers/food/condiment/peppermill,
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -102,7 +98,6 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -114,7 +109,6 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -124,7 +118,6 @@
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -137,7 +130,6 @@
 	},
 /obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -182,7 +174,6 @@
 /area/awaymission/centcomAway/cafe)
 "ay" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -213,7 +204,6 @@
 "aC" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -270,7 +260,6 @@
 "aL" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull";
 	icon_state = "redyellowfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -296,7 +285,6 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -374,7 +362,6 @@
 "aZ" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -409,7 +396,6 @@
 "be" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -417,7 +403,6 @@
 "bf" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -425,7 +410,6 @@
 "bg" = (
 /obj/structure/sink,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -433,7 +417,6 @@
 "bh" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -444,7 +427,6 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -501,7 +483,6 @@
 /obj/machinery/chem_dispenser,
 /obj/item/storage/box/beakers,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -512,7 +493,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -529,7 +509,6 @@
 /area/awaymission/centcomAway/hangar)
 "bu" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHWEST)";
 	icon_state = "vault";
 	dir = 9
 	},
@@ -670,7 +649,6 @@
 "bT" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -681,7 +659,6 @@
 "bV" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -825,7 +802,6 @@
 /obj/item/paper_bin,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull";
 	icon_state = "redyellowfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -833,7 +809,6 @@
 /obj/item/clipboard,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull";
 	icon_state = "redyellowfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -844,7 +819,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/southright,
 /turf/simulated/floor/plasteel{
-	tag = "icon-greenfull (NORTH)";
 	icon_state = "greenfull";
 	dir = 1
 	},
@@ -899,8 +873,7 @@
 "cz" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/maint)
@@ -912,8 +885,7 @@
 /area/awaymission/centcomAway/hangar)
 "cB" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/maint)
@@ -970,38 +942,32 @@
 "cL" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/centcomAway/maint)
 "cM" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/maint)
 "cN" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/awaymission/centcomAway/maint)
 "cO" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -1042,7 +1008,6 @@
 /obj/item/pen,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull";
 	icon_state = "redyellowfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1251,7 +1216,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHWEST)";
 	icon_state = "vault";
 	dir = 9
 	},
@@ -1268,7 +1232,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/northright,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1303,7 +1266,6 @@
 /area/awaymission/centcomAway/hangar)
 "dG" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
 	icon_state = "vault";
 	dir = 4
 	},
@@ -1311,27 +1273,23 @@
 "dH" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "dI" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "dJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "dK" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1375,8 +1333,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/maint)
@@ -1405,12 +1362,10 @@
 /area/awaymission/centcomAway/hangar)
 "dU" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -1493,8 +1448,7 @@
 /area/awaymission/centcomAway/hangar)
 "eh" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -1510,7 +1464,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1518,7 +1471,6 @@
 /obj/machinery/chem_dispenser,
 /obj/item/storage/box/beakers,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1531,7 +1483,6 @@
 "em" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1550,7 +1501,6 @@
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull";
 	icon_state = "redyellowfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1559,14 +1509,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "er" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1589,7 +1537,6 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1599,7 +1546,6 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1633,7 +1579,6 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1746,7 +1691,6 @@
 "eS" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1812,7 +1756,6 @@
 "fe" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid11";
 	name = "plating";
 	icon_state = "asteroid11"
 	},
@@ -1820,7 +1763,6 @@
 "ff" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid2";
 	name = "plating";
 	icon_state = "asteroid2"
 	},
@@ -1850,7 +1792,6 @@
 "fi" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid";
 	name = "plating";
 	icon_state = "asteroid"
 	},
@@ -1861,7 +1802,6 @@
 "fk" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid3";
 	name = "plating";
 	icon_state = "asteroid3"
 	},
@@ -1877,7 +1817,6 @@
 "fn" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid10";
 	name = "plating";
 	icon_state = "asteroid10"
 	},
@@ -1885,7 +1824,6 @@
 "fo" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid9";
 	name = "plating";
 	icon_state = "asteroid9"
 	},
@@ -1916,14 +1854,12 @@
 "fs" = (
 /obj/structure/closet/chefcloset,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
 "ft" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1933,7 +1869,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1942,7 +1877,6 @@
 /obj/item/reagent_containers/food/condiment/peppermill,
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1950,7 +1884,6 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -1997,7 +1930,6 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -2009,7 +1941,6 @@
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -2066,7 +1997,6 @@
 	},
 /obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/awaymission/centcomAway/cafe)
@@ -2140,7 +2070,6 @@
 /area/awaymission/centcomAway/courtroom)
 "fY" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -2150,7 +2079,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -2163,7 +2091,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -2287,7 +2214,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -2452,8 +2378,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/maint)
@@ -2468,8 +2393,7 @@
 "gS" = (
 /obj/machinery/light,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/maint)
@@ -2501,8 +2425,7 @@
 /area/awaymission/centcomAway/hangar)
 "gZ" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/maint)
@@ -2537,8 +2460,7 @@
 	req_access = list(10)
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/general)
@@ -2560,15 +2482,13 @@
 /area/awaymission/centcomAway/general)
 "hi" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
 "hj" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -2612,7 +2532,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -2775,8 +2694,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow";
@@ -2852,7 +2770,6 @@
 /area/awaymission/centcomAway/hangar)
 "hY" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-blackcorner (NORTH)";
 	icon_state = "blackcorner";
 	dir = 1
 	},
@@ -2862,7 +2779,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-blackcorner (EAST)";
 	icon_state = "blackcorner";
 	dir = 4
 	},
@@ -2940,8 +2856,7 @@
 /area/awaymission/centcomAway/courtroom)
 "ik" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
@@ -2969,12 +2884,10 @@
 /area/awaymission/centcomAway/general)
 "io" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
@@ -3157,8 +3070,7 @@
 /area/awaymission/centcomAway/hangar)
 "iO" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -3173,8 +3085,7 @@
 /area/awaymission/centcomAway/hangar)
 "iQ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -3199,12 +3110,10 @@
 /area/awaymission/centcomAway/general)
 "iU" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
@@ -3214,8 +3123,7 @@
 	in_use = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -3231,8 +3139,7 @@
 /area/awaymission/centcomAway/general)
 "iX" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -3241,11 +3148,9 @@
 /area/awaymission/centcomAway/general)
 "iY" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-purplecorner (EAST)";
 	icon_state = "purplecorner";
 	dir = 4
 	},
@@ -3271,12 +3176,10 @@
 /area/awaymission/centcomAway/courtroom)
 "jc" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/centcomAway/general)
@@ -3292,22 +3195,18 @@
 	in_use = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-purple (NORTH)";
 	icon_state = "purple";
 	dir = 1
 	},
 /area/awaymission/centcomAway/general)
 "jf" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-purple (NORTH)";
 	icon_state = "purple";
 	dir = 1
 	},
@@ -3406,8 +3305,7 @@
 /area/awaymission/centcomAway/hangar)
 "jq" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -3416,8 +3314,7 @@
 /area/awaymission/centcomAway/hangar)
 "jr" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/awaymission/centcomAway/hangar)
@@ -3426,8 +3323,7 @@
 	req_access = list(101)
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/centcomAway/maint)
@@ -3487,12 +3383,10 @@
 /area/awaymission/centcomAway/general)
 "jB" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -3608,7 +3502,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-blackcorner (WEST)";
 	icon_state = "blackcorner";
 	dir = 8
 	},
@@ -3636,7 +3529,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-blackcorner";
 	icon_state = "blackcorner"
 	},
 /area/awaymission/centcomAway/general)
@@ -3961,8 +3853,7 @@
 /area/awaymission/centcomAway/hangar)
 "kT" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -4013,7 +3904,6 @@
 /obj/item/flash,
 /obj/item/flash,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
 	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
@@ -4021,14 +3911,12 @@
 /obj/structure/table,
 /obj/item/mmi,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
 	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
 "kZ" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "green"
@@ -4037,21 +3925,17 @@
 "la" = (
 /obj/machinery/light,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-blackcorner";
 	icon_state = "blackcorner"
 	},
 /area/awaymission/centcomAway/general)
 "lb" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-blackcorner (WEST)";
 	icon_state = "blackcorner";
 	dir = 8
 	},
@@ -4093,7 +3977,6 @@
 "lh" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -4146,7 +4029,6 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (WEST)";
 	icon_state = "vault";
 	dir = 8
 	},
@@ -4154,7 +4036,6 @@
 "lp" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
 	icon_state = "vault";
 	dir = 4
 	},
@@ -4199,8 +4080,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "asteroid6";
-	name = "sand";
-	tag = "icon-asteroid6"
+	name = "sand"
 	},
 /area/awaymission/centcomAway/general)
 "lv" = (
@@ -4247,7 +4127,6 @@
 /area/awaymission/centcomAway/general)
 "lA" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (WEST)";
 	icon_state = "vault";
 	dir = 8
 	},
@@ -4276,7 +4155,6 @@
 "lF" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -4284,7 +4162,6 @@
 "lG" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -4328,16 +4205,8 @@
 	icon_state = "dark"
 	},
 /area/awaymission/centcomAway/hangar)
-"lL" = (
-/turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
-	icon_state = "vault";
-	dir = 5
-	},
-/area/awaymission/centcomAway/hangar)
 "lM" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-ironsand3 (WEST)";
 	icon_state = "ironsand3";
 	dir = 8;
 	heat_capacity = 1
@@ -4348,7 +4217,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -4358,7 +4226,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -4420,7 +4287,6 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
 	icon_state = "vault";
 	dir = 1
 	},
@@ -4428,7 +4294,6 @@
 "lV" = (
 /obj/structure/closet/wardrobe/red,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
 	icon_state = "vault";
 	dir = 4
 	},
@@ -4436,7 +4301,6 @@
 "lW" = (
 /obj/structure/mecha_wreckage/seraph,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -4444,7 +4308,6 @@
 "lX" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -4454,14 +4317,12 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/russian/ranged)
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
 /area/awaymission/centcomAway/general)
 "lZ" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-ironsand11 (WEST)";
 	icon_state = "ironsand11";
 	dir = 8;
 	heat_capacity = 1
@@ -4482,14 +4343,12 @@
 "mc" = (
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
 	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/centcomAway/general)
 "md" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-ironsand9 (WEST)";
 	icon_state = "ironsand9";
 	dir = 8;
 	heat_capacity = 1
@@ -4572,7 +4431,6 @@
 /area/awaymission/centcomAway/general)
 "mm" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
 	icon_state = "vault";
 	dir = 4
 	},
@@ -4584,14 +4442,12 @@
 	pixel_x = 25
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
 	icon_state = "vault";
 	dir = 1
 	},
 /area/awaymission/centcomAway/hangar)
 "mo" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-ironsand4 (WEST)";
 	icon_state = "ironsand4";
 	dir = 8;
 	heat_capacity = 1
@@ -4622,7 +4478,6 @@
 "mt" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
 	icon_state = "vault";
 	dir = 1
 	},
@@ -4632,7 +4487,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -4687,7 +4541,6 @@
 /obj/item/stamp/granted,
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
 	icon_state = "vault";
 	dir = 4
 	},
@@ -4699,7 +4552,6 @@
 "mF" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (WEST)";
 	icon_state = "vault";
 	dir = 8
 	},
@@ -4724,7 +4576,6 @@
 /obj/structure/table,
 /obj/item/bot_assembly/firstaid_arm_assembly,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
 	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
@@ -4745,7 +4596,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
 	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
@@ -4753,7 +4603,6 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault";
 	icon_state = "vault"
 	},
 /area/awaymission/centcomAway/hangar)
@@ -4775,14 +4624,12 @@
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
 	icon_state = "asteroid6";
-	name = "sand";
-	tag = "icon-asteroid6"
+	name = "sand"
 	},
 /area/awaymission/centcomAway/general)
 "mP" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid10";
 	name = "plating";
 	icon_state = "asteroid10"
 	},
@@ -4791,14 +4638,12 @@
 /obj/structure/sink/puddle,
 /turf/simulated/floor/plasteel{
 	icon_state = "asteroid6";
-	name = "sand";
-	tag = "icon-asteroid6"
+	name = "sand"
 	},
 /area/awaymission/centcomAway/general)
 "mR" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid4";
 	name = "plating";
 	icon_state = "asteroid4"
 	},
@@ -4840,7 +4685,6 @@
 "mW" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid";
 	name = "plating";
 	icon_state = "asteroid"
 	},
@@ -4848,7 +4692,6 @@
 "mX" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid9";
 	name = "plating";
 	icon_state = "asteroid9"
 	},
@@ -4864,7 +4707,6 @@
 "mZ" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid11";
 	name = "plating";
 	icon_state = "asteroid11"
 	},
@@ -4872,7 +4714,6 @@
 "na" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid8";
 	name = "plating";
 	icon_state = "asteroid8"
 	},
@@ -4946,8 +4787,7 @@
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "asteroid8";
-	name = "sand";
-	tag = "icon-asteroid8 (SOUTHEAST)"
+	name = "sand"
 	},
 /area/awaymission/centcomAway/general)
 "nk" = (
@@ -4957,8 +4797,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "asteroid6";
-	name = "sand";
-	tag = "icon-asteroid6"
+	name = "sand"
 	},
 /area/awaymission/centcomAway/general)
 "nl" = (
@@ -4967,7 +4806,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid";
 	name = "plating";
 	icon_state = "asteroid"
 	},
@@ -4975,7 +4813,6 @@
 "nm" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/plasteel{
-	tag = "icon-asteroid5";
 	name = "plating";
 	icon_state = "asteroid5"
 	},
@@ -5046,7 +4883,6 @@
 /obj/structure/table/reinforced,
 /obj/item/paper/pamphlet/ccaInfo,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
 	icon_state = "vault";
 	dir = 4
 	},
@@ -5064,7 +4900,6 @@
 "nw" = (
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
 	icon_state = "vault";
 	dir = 1
 	},
@@ -5100,7 +4935,6 @@
 "nB" = (
 /obj/machinery/computer/card,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
 	icon_state = "vault";
 	dir = 1
 	},
@@ -5115,7 +4949,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
 	icon_state = "vault";
 	dir = 4
 	},
@@ -5144,7 +4977,6 @@
 /area/awaymission/centcomAway/general)
 "nH" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
 	icon_state = "vault";
 	dir = 1
 	},
@@ -5181,7 +5013,6 @@
 "nN" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
 	icon_state = "vault";
 	dir = 1
 	},
@@ -5191,7 +5022,6 @@
 /obj/item/storage/box/handcuffs,
 /obj/item/stamp/granted,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
 	icon_state = "vault";
 	dir = 1
 	},
@@ -5221,7 +5051,6 @@
 "nS" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5305,7 +5134,6 @@
 /obj/item/taperecorder,
 /obj/item/stamp/granted,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
 	icon_state = "vault";
 	dir = 1
 	},
@@ -5320,7 +5148,6 @@
 /obj/structure/table,
 /obj/item/paicard,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5335,7 +5162,6 @@
 "oj" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5343,7 +5169,6 @@
 "ok" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5351,14 +5176,12 @@
 "ol" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
 /area/awaymission/centcomAway/thunderdome)
 "om" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5375,7 +5198,6 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5386,7 +5208,6 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5421,7 +5242,6 @@
 "ot" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5429,7 +5249,6 @@
 "ou" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5437,7 +5256,6 @@
 "ov" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber (WEST)";
 	icon_state = "barber";
 	dir = 8;
 	heat_capacity = 1
@@ -5446,7 +5264,6 @@
 "ow" = (
 /obj/machinery/door/window/southleft,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5454,7 +5271,6 @@
 "ox" = (
 /obj/machinery/door/window/southright,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5462,7 +5278,6 @@
 "oy" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5473,7 +5288,6 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber (WEST)";
 	icon_state = "barber";
 	dir = 8;
 	heat_capacity = 1
@@ -5481,7 +5295,6 @@
 /area/awaymission/centcomAway/thunderdome)
 "oA" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber (WEST)";
 	icon_state = "barber";
 	dir = 8;
 	heat_capacity = 1
@@ -5491,7 +5304,6 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/popcorn,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber (WEST)";
 	icon_state = "barber";
 	dir = 8;
 	heat_capacity = 1
@@ -5499,7 +5311,6 @@
 /area/awaymission/centcomAway/thunderdome)
 "oC" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
 	icon_state = "redbluefull";
 	dir = 8
 	},
@@ -5510,7 +5321,6 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
 	icon_state = "redbluefull";
 	dir = 8
 	},
@@ -5522,7 +5332,6 @@
 "oF" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
 	icon_state = "redbluefull";
 	dir = 8
 	},
@@ -5530,7 +5339,6 @@
 "oG" = (
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
 	icon_state = "redbluefull";
 	dir = 8
 	},
@@ -5542,7 +5350,6 @@
 	in_use = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
 	icon_state = "redbluefull";
 	dir = 8
 	},
@@ -5556,7 +5363,6 @@
 "oJ" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
 	icon_state = "redbluefull";
 	dir = 8
 	},
@@ -5566,7 +5372,6 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/russian/ranged)
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5575,7 +5380,6 @@
 /obj/structure/table,
 /obj/item/lipstick,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5586,7 +5390,6 @@
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/drinks/ice,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber (WEST)";
 	icon_state = "barber";
 	dir = 8;
 	heat_capacity = 1
@@ -5595,7 +5398,6 @@
 "oN" = (
 /obj/machinery/icemachine,
 /turf/simulated/floor/plasteel{
-	tag = "icon-barber (WEST)";
 	icon_state = "barber";
 	dir = 8;
 	heat_capacity = 1
@@ -5606,7 +5408,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5614,7 +5415,6 @@
 "oP" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redbluefull (WEST)";
 	icon_state = "redbluefull";
 	dir = 8
 	},
@@ -5655,7 +5455,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5757,7 +5556,6 @@
 /obj/structure/table,
 /obj/item/camera,
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5777,7 +5575,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTHEAST)";
 	icon_state = "vault";
 	dir = 5
 	},
@@ -5835,7 +5632,6 @@
 /area/awaymission/centcomAway/thunderdome)
 "pu" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-plaque";
 	icon_state = "plaque"
 	},
 /area/awaymission/centcomAway/thunderdome)
@@ -5888,14 +5684,12 @@
 /area/awaymission/centcomAway/thunderdome)
 "pD" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (EAST)";
 	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/centcomAway/thunderdome)
 "pE" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-vault (NORTH)";
 	icon_state = "vault";
 	dir = 1
 	},
@@ -5957,7 +5751,6 @@
 /area/awaymission/centcomAway/thunderdome)
 "pN" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -5967,7 +5760,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -5976,7 +5768,6 @@
 /obj/structure/table/wood,
 /obj/item/radio/off,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -5986,7 +5777,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -5998,7 +5788,6 @@
 	req_access = list(102)
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -6008,7 +5797,6 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -6024,7 +5812,6 @@
 	loot = list(/obj/effect/mob_spawn/human/corpse/russian/ranged)
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -6033,7 +5820,6 @@
 /obj/structure/table,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -6044,7 +5830,6 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -6052,7 +5837,6 @@
 "pX" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -6060,7 +5844,6 @@
 "pY" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -6068,7 +5851,6 @@
 "pZ" = (
 /obj/machinery/computer/area_atmos,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -6083,7 +5865,6 @@
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -6091,7 +5872,6 @@
 "qc" = (
 /obj/structure/closet/secure_closet/cabinet/bar,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -6100,7 +5880,6 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -6110,7 +5889,6 @@
 /obj/item/reagent_containers/food/snacks/popcorn,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -6119,7 +5897,6 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
-	tag = "icon-redyellowfull (NORTHEAST)";
 	icon_state = "redyellowfull";
 	dir = 5
 	},
@@ -11382,8 +11159,8 @@ aW
 iR
 cC
 jk
-lL
-lL
+bn
+bn
 gX
 gX
 mJ
@@ -11513,7 +11290,7 @@ pT
 cC
 lK
 lW
-lL
+bn
 jI
 gX
 kX
@@ -11641,9 +11418,9 @@ gX
 iB
 cU
 lF
-lL
-lL
-lL
+bn
+bn
+bn
 gX
 gX
 mL
@@ -11772,8 +11549,8 @@ aW
 cU
 cC
 gX
-lL
-lL
+bn
+bn
 jI
 gX
 kY
@@ -11902,8 +11679,8 @@ aW
 iS
 cC
 jk
-lL
-lL
+bn
+bn
 gX
 gX
 mM

--- a/_maps/map_files/RandomZLevels/evil_santa.dmm
+++ b/_maps/map_files/RandomZLevels/evil_santa.dmm
@@ -20,8 +20,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "ad" = (
@@ -83,8 +82,7 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "aE" = (
@@ -103,8 +101,7 @@
 /obj/machinery/chem_dispenser/soda,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "aS" = (
@@ -144,8 +141,7 @@
 	dir = 4
 	},
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood/fancy,
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
@@ -276,8 +272,7 @@
 "cF" = (
 /mob/living/simple_animal/hostile/winter/snowman,
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/snow/clean/edge,
 /turf/simulated/floor/plating/ice,
@@ -340,8 +335,7 @@
 /area/vision_change_area/awaymission/evil_santa/spawn_ne)
 "dp" = (
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/vision_change_area/awaymission/evil_santa/hut_n)
@@ -425,8 +419,7 @@
 "dU" = (
 /obj/effect/decal/snow/clean/edge,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/vision_change_area/awaymission/evil_santa/hut_e)
 "dV" = (
@@ -491,8 +484,7 @@
 /area/vision_change_area/awaymission/evil_santa/mine)
 "ez" = (
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid,
 /area/vision_change_area/awaymission/evil_santa/hut_e)
@@ -541,8 +533,7 @@
 	opacity = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "eV" = (
@@ -564,8 +555,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/flatdough,
 /obj/item/reagent_containers/food/snacks/meat,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "fc" = (
@@ -597,8 +587,7 @@
 /obj/machinery/vending/boozeomat,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "fr" = (
@@ -650,8 +639,7 @@
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "fD" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/vision_change_area/awaymission/evil_santa/hut_n)
 "fH" = (
@@ -714,20 +702,13 @@
 /obj/structure/decorative_structures/garland,
 /turf/simulated/floor/carpet/red,
 /area/vision_change_area/awaymission/evil_santa/end/exit)
-"gg" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
-	},
-/area/vision_change_area/awaymission/evil_santa/hut_w)
 "gk" = (
 /obj/structure/window/full/reinforced/ice,
 /turf/simulated/floor/wood/cold,
 /area/vision_change_area/awaymission/evil_santa/hut_n)
 "gl" = (
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood/fancy,
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
@@ -868,8 +849,7 @@
 /area/vision_change_area/awaymission/evil_santa/spawn_s)
 "hi" = (
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/snow/clean/edge{
 	dir = 8
@@ -1188,14 +1168,12 @@
 /area/vision_change_area/awaymission/evil_santa/mine/labyrinth_m)
 "jq" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/vision_change_area/awaymission/evil_santa/hut_e)
 "js" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/vision_change_area/awaymission/evil_santa/hut_w)
 "jt" = (
@@ -1247,8 +1225,7 @@
 	icon_state = "small"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/vision_change_area/awaymission/evil_santa/hut_e)
 "jI" = (
@@ -1273,8 +1250,7 @@
 /area/vision_change_area/awaymission/evil_santa_storm)
 "jO" = (
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/vision_change_area/awaymission/evil_santa/hut_e)
@@ -1440,8 +1416,7 @@
 	dir = 8
 	},
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood/fancy,
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
@@ -1470,8 +1445,7 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "lP" = (
@@ -1939,8 +1913,7 @@
 "pg" = (
 /obj/machinery/kitchen_machine/oven,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "ph" = (
@@ -1994,8 +1967,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "pM" = (
@@ -2265,8 +2237,7 @@
 	pixel_y = 11
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "sa" = (
@@ -2406,8 +2377,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "tk" = (
@@ -2511,8 +2481,7 @@
 /obj/item/kitchen/rollingpin,
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "ut" = (
@@ -2618,8 +2587,7 @@
 /area/vision_change_area/awaymission/evil_santa/spawn_s)
 "vk" = (
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/snow/clean/edge{
 	dir = 4
@@ -2758,8 +2726,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "wC" = (
@@ -3137,8 +3104,7 @@
 /obj/item/reagent_containers/food/drinks/cans/non_alcoholic_beer,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "zL" = (
@@ -3165,8 +3131,7 @@
 "Ae" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "Aj" = (
@@ -3359,8 +3324,7 @@
 /obj/machinery/chem_dispenser/beer,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "Cf" = (
@@ -3663,8 +3627,7 @@
 	dir = 4
 	},
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating/ice,
 /area/vision_change_area/awaymission/evil_santa/mine)
@@ -3737,8 +3700,7 @@
 /area/vision_change_area/awaymission/evil_santa/spawn_ne)
 "FX" = (
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/snow/clean/edge{
 	dir = 4
@@ -4142,8 +4104,7 @@
 /area/vision_change_area/awaymission/evil_santa/hut_e)
 "Jh" = (
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /obj/item/clothing/suit/space/santa,
 /turf/simulated/floor/wood,
@@ -4593,12 +4554,6 @@
 /obj/effect/decal/snow/clean/edge,
 /turf/simulated/floor/plating/ice,
 /area/vision_change_area/awaymission/evil_santa/mine)
-"Nf" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
-	},
-/area/vision_change_area/awaymission/evil_santa/hut_e)
 "Ni" = (
 /turf/simulated/floor/chasm/straight_down/lava_land_surface/normal_air,
 /area/vision_change_area/awaymission/evil_santa/mine)
@@ -4664,8 +4619,7 @@
 /area/vision_change_area/awaymission/evil_santa/mine/labyrinth_l)
 "NH" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "NK" = (
@@ -4894,8 +4848,7 @@
 /obj/item/reagent_containers/glass/rag,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "Px" = (
@@ -4946,8 +4899,7 @@
 	dir = 8
 	},
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating/ice,
 /area/vision_change_area/awaymission/evil_santa/mine)
@@ -4968,14 +4920,12 @@
 "Qb" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "Qc" = (
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/snow/clean/edge{
 	dir = 4
@@ -5067,8 +5017,7 @@
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "QW" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/vision_change_area/awaymission/evil_santa/hut_w)
 "QX" = (
@@ -5208,8 +5157,7 @@
 /area/vision_change_area/awaymission/evil_santa/end/exit)
 "RZ" = (
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/green,
 /area/vision_change_area/awaymission/evil_santa/end/santa)
@@ -5365,13 +5313,11 @@
 /area/vision_change_area/awaymission/evil_santa/end/exit)
 "Ts" = (
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/vision_change_area/awaymission/evil_santa/hut_e)
 "Tu" = (
@@ -5435,8 +5381,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/vision_change_area/awaymission/evil_santa/hut_w)
 "TQ" = (
@@ -5514,8 +5459,7 @@
 	dir = 4
 	},
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating/ice,
 /area/vision_change_area/awaymission/evil_santa/mine)
@@ -5572,8 +5516,7 @@
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "UW" = (
 /obj/effect/decal/snow/clean/edge{
-	dir = 1;
-	tag = "icon-snow_corner (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/snow/clean/edge,
 /turf/simulated/floor/plating/ice,
@@ -5797,8 +5740,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/vision_change_area/awaymission/evil_santa/end/lounge)
 "WO" = (
@@ -5914,12 +5856,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/vision_change_area/awaymission/evil_santa/mine/labyrinth_l)
-"XQ" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
-	},
-/area/vision_change_area/awaymission/evil_santa/hut_w)
 "XR" = (
 /obj/effect/spawner/lootdrop/spentcasing/rifle,
 /turf/simulated/floor/carpet,
@@ -13777,7 +13713,7 @@ xr
 zD
 iv
 Ww
-XQ
+eD
 Ww
 Ww
 Ww
@@ -14293,7 +14229,7 @@ Oc
 TO
 ZR
 Ww
-gg
+KP
 bN
 xv
 ny
@@ -39727,7 +39663,7 @@ Sp
 Sp
 Sp
 EY
-Nf
+sI
 Jd
 Fg
 EY

--- a/_maps/map_files/RandomZLevels/example.dmm
+++ b/_maps/map_files/RandomZLevels/example.dmm
@@ -68,30 +68,25 @@
 /area/awaymission/example)
 "ak" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
 "al" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
 "am" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
@@ -118,8 +113,7 @@
 /area/awaymission/example)
 "aq" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
@@ -137,8 +131,7 @@
 "at" = (
 /obj/machinery/gateway,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
@@ -147,8 +140,7 @@
 	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
@@ -172,22 +164,19 @@
 "ay" = (
 /obj/machinery/light/small,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/example)
 "az" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/example)
 "aA" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plasteel,
@@ -273,7 +262,6 @@
 /area/awaymission/example)
 "aQ" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-yellowfull (WEST)";
 	icon_state = "yellowfull";
 	dir = 8
 	},
@@ -463,7 +451,6 @@
 /area/awaymission/example)
 "bo" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-stage_stairs (WEST)";
 	icon_state = "stage_stairs";
 	dir = 8
 	},
@@ -631,7 +618,6 @@
 /area/awaymission/example)
 "bJ" = (
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -640,7 +626,6 @@
 /area/awaymission/example)
 "bK" = (
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -665,7 +650,6 @@
 /area/awaymission/example)
 "bN" = (
 /obj/structure/chair/wood{
-	tag = "icon-wooden_chair (NORTH)";
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -836,7 +820,6 @@
 "cq" = (
 /obj/effect/landmark/awaystart,
 /obj/machinery/light_construct/small{
-	tag = "icon-bulb-construct-stage1 (WEST)";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/map_files/RandomZLevels/moonoutpost19.dmm
@@ -165,8 +165,7 @@
 "ax" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "darkred";
-	tag = "icon-darkred (NORTHWEST)"
+	icon_state = "darkred"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "ay" = (
@@ -177,23 +176,20 @@
 "az" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners";
-	tag = "icon-darkredcorners (NORTH)"
+	icon_state = "darkredcorners"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "aA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "darkred";
-	tag = "icon-darkred (NORTHEAST)"
+	icon_state = "darkred"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "aB" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "darkredcorners";
-	tag = "icon-darkredcorners (EAST)"
+	icon_state = "darkredcorners"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "aC" = (
@@ -225,8 +221,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "darkredcorners";
-	tag = "icon-darkredcorners (NORTH)"
+	icon_state = "darkredcorners"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "aF" = (
@@ -365,8 +360,7 @@
 "aU" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "darkredcorners";
-	tag = "icon-darkredcorners (WEST)"
+	icon_state = "darkredcorners"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "aV" = (
@@ -391,8 +385,7 @@
 /area/moonoutpost19/syndicateoutpost)
 "aX" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "darkredcorners";
-	tag = "icon-darkredcorners"
+	icon_state = "darkredcorners"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "aY" = (
@@ -443,14 +436,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "darkred";
-	tag = "icon-darkred (SOUTHWEST)"
+	icon_state = "darkred"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "bf" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -459,15 +450,13 @@
 "bg" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "darkred";
-	tag = "icon-darkred (SOUTHEAST)"
+	icon_state = "darkred"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "bh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "darkredcorners";
-	tag = "icon-darkredcorners"
+	icon_state = "darkredcorners"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "bi" = (
@@ -582,8 +571,7 @@
 	req_access = list(150)
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -662,8 +650,7 @@
 /area/moonoutpost19/syndicateoutpost)
 "bB" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -761,8 +748,7 @@
 /area/moonoutpost19/syndicateoutpost)
 "bQ" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/highsecurity{
 	locked = 1;
@@ -773,8 +759,7 @@
 /area/moonoutpost19/syndicateoutpost)
 "bR" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -806,8 +791,7 @@
 	},
 /obj/machinery/computer/monitor,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
@@ -923,8 +907,7 @@
 /area/moonoutpost19/syndicateoutpost)
 "cf" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/north,
@@ -966,8 +949,7 @@
 /area/moonoutpost19/syndicateoutpost)
 "ci" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -1078,12 +1060,10 @@
 /area/moonoutpost19/syndicateoutpost)
 "ct" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -1094,8 +1074,7 @@
 /area/moonoutpost19/syndicateoutpost)
 "cu" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -1108,8 +1087,7 @@
 /area/moonoutpost19/syndicateoutpost)
 "cv" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds{
@@ -1121,15 +1099,13 @@
 /area/moonoutpost19/syndicateoutpost)
 "cw" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/moonoutpost19/syndicateoutpost)
 "cx" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Power Maintenance";
@@ -1139,24 +1115,20 @@
 /area/moonoutpost19/syndicateoutpost)
 "cy" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/moonoutpost19/syndicateoutpost)
 "cz" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/moonoutpost19/syndicateoutpost)
@@ -1168,8 +1140,7 @@
 /area/moonoutpost19/syndicateoutpost)
 "cB" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
@@ -1371,8 +1342,7 @@
 /turf/simulated/floor/plasteel/airless{
 	dir = 8;
 	icon_state = "wood";
-	name = "floor";
-	tag = "icon-warningcorner (NORTH)"
+	name = "floor"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "cU" = (
@@ -1440,8 +1410,7 @@
 /turf/simulated/floor/plasteel/airless{
 	dir = 8;
 	icon_state = "wood";
-	name = "floor";
-	tag = "icon-warningcorner (NORTH)"
+	name = "floor"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "da" = (
@@ -1452,8 +1421,7 @@
 /turf/simulated/floor/plasteel/airless{
 	dir = 8;
 	icon_state = "wood";
-	name = "floor";
-	tag = "icon-warningcorner (NORTH)"
+	name = "floor"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "db" = (
@@ -1520,8 +1488,7 @@
 /turf/simulated/floor/plasteel/airless{
 	dir = 8;
 	icon_state = "wood";
-	name = "floor";
-	tag = "icon-warningcorner (NORTH)"
+	name = "floor"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "di" = (
@@ -1534,8 +1501,7 @@
 /turf/simulated/floor/plasteel/airless{
 	dir = 8;
 	icon_state = "wood";
-	name = "floor";
-	tag = "icon-warningcorner (NORTH)"
+	name = "floor"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "dj" = (
@@ -1616,8 +1582,7 @@
 /turf/simulated/floor/plasteel/airless{
 	dir = 8;
 	icon_state = "wood";
-	name = "floor";
-	tag = "icon-warningcorner (NORTH)"
+	name = "floor"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "dr" = (
@@ -1632,8 +1597,7 @@
 /turf/simulated/floor/plasteel/airless{
 	dir = 8;
 	icon_state = "wood";
-	name = "floor";
-	tag = "icon-warningcorner (NORTH)"
+	name = "floor"
 	},
 /area/moonoutpost19/syndicateoutpost)
 "ds" = (
@@ -1705,8 +1669,7 @@
 /area/moonoutpost19/khonsu19)
 "dB" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
@@ -1955,8 +1918,7 @@
 /area/moonoutpost19/mo19research)
 "ei" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -1970,8 +1932,7 @@
 /area/moonoutpost19/mo19research)
 "ej" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -2119,8 +2080,7 @@
 /area/moonoutpost19/mo19research)
 "ex" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
@@ -2277,8 +2237,7 @@
 /area/moonoutpost19/mo19research)
 "eO" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/chair/office/light{
@@ -2392,8 +2351,7 @@
 /area/moonoutpost19/mo19utilityroom)
 "fa" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
@@ -2429,8 +2387,7 @@
 /area/moonoutpost19/mo19utilityroom)
 "fd" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -2453,8 +2410,7 @@
 /area/moonoutpost19/mo19research)
 "fe" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/moonoutpost19/mo19utilityroom)
@@ -2464,8 +2420,7 @@
 /area/moonoutpost19/mo19utilityroom)
 "fg" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/newspaper,
 /turf/simulated/floor/plating,
@@ -2522,8 +2477,7 @@
 /area/moonoutpost19/mo19research)
 "fm" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/alien/weeds{
@@ -2584,8 +2538,7 @@
 /area/moonoutpost19/mo19research)
 "fr" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/moonoutpost19/mo19utilityroom)
@@ -2602,8 +2555,7 @@
 /area/moonoutpost19/mo19utilityroom)
 "ft" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -2622,8 +2574,7 @@
 	pixel_x = 32
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/alien/weeds{
 	icon_state = "weeds1"
@@ -2678,19 +2629,16 @@
 /area/moonoutpost19/mo19research)
 "fx" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/moonoutpost19/mo19utilityroom)
 "fy" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -2698,8 +2646,7 @@
 /area/moonoutpost19/mo19utilityroom)
 "fz" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds{
@@ -2709,8 +2656,7 @@
 /area/moonoutpost19/mo19research)
 "fA" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -2719,8 +2665,7 @@
 /area/moonoutpost19/mo19research)
 "fB" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/east,
@@ -2731,8 +2676,7 @@
 /area/moonoutpost19/mo19research)
 "fC" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor/plasteel{
@@ -2741,8 +2685,7 @@
 /area/moonoutpost19/mo19research)
 "fD" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -2794,8 +2737,7 @@
 	icon_state = "medium"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -2889,15 +2831,13 @@
 /area/moonoutpost19/mo19utilityroom)
 "fN" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/moonoutpost19/mo19utilityroom)
 "fO" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/moonoutpost19/mo19utilityroom)
@@ -2906,8 +2846,7 @@
 /area/moonoutpost19/mo19utilityroom)
 "fQ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -2926,12 +2865,10 @@
 /area/moonoutpost19/mo19research)
 "fR" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/alien/weeds,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2992,12 +2929,10 @@
 /area/moonoutpost19/mo19utilityroom)
 "fZ" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/moonoutpost19/mo19utilityroom)
@@ -3086,12 +3021,10 @@
 /area/moonoutpost19/mo19research)
 "gh" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/blood/oil{
 	color = "black"
@@ -3101,8 +3034,7 @@
 "gi" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/moonoutpost19/mo19utilityroom)
@@ -3168,8 +3100,7 @@
 	pixel_x = 32
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/alien/weeds{
 	icon_state = "weeds2"
@@ -3501,8 +3432,7 @@
 	color = "black"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/power/apc/noalarm{
 	cell_type = 15000;
@@ -3518,8 +3448,7 @@
 /area/moonoutpost19/mo19utilityroom)
 "gQ" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/stack/rods,
 /obj/effect/mapping_helpers/turfs/damage,
@@ -3680,8 +3609,7 @@
 /area/moonoutpost19/mo19research)
 "hf" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm/no_alarm{
 	dir = 4;
@@ -3738,8 +3666,7 @@
 /area/moonoutpost19/mo19research)
 "hl" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/oil{
 	color = "black"
@@ -3817,8 +3744,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "ht" = (
@@ -3840,8 +3766,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "hu" = (
@@ -3938,16 +3863,14 @@
 "hC" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "hD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "hE" = (
@@ -4000,8 +3923,7 @@
 /area/moonoutpost19/mo19research)
 "hH" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
@@ -4029,16 +3951,14 @@
 /area/moonoutpost19/mo19arrivals)
 "hL" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/moonoutpost19/mo19utilityroom)
 "hM" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -4047,8 +3967,7 @@
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "hO" = (
@@ -4161,8 +4080,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "hZ" = (
@@ -4173,8 +4091,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "ia" = (
@@ -4189,8 +4106,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "ib" = (
@@ -4200,8 +4116,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "ic" = (
@@ -4366,8 +4281,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "is" = (
@@ -4517,8 +4431,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "iJ" = (
@@ -4527,8 +4440,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "iK" = (
@@ -4537,14 +4449,12 @@
 /obj/item/laser_pointer,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "iL" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plating,
@@ -4555,8 +4465,7 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	name = "emergency shower";
-	tag = "icon-shower (EAST)"
+	name = "emergency shower"
 	},
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
@@ -4632,8 +4541,7 @@
 /obj/machinery/vending/boozeomat,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "iW" = (
@@ -4656,8 +4564,7 @@
 "iY" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "iZ" = (
@@ -4665,8 +4572,7 @@
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "ja" = (
@@ -4776,8 +4682,7 @@
 /obj/effect/decal/cleanable/flour,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "jp" = (
@@ -4789,8 +4694,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "jq" = (
@@ -4820,8 +4724,7 @@
 /obj/item/paicard_upgrade,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "js" = (
@@ -4838,14 +4741,12 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "ju" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4874,15 +4775,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "purple";
-	tag = "icon-purple (NORTHWEST)"
+	icon_state = "purple"
 	},
 /area/moonoutpost19/mo19arrivals)
 "jz" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "purple";
-	tag = "icon-purple (NORTHEAST)"
+	icon_state = "purple"
 	},
 /area/moonoutpost19/mo19arrivals)
 "jA" = (
@@ -5007,8 +4906,7 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "jR" = (
@@ -5019,16 +4917,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "jS" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "jT" = (
@@ -5058,8 +4954,7 @@
 /area/moonoutpost19/mo19arrivals)
 "jW" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/moonoutpost19/mo19arrivals)
@@ -5068,8 +4963,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "jY" = (
@@ -5085,8 +4979,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "jZ" = (
@@ -5111,8 +5004,7 @@
 /area/moonoutpost19/mo19utilityroom)
 "kc" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
@@ -5137,8 +5029,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "kg" = (
@@ -5150,8 +5041,7 @@
 /area/moonoutpost19/mo19arrivals)
 "kh" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -5189,22 +5079,19 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19research)
 "kk" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/moonoutpost19/mo19utilityroom)
 "kl" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -5219,8 +5106,7 @@
 /area/moonoutpost19/mo19arrivals)
 "kn" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/oil{
 	color = "black"
@@ -5238,8 +5124,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "kq" = (
@@ -5248,8 +5133,7 @@
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "kr" = (
@@ -5261,16 +5145,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "ks" = (
 /obj/effect/decal/cleanable/plant_smudge,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "kt" = (
@@ -5286,14 +5168,12 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "ku" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -5344,8 +5224,7 @@
 /area/moonoutpost19/mo19arrivals)
 "kA" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5367,8 +5246,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purple";
-	tag = "icon-purple (NORTH)"
+	icon_state = "purple"
 	},
 /area/moonoutpost19/mo19arrivals)
 "kD" = (
@@ -5394,8 +5272,7 @@
 /area/moonoutpost19/mo19arrivals)
 "kF" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5406,8 +5283,7 @@
 /area/moonoutpost19/mo19arrivals)
 "kG" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5418,8 +5294,7 @@
 /area/moonoutpost19/mo19arrivals)
 "kH" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5431,8 +5306,7 @@
 /area/moonoutpost19/mo19arrivals)
 "kI" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5483,8 +5357,7 @@
 /obj/item/reagent_containers/food/snacks/badrecipe,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "kO" = (
@@ -5498,8 +5371,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -5509,8 +5381,7 @@
 /area/moonoutpost19/mo19arrivals)
 "kQ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5521,8 +5392,7 @@
 /area/moonoutpost19/mo19arrivals)
 "kR" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor{
 	density = 1;
@@ -5559,8 +5429,7 @@
 "kU" = (
 /obj/machinery/light/small,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5580,8 +5449,7 @@
 /area/moonoutpost19/mo19arrivals)
 "kW" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5637,8 +5505,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "ld" = (
@@ -5662,8 +5529,7 @@
 /area/moonoutpost19/mo19arrivals)
 "li" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5777,8 +5643,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "lv" = (
@@ -5831,8 +5696,7 @@
 "lF" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "burst_r";
-	tag = "icon-burst_r (WEST)"
+	icon_state = "burst_r"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/moonoutpost19/mo19arrivals)
@@ -5856,22 +5720,19 @@
 /area/moonoutpost19/mo19arrivals)
 "lJ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner";
-	tag = "icon-purplecorner (NORTH)"
+	icon_state = "purplecorner"
 	},
 /area/moonoutpost19/mo19arrivals)
 "lK" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 4;
-	tag = "icon-heater (EAST)"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5917,8 +5778,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/alarm/monitor{
 	locked = 0;
@@ -6019,8 +5879,7 @@
 "mg" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "burst_l";
-	tag = "icon-burst_l (WEST)"
+	icon_state = "burst_l"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/moonoutpost19/mo19arrivals)
@@ -6065,8 +5924,7 @@
 /area/moonoutpost19/mo19arrivals)
 "mn" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6079,8 +5937,7 @@
 /area/moonoutpost19/mo19arrivals)
 "mo" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -6092,8 +5949,7 @@
 	opacity = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6561,8 +6417,7 @@
 /area/moonoutpost19/mo19arrivals)
 "nA" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -6722,8 +6577,7 @@
 /area/moonoutpost19/mo19arrivals)
 "nU" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6928,8 +6782,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/moonoutpost19/mo19arrivals)
 "ot" = (
@@ -7076,8 +6929,7 @@
 "oJ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/moonoutpost19/mo19arrivals)

--- a/_maps/map_files/RandomZLevels/spacebattle.dmm
+++ b/_maps/map_files/RandomZLevels/spacebattle.dmm
@@ -14,8 +14,7 @@
 "ad" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r (NORTH)"
+	icon_state = "propulsion_r"
 	},
 /turf/space,
 /area/awaymission/spacebattle/syndicate2)
@@ -29,8 +28,7 @@
 "af" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (NORTH)"
+	icon_state = "propulsion_l"
 	},
 /turf/space,
 /area/awaymission/spacebattle/syndicate2)
@@ -285,8 +283,7 @@
 "aX" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -296,8 +293,7 @@
 "aY" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -522,22 +518,6 @@
 "bH" = (
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/engineering)
-"bJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutral"
-	},
-/area/awaymission/spacebattle/prhallway1)
 "bK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -568,8 +548,7 @@
 /obj/item/reagent_containers/hypospray/safety,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "bP" = (
@@ -621,8 +600,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/hallway5)
@@ -659,8 +637,7 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
 	icon_state = "heater3x3_side_inv";
-	layer = 3.5;
-	tag = "icon-heater (NORTH)"
+	layer = 3.5
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate2)
@@ -747,8 +724,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
@@ -847,8 +823,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -927,8 +902,7 @@
 "cV" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/syndicate5)
 "cW" = (
@@ -1034,8 +1008,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -1073,8 +1046,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1351,18 +1323,6 @@
 	icon_state = "vault"
 	},
 /area/awaymission/spacebattle/hallway6)
-"ei" = (
-/obj/machinery/door/airlock/security{
-	name = "Turret Room"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/spacebattle/cruiser)
 "ej" = (
 /obj/machinery/door/airlock/syndicate/freezer,
 /turf/simulated/floor/shuttle{
@@ -1482,16 +1442,14 @@
 "eC" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/awaymission/spacebattle/bridge)
 "eD" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/closet/hydrant{
 	opened = 1;
@@ -1515,8 +1473,7 @@
 "eG" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r (NORTH)"
+	icon_state = "propulsion_r"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate1)
@@ -1566,16 +1523,14 @@
 "eQ" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (NORTH)"
+	icon_state = "propulsion_l"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate1)
 "eR" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (NORTH)"
+	icon_state = "propulsion_l"
 	},
 /turf/space,
 /area/awaymission/spacebattle/syndicate3)
@@ -1583,8 +1538,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
@@ -1610,8 +1564,7 @@
 	name = "Broken Computer"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/awaymission/spacebattle/bridge)
 "eY" = (
@@ -1745,8 +1698,7 @@
 /obj/machinery/computer/shuttle,
 /obj/item/paper/check/spacebattle/bridge2,
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/awaymission/spacebattle/bridge)
 "fu" = (
@@ -1770,8 +1722,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/awaymission/spacebattle/server)
@@ -1830,8 +1781,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -1844,8 +1794,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -1859,14 +1808,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/effect/landmark/awaymissions/spacebattle/mine_spawner{
 	faction = "syndicate";
@@ -1882,8 +1829,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -1898,8 +1844,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -1911,8 +1856,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1990,8 +1934,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway8)
@@ -2068,8 +2011,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -2099,8 +2041,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/red/corner{
@@ -2290,8 +2231,7 @@
 	name = "Broken Computer"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/awaymission/spacebattle/bridge)
 "gK" = (
@@ -2332,8 +2272,7 @@
 "gP" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "gQ" = (
@@ -2379,8 +2318,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -2413,16 +2351,14 @@
 /area/awaymission/spacebattle/server)
 "hc" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/space)
 "hd" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2442,8 +2378,7 @@
 /area/awaymission/spacebattle/syndicate7)
 "hg" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 4;
-	tag = "icon-heater (EAST)"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	color = "red";
@@ -2454,8 +2389,7 @@
 "hh" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (WEST)"
+	icon_state = "propulsion_l"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/awaymission/spacebattle/syndicate7)
@@ -2486,8 +2420,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/dispenser/oxygen{
 	anchored = 0
@@ -2500,8 +2433,7 @@
 "hn" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/syndicate5)
 "ho" = (
@@ -2621,8 +2553,7 @@
 "hG" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "hH" = (
@@ -2636,8 +2567,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/screwdriver,
 /turf/simulated/floor/plasteel,
@@ -2700,8 +2630,7 @@
 /obj/structure/closet/crate/secure/bin,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "hU" = (
@@ -2767,8 +2696,7 @@
 "ie" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2779,8 +2707,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	basecolor = "#030303";
@@ -2832,8 +2759,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/mob_spawn/human/corpse/spacebattle/bridgeofficer,
 /turf/simulated/floor/plasteel{
@@ -2844,8 +2770,7 @@
 "il" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2909,31 +2834,27 @@
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel/airless{
 	dir = 10;
-	icon_state = "floor4";
-	tag = "icon-floor4 (SOUTHWEST)"
+	icon_state = "floor4"
 	},
 /area/space/nearstation)
 "iv" = (
 /turf/simulated/floor/plasteel/airless{
 	dir = 10;
-	icon_state = "floor4";
-	tag = "icon-floor4 (SOUTHWEST)"
+	icon_state = "floor4"
 	},
 /area/space/nearstation)
 "ix" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plasteel/airless{
 	dir = 10;
-	icon_state = "floor4";
-	tag = "icon-floor4 (SOUTHWEST)"
+	icon_state = "floor4"
 	},
 /area/space/nearstation)
 "iy" = (
 /obj/item/stack/rods,
 /turf/simulated/floor/plasteel/airless{
 	dir = 10;
-	icon_state = "floor4";
-	tag = "icon-floor4 (SOUTHWEST)"
+	icon_state = "floor4"
 	},
 /area/space/nearstation)
 "iz" = (
@@ -2969,8 +2890,7 @@
 	},
 /turf/simulated/floor/plasteel/airless{
 	dir = 10;
-	icon_state = "floor4";
-	tag = "icon-floor4 (SOUTHWEST)"
+	icon_state = "floor4"
 	},
 /area/space/nearstation)
 "iD" = (
@@ -3023,8 +2943,7 @@
 "iN" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/hallway3)
 "iO" = (
@@ -3232,8 +3151,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
@@ -3251,8 +3169,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -3263,8 +3180,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -3306,8 +3222,7 @@
 "jC" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3425,8 +3340,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -3445,8 +3359,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plasteel{
@@ -3471,8 +3384,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/bridge)
@@ -3543,8 +3455,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
@@ -3629,14 +3540,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/stack/rods,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/hallway11)
 "kx" = (
@@ -3659,8 +3568,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/turret8)
@@ -3754,8 +3662,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -3770,8 +3677,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -3810,8 +3716,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/awaymission/spacebattle/storage)
@@ -3834,8 +3739,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/shuttle,
 /area/awaymission/spacebattle/hallway5)
@@ -3843,8 +3747,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3873,8 +3776,7 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel/airless{
 	dir = 10;
-	icon_state = "floor4";
-	tag = "icon-floor4 (SOUTHWEST)"
+	icon_state = "floor4"
 	},
 /area/space/nearstation)
 "lc" = (
@@ -3940,8 +3842,7 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate2)
@@ -4084,8 +3985,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "lR" = (
@@ -4184,14 +4084,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway13)
@@ -4211,8 +4109,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel{
@@ -4223,8 +4120,7 @@
 "mh" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/syndicate6)
 "mk" = (
@@ -4272,8 +4168,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -4311,8 +4206,7 @@
 	name = "Broken Computer"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/awaymission/spacebattle/bridge)
 "mw" = (
@@ -4336,8 +4230,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/turret4)
@@ -4367,8 +4260,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 2.8
@@ -4379,8 +4271,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel,
@@ -4389,8 +4280,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/closed{
@@ -4494,8 +4384,7 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
 	icon_state = "heater3x3_side_inv";
-	layer = 3.5;
-	tag = "icon-heater (NORTH)"
+	layer = 3.5
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate3)
@@ -4566,8 +4455,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/turret9)
@@ -4616,8 +4504,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -4628,8 +4515,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -4670,8 +4556,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/red/line{
@@ -4775,8 +4660,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/window/plasmareinforced{
@@ -4799,14 +4683,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway6)
@@ -4822,8 +4704,7 @@
 /area/awaymission/spacebattle/hallway11)
 "nM" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/window/plasmareinforced{
 	dir = 8
@@ -4871,8 +4752,7 @@
 /obj/effect/decal/cleanable/shreds,
 /turf/simulated/floor/plasteel/airless{
 	dir = 10;
-	icon_state = "floor4";
-	tag = "icon-floor4 (SOUTHWEST)"
+	icon_state = "floor4"
 	},
 /area/space/nearstation)
 "nU" = (
@@ -4896,8 +4776,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/engine)
@@ -4980,8 +4859,7 @@
 "om" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/window/plasmareinforced,
 /turf/simulated/floor/shuttle/plating,
@@ -5017,8 +4895,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway12)
@@ -5036,8 +4913,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/awaymission/spacebattle/server)
@@ -5059,8 +4935,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway7)
@@ -5110,8 +4985,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/engine)
@@ -5136,8 +5010,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5157,8 +5030,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -5169,8 +5041,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -5271,8 +5142,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/sign/redcross{
 	pixel_x = 32
@@ -5287,8 +5157,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/mob_spawn/human/corpse/spacebattle/bridgeofficer,
 /turf/simulated/floor/plasteel{
@@ -5396,8 +5265,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway7)
@@ -5515,8 +5383,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/spacebattle/engineering)
@@ -5749,8 +5616,7 @@
 "qC" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "qE" = (
@@ -5773,8 +5639,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway11)
@@ -5782,8 +5647,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5804,16 +5668,14 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "qM" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/hallway11)
 "qN" = (
@@ -5826,8 +5688,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "qO" = (
@@ -5845,8 +5706,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway12)
@@ -5867,8 +5727,7 @@
 "qS" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "qT" = (
@@ -5991,8 +5850,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /mob/living/simple_animal/hostile/syndicate/melee/space/autogib/spacebattle,
 /turf/simulated/floor/plasteel,
@@ -6042,13 +5900,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/hallway11)
 "rv" = (
@@ -6277,8 +6133,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -6424,8 +6279,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 2.8
@@ -6469,8 +6323,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -6484,8 +6337,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/turret10)
@@ -6515,8 +6367,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -6534,8 +6385,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 8
@@ -6582,8 +6432,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/engine)
@@ -6607,8 +6456,7 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
 	icon_state = "heater3x3";
-	layer = 3.7;
-	tag = "icon-heater (NORTH)"
+	layer = 3.7
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate2)
@@ -6648,8 +6496,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
 	locked = 1;
@@ -6685,8 +6532,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -6707,8 +6553,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway1)
@@ -6741,8 +6586,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 4
@@ -6859,8 +6703,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway9)
@@ -6871,8 +6714,7 @@
 	name = "Nuke Vault Door Controller"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/awaymission/spacebattle/bridge)
 "tD" = (
@@ -6902,8 +6744,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -6947,8 +6788,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -6987,8 +6827,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed,
 /turf/simulated/floor/plasteel,
@@ -7077,8 +6916,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/red/line{
@@ -7156,8 +6994,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway13)
@@ -7189,8 +7026,7 @@
 	},
 /turf/simulated/floor/plasteel/airless{
 	dir = 10;
-	icon_state = "floor4";
-	tag = "icon-floor4 (SOUTHWEST)"
+	icon_state = "floor4"
 	},
 /area/space/nearstation)
 "uB" = (
@@ -7245,8 +7081,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/turret1)
@@ -7255,8 +7090,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway7)
@@ -7318,8 +7152,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/pod/dark,
 /area/awaymission/spacebattle/hallway5)
@@ -7409,8 +7242,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -7451,8 +7283,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 2.8
@@ -7464,8 +7295,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 3.2
@@ -7531,8 +7361,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -7541,8 +7370,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/awaymissions/spacebattle/mine_spawner{
 	faction = "syndicate";
@@ -7582,8 +7410,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/ammo_casing/shotgun,
 /turf/simulated/floor/plasteel,
@@ -7595,8 +7422,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -7615,8 +7441,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/engine)
@@ -7663,8 +7488,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/stock_parts/cell,
 /turf/simulated/floor/plasteel/airless,
@@ -7706,8 +7530,7 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate2)
@@ -7715,8 +7538,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -7749,14 +7571,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -7768,8 +7588,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway11)
@@ -7777,8 +7596,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/prhallway1)
@@ -7798,8 +7616,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -7833,8 +7650,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 3.2
@@ -7855,8 +7671,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/sec_storage)
@@ -7864,8 +7679,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/awaymissions/spacebattle/mine_spawner{
 	faction = "syndicate";
@@ -7899,8 +7713,7 @@
 /area/awaymission/spacebattle/hallway11)
 "wu" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/window/plasmareinforced{
 	dir = 4
@@ -7974,8 +7787,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/bridge)
@@ -8013,8 +7825,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -8024,8 +7835,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/spacebattle/hallway11)
@@ -8034,8 +7844,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8117,8 +7926,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -8158,8 +7966,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -8169,8 +7976,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/awaymissions/spacebattle/mob_spawn/ranged{
 	id = "toalet"
@@ -8196,8 +8002,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/engine)
@@ -8211,14 +8016,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway10)
@@ -8231,8 +8034,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
@@ -8253,8 +8055,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/light_construct,
 /turf/simulated/floor/plasteel,
@@ -8270,8 +8071,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
 	locked = 1;
@@ -8303,16 +8103,14 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/awaymission/spacebattle/storage)
 "xq" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/window/plasmareinforced,
 /turf/simulated/floor/shuttle/plating,
@@ -8366,8 +8164,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/multi_tile/two_tile_ver{
 	id_tag = "LHall"
@@ -8385,8 +8182,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/awaymissions/spacebattle/mob_spawn/ranged{
 	id = "turret2"
@@ -8397,8 +8193,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -8408,8 +8203,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway5)
@@ -8528,8 +8322,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway1)
@@ -8540,8 +8333,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/pod/dark,
 /area/awaymission/spacebattle/hallway5)
@@ -8580,8 +8372,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway7)
@@ -8613,14 +8404,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /mob/living/simple_animal/hostile/syndicate/ranged/space/autogib/spacebattle,
 /turf/simulated/floor/plasteel/airless,
@@ -8642,8 +8431,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -8704,8 +8492,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -8723,8 +8510,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/awaymission/spacebattle/storage)
@@ -8789,8 +8575,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/spacebattle/engineering)
@@ -8805,8 +8590,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel/airless,
@@ -8816,8 +8600,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/multi_tile/two_tile_ver{
 	id_tag = "BR"
@@ -8895,8 +8678,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -8909,14 +8691,12 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -9054,8 +8834,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway10)
@@ -9103,8 +8882,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/awaymissions/spacebattle/mob_spawn/ranged_space{
 	id = "MainBridge"
@@ -9313,8 +9091,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/light/spot,
 /turf/simulated/floor/plasteel{
@@ -9354,8 +9131,7 @@
 "Ah" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/awaymission/spacebattle/medbay)
 "Ai" = (
@@ -9385,8 +9161,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway6)
@@ -9399,8 +9174,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 3.2
@@ -9501,8 +9275,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -9568,8 +9341,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/turret1)
@@ -9649,8 +9421,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -9680,8 +9451,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -9718,8 +9488,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway11)
@@ -9755,8 +9524,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -9836,8 +9604,7 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
 	icon_state = "heater3x3";
-	layer = 3.7;
-	tag = "icon-heater (NORTH)"
+	layer = 3.7
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate3)
@@ -9886,8 +9653,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9901,8 +9667,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway8)
@@ -9938,8 +9703,7 @@
 "BP" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/syndicate6)
 "BQ" = (
@@ -9976,8 +9740,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -10045,8 +9808,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway10)
@@ -10091,8 +9853,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -10140,8 +9901,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 2.8
@@ -10185,8 +9945,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel,
@@ -10342,8 +10101,7 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "Db" = (
@@ -10360,8 +10118,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/spacebattle/hallway3)
@@ -10379,8 +10136,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/spacebattle,
 /turf/simulated/floor/plasteel{
@@ -10391,14 +10147,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -10413,8 +10167,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 3.2
@@ -10513,8 +10266,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/engine)
@@ -10553,8 +10305,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -10632,8 +10383,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/shard{
 	icon_state = "small"
@@ -10827,8 +10577,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -10848,14 +10597,12 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/effect/mob_spawn/human/corpse/spacebattle/engineer,
@@ -10892,8 +10639,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway1)
@@ -10970,8 +10716,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -10987,8 +10732,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
@@ -11033,8 +10777,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/pod/dark,
 /area/awaymission/spacebattle/cruiser)
@@ -11164,8 +10907,7 @@
 /area/space)
 "Fn" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "Fo" = (
@@ -11204,8 +10946,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -11281,8 +11022,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/spacebattle/engineering)
@@ -11317,8 +11057,7 @@
 "FK" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/hallway3)
 "FL" = (
@@ -11356,14 +11095,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/spacebattle/hallway3)
@@ -11418,13 +11155,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/hallway3)
 "FZ" = (
@@ -11465,8 +11200,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel,
@@ -11563,8 +11297,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway5)
@@ -11588,8 +11321,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -11630,8 +11362,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -11763,14 +11494,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/chair{
 	dir = 4
@@ -11878,8 +11607,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -11891,8 +11619,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -11901,14 +11628,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -12082,8 +11807,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/awaymissions/spacebattle/mob_spawn/melee{
 	id = "ssu"
@@ -12118,8 +11842,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel,
@@ -12349,8 +12072,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/awaystart,
 /turf/simulated/floor/plasteel,
@@ -12363,8 +12085,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /mob/living/simple_animal/hostile/syndicate/ranged/autogib/spacebattle,
 /turf/simulated/floor/plasteel,
@@ -12373,13 +12094,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/hallway3)
 "IF" = (
@@ -12484,8 +12203,7 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
 	icon_state = "heater3x3";
-	layer = 3.7;
-	tag = "icon-heater (NORTH)"
+	layer = 3.7
 	},
 /obj/structure/window/plasmareinforced,
 /turf/simulated/floor/shuttle/plating,
@@ -12494,8 +12212,7 @@
 /mob/living/simple_animal/hostile/malf_drone/spacebattle,
 /turf/simulated/floor/plasteel/airless{
 	dir = 10;
-	icon_state = "floor4";
-	tag = "icon-floor4 (SOUTHWEST)"
+	icon_state = "floor4"
 	},
 /area/space/nearstation)
 "IY" = (
@@ -12595,8 +12312,7 @@
 "Jo" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "Jp" = (
@@ -12618,8 +12334,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -12639,8 +12354,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -12656,8 +12370,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/server)
@@ -12709,8 +12422,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/awaymission/spacebattle/storage)
@@ -12798,8 +12510,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/reagent_dispensers/oil,
 /turf/simulated/floor/plasteel{
@@ -12882,8 +12593,7 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/syndicate3)
@@ -12927,8 +12637,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway12)
@@ -12945,8 +12654,7 @@
 "Kr" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r (NORTH)"
+	icon_state = "propulsion_r"
 	},
 /turf/space,
 /area/awaymission/spacebattle/syndicate3)
@@ -12988,8 +12696,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/hallway5)
@@ -13078,8 +12785,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/turret9)
@@ -13087,8 +12793,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plasteel,
@@ -13111,8 +12816,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -13161,8 +12865,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -13217,8 +12920,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/engine)
@@ -13243,8 +12945,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/hallway9)
@@ -13263,8 +12964,7 @@
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "Lj" = (
@@ -13361,8 +13061,7 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "Ly" = (
@@ -13416,8 +13115,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -13431,8 +13129,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -13452,8 +13149,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -13514,8 +13210,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway1)
@@ -13603,8 +13298,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -13748,8 +13442,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -13777,14 +13470,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway7)
@@ -13793,8 +13484,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/pod/dark,
 /area/awaymission/spacebattle/hallway5)
@@ -13858,8 +13548,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -13885,8 +13574,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/hallway9)
@@ -13939,8 +13627,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -13977,14 +13664,12 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/pod/dark,
 /area/awaymission/spacebattle/hallway5)
@@ -14024,14 +13709,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -14059,8 +13742,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -14098,8 +13780,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/red/corner{
@@ -14168,8 +13849,7 @@
 "NK" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "NL" = (
@@ -14181,8 +13861,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -14196,8 +13875,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -14244,8 +13922,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/turret3)
@@ -14263,8 +13940,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -14278,18 +13954,6 @@
 	underlay_floor_icon_state = "0"
 	},
 /area/awaymission/spacebattle/syndicate4)
-"NY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/awaymission/spacebattle/hallway10)
 "NZ" = (
 /obj/structure/lattice,
 /turf/space,
@@ -14342,8 +14006,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/hallway5)
@@ -14360,8 +14023,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -14372,8 +14034,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -14384,8 +14045,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -14425,14 +14085,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway5)
@@ -14500,14 +14158,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -14615,8 +14271,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -14658,8 +14313,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -14671,8 +14325,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway11)
@@ -14769,8 +14422,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mob_spawn/human/corpse/spacebattle/engineer/space,
 /turf/simulated/floor/plating/airless,
@@ -14779,8 +14431,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating/airless,
@@ -14853,8 +14504,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -14864,8 +14514,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
@@ -14934,8 +14583,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /mob/living/simple_animal/hostile/syndicate/ranged/space/autogib/spacebattle{
 	aggro_vision_range = 12
@@ -15125,8 +14773,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 3.2
@@ -15186,8 +14833,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -15204,8 +14850,7 @@
 /obj/structure/table/reinforced,
 /obj/item/ammo_box/shotgun,
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/awaymission/spacebattle/bridge)
 "Qs" = (
@@ -15217,8 +14862,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -15261,8 +14905,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -15293,8 +14936,7 @@
 	},
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "QC" = (
@@ -15321,8 +14963,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway10)
@@ -15406,8 +15047,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -15432,8 +15072,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 3.2
@@ -15586,8 +15225,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/clothing/mask/cigarette/menthol,
 /turf/simulated/floor/plasteel,
@@ -15697,8 +15335,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -15782,13 +15419,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/hallway11)
 "RU" = (
@@ -15865,8 +15500,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/awaystart,
 /turf/simulated/floor/plasteel,
@@ -15922,8 +15556,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -15968,8 +15601,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/engineering)
@@ -16097,8 +15729,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mob_spawn/human/bartender,
 /turf/simulated/floor/plasteel,
@@ -16217,8 +15848,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -16264,8 +15894,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/screwdriver,
 /turf/simulated/floor/plasteel{
@@ -16306,8 +15935,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/awaymissions/spacebattle/mob_spawn/melee_space{
 	id = "MainBridge"
@@ -16452,8 +16080,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -16511,8 +16138,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/awaymission/spacebattle/server)
@@ -16534,14 +16160,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway1)
@@ -16578,8 +16202,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/prhallway5)
@@ -16594,8 +16217,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "Ug" = (
@@ -16776,8 +16398,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/living)
@@ -16813,8 +16434,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/gibs{
 	layer = 3.5
@@ -16954,8 +16574,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -17009,8 +16628,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating/airless,
@@ -17035,8 +16653,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway1)
@@ -17076,8 +16693,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/clothing/gloves/color/yellow/fake,
 /turf/simulated/floor/plasteel{
@@ -17154,14 +16770,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/living)
@@ -17195,8 +16809,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -17249,14 +16862,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/spacebattle/engineering)
@@ -17264,8 +16875,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -17297,8 +16907,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -17400,8 +17009,7 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/hallway11)
 "Ws" = (
@@ -17409,8 +17017,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
@@ -17431,8 +17038,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -17452,8 +17058,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/closed{
 	layer = 2.8
@@ -17482,8 +17087,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -17589,8 +17193,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/mass_driver_frame{
 	dir = 1
@@ -17661,8 +17264,7 @@
 "Xd" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/awaymission/spacebattle/hallway11)
 "Xe" = (
@@ -17723,8 +17325,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
@@ -17747,8 +17348,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "spacebattlestorage";
@@ -17831,8 +17431,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway12)
@@ -17860,8 +17459,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/spacebattle/engine)
@@ -17913,8 +17511,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel,
@@ -17929,8 +17526,7 @@
 "XT" = (
 /obj/structure/shuttle/engine/router,
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/window/plasmareinforced{
 	dir = 1;
@@ -17942,8 +17538,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -17961,8 +17556,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -17999,8 +17593,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway3)
@@ -18037,8 +17630,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security,
 /turf/simulated/floor/plasteel{
@@ -18049,8 +17641,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway6)
@@ -18153,8 +17744,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/mob_spawn/human/corpse/spacebattle/engineer,
 /turf/simulated/floor/plasteel,
@@ -18232,8 +17822,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
@@ -18250,8 +17839,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/item/stack/sheet/mineral/titanium,
 /obj/effect/mapping_helpers/turfs/damage,
@@ -18420,8 +18008,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway8)
@@ -18466,8 +18053,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -18478,8 +18064,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -18530,8 +18115,7 @@
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/pod/dark,
@@ -18565,16 +18149,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "ZN" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/item/stack/medical/splint,
@@ -18596,8 +18178,7 @@
 "ZQ" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/awaymission/spacebattle/medbay)
 "ZR" = (
@@ -18608,8 +18189,7 @@
 	},
 /turf/simulated/floor/plasteel/airless{
 	dir = 10;
-	icon_state = "floor4";
-	tag = "icon-floor4 (SOUTHWEST)"
+	icon_state = "floor4"
 	},
 /area/space/nearstation)
 "ZS" = (
@@ -18637,8 +18217,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/spacebattle/hallway3)
@@ -49357,7 +48936,7 @@ we
 EX
 WH
 MV
-bJ
+Nq
 pB
 nt
 nt
@@ -52440,7 +52019,7 @@ Gc
 VI
 ZI
 vn
-NY
+rJ
 BI
 Fz
 QZ
@@ -55552,7 +55131,7 @@ kk
 kM
 ro
 Oj
-ei
+pk
 AT
 pm
 ab
@@ -61455,7 +61034,7 @@ bh
 Re
 MI
 WS
-ei
+pk
 ZS
 Sm
 ab

--- a/_maps/map_files/RandomZLevels/stationCollision.dmm
+++ b/_maps/map_files/RandomZLevels/stationCollision.dmm
@@ -91,8 +91,7 @@
 "av" = (
 /obj/structure/window/reinforced/tinted,
 /obj/structure/window/reinforced/tinted{
-	dir = 8;
-	tag = ""
+	dir = 8
 	},
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
@@ -127,8 +126,7 @@
 "aA" = (
 /obj/structure/window/reinforced/tinted,
 /obj/structure/window/reinforced/tinted{
-	dir = 4;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel/airless,
@@ -161,8 +159,7 @@
 "aI" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "burst_l";
-	tag = "icon-burst_l (EAST)"
+	icon_state = "burst_l"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/awaymission/syndishuttle)
@@ -186,7 +183,6 @@
 /area/awaymission/northblock)
 "aP" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
@@ -272,14 +268,12 @@
 /area/awaymission/northblock)
 "bj" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-bluecorner (WEST)";
 	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/awaymission/northblock)
 "bk" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/awaymission/northblock)
@@ -291,7 +285,6 @@
 /area/awaymission/northblock)
 "bm" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (WEST)";
 	icon_state = "blue";
 	dir = 8
 	},
@@ -308,7 +301,6 @@
 /area/awaymission/syndishuttle)
 "bq" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
 	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
@@ -327,7 +319,6 @@
 /area/awaymission/syndishuttle)
 "bu" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (SOUTHEAST)";
 	icon_state = "blue";
 	dir = 6
 	},
@@ -351,20 +342,17 @@
 "bz" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/awaymission/northblock)
 "bA" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (SOUTHWEST)";
 	icon_state = "blue";
 	dir = 10
 	},
 /area/awaymission/northblock)
 "bB" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTHWEST)";
 	icon_state = "blue";
 	dir = 9
 	},
@@ -379,7 +367,6 @@
 /area/awaymission/northblock)
 "bD" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTH)";
 	icon_state = "blue";
 	dir = 1
 	},
@@ -490,14 +477,12 @@
 /area/awaymission/research)
 "bV" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (NORTH)";
 	dir = 1
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/awaymission/syndishuttle)
 "bX" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTHEAST)";
 	icon_state = "blue";
 	dir = 5
 	},
@@ -688,14 +673,12 @@
 "cy" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "burst_l";
-	tag = "icon-burst_l (EAST)"
+	icon_state = "burst_l"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/awaymission/research)
 "cz" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
 	dir = 8
 	},
 /obj/structure/window/reinforced,
@@ -767,7 +750,6 @@
 /area/awaymission/research)
 "cK" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -901,7 +883,6 @@
 /area/awaymission/northblock)
 "db" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted,
@@ -975,8 +956,7 @@
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/rank/bartender,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/toy/russian_revolver,
@@ -1027,15 +1007,13 @@
 	name = "Security Airlock"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/research)
 "ds" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plating/airless,
@@ -1048,8 +1026,7 @@
 	name = "Windoor"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -1057,8 +1034,7 @@
 /area/awaymission/research)
 "du" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -1075,40 +1051,34 @@
 "dw" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (EAST)";
 	icon_state = "blue";
 	dir = 4
 	},
 /area/awaymission/northblock)
 "dx" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/northblock)
 "dy" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/northblock)
 "dz" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (EAST)";
 	icon_state = "blue";
 	dir = 4
 	},
 /area/awaymission/northblock)
 "dA" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -1116,8 +1086,7 @@
 "dB" = (
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = -10;
-	tag = "icon-shower (EAST)"
+	pixel_y = -10
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -1126,8 +1095,7 @@
 /area/awaymission/research)
 "dC" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating/airless,
@@ -1177,8 +1145,7 @@
 /area/awaymission/research)
 "dI" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/midblock)
@@ -1213,7 +1180,6 @@
 "dM" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-bluecorner (EAST)";
 	icon_state = "bluecorner";
 	dir = 4
 	},
@@ -1234,7 +1200,6 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTHWEST)";
 	icon_state = "blue";
 	dir = 9
 	},
@@ -1242,14 +1207,12 @@
 "dP" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTH)";
 	icon_state = "blue";
 	dir = 1
 	},
 /area/awaymission/northblock)
 "dQ" = (
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-bluecorner (EAST)";
 	icon_state = "bluecorner";
 	dir = 4
 	},
@@ -1340,7 +1303,6 @@
 /obj/machinery/light/small,
 /obj/structure/computerframe,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTH)";
 	icon_state = "blue";
 	dir = 1
 	},
@@ -1348,7 +1310,6 @@
 "ee" = (
 /obj/machinery/computer/crew,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-bluecorner (EAST)";
 	icon_state = "bluecorner";
 	dir = 4
 	},
@@ -1356,7 +1317,6 @@
 "ef" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel/airless{
-	tag = "icon-blue (NORTH)";
 	icon_state = "blue";
 	dir = 1
 	},
@@ -1388,8 +1348,7 @@
 /area/awaymission/syndishuttle)
 "ej" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plating/airless,
@@ -1459,15 +1418,13 @@
 "es" = (
 /obj/machinery/door/airlock/command,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/northblock)
 "et" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel/airless,
@@ -1483,20 +1440,17 @@
 /area/awaymission/arrivalblock)
 "ev" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/northblock)
 "ew" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plating/airless,
@@ -1570,7 +1524,6 @@
 /area/awaymission/research)
 "eH" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -1746,8 +1699,7 @@
 /area/awaymission/midblock)
 "fb" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/northblock)
@@ -1898,23 +1850,20 @@
 /area/awaymission/midblock)
 "fr" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/northblock)
 "fs" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/midblock)
 "ft" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel/airless,
@@ -2007,8 +1956,7 @@
 /obj/item/ammo_casing/c10mm,
 /obj/item/clothing/under/syndicate,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/item/gun/projectile/shotgun/toy/tommygun,
 /turf/simulated/floor/plasteel,
@@ -2033,20 +1981,17 @@
 /area/awaymission/midblock)
 "fF" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/midblock)
 "fG" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plasteel/airless,
@@ -2134,8 +2079,7 @@
 /area/awaymission/northblock)
 "fT" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/midblock)
@@ -2214,8 +2158,7 @@
 /area/awaymission/midblock)
 "gg" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plating/airless,
@@ -2230,12 +2173,10 @@
 "gj" = (
 /obj/structure/closet/wardrobe/pjs,
 /obj/structure/window/reinforced/tinted{
-	dir = 8;
-	tag = ""
+	dir = 8
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 4;
-	tag = ""
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -2273,8 +2214,7 @@
 /area/awaymission/midblock)
 "gq" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/midblock)
@@ -2384,16 +2324,14 @@
 "gG" = (
 /obj/structure/table,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/midblock)
 "gH" = (
 /obj/structure/chair/stool,
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/midblock)
@@ -2543,12 +2481,10 @@
 /area/awaymission/midblock)
 "hd" = (
 /obj/structure/window/reinforced/tinted{
-	dir = 4;
-	tag = ""
+	dir = 4
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 8;
-	tag = ""
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/midblock)
@@ -2602,8 +2538,7 @@
 "hj" = (
 /obj/structure/chair/stool,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/midblock)
@@ -2717,8 +2652,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/midblock)
@@ -2745,8 +2679,7 @@
 /area/awaymission/midblock)
 "hD" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/midblock)
@@ -2811,8 +2744,7 @@
 /area/awaymission/midblock)
 "hO" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/plasteel,
@@ -2887,8 +2819,7 @@
 /area/awaymission/arrivalblock)
 "hY" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/arrivalblock)
@@ -2897,16 +2828,14 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/arrivalblock)
 "ia" = (
 /obj/effect/decal/remains/human,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red";
@@ -2918,15 +2847,13 @@
 	name = "Glass Airlock"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/arrivalblock)
 "ic" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/midblock)
@@ -3053,8 +2980,7 @@
 "iy" = (
 /obj/item/ammo_casing/c10mm,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/plasteel,
@@ -3129,8 +3055,7 @@
 "iI" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/midblock)
@@ -3196,8 +3121,7 @@
 /area/awaymission/southblock)
 "iS" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/southblock)
@@ -3259,7 +3183,6 @@
 /area/awaymission/arrivalblock)
 "jd" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r";
 	icon_state = "propulsion_r"
 	},
 /obj/structure/shuttle/engine/propulsion,
@@ -3274,15 +3197,12 @@
 /area/awaymission/arrivalblock)
 "jg" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l";
 	icon_state = "propulsion_l"
 	},
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-burst_l";
 	icon_state = "burst_l"
 	},
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l";
 	icon_state = "propulsion_l"
 	},
 /obj/structure/shuttle/engine/propulsion,
@@ -3290,15 +3210,13 @@
 /area/awaymission/arrivalblock)
 "jh" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/southblock)
 "ji" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/southblock)
@@ -3307,37 +3225,31 @@
 	pixel_y = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/southblock)
 "jk" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/southblock)
 "jl" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/southblock)
 "jm" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel/airless,
 /area/awaymission/southblock)
@@ -3358,8 +3270,7 @@
 	name = "Airlock"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/southblock)
@@ -3376,8 +3287,7 @@
 "jt" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/southblock)
@@ -3448,8 +3358,7 @@
 /area/awaymission/southblock)
 "jE" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/southblock)
@@ -3627,8 +3536,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/southblock)
@@ -3657,8 +3565,7 @@
 /area/awaymission/gateroom)
 "kk" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/landmark/awaystart,
 /obj/effect/decal/warning_stripes/north,
@@ -3717,8 +3624,7 @@
 /area/awaymission/gateroom)
 "ks" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/gateway,
 /turf/simulated/floor/plasteel,
@@ -3762,7 +3668,6 @@
 /area/awaymission/gateroom)
 "kA" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (NORTH)";
 	icon_state = "propulsion_l";
 	dir = 1
 	},
@@ -3771,7 +3676,6 @@
 /area/awaymission/arrivalblock)
 "kB" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_r (NORTH)";
 	icon_state = "propulsion_r";
 	dir = 1
 	},
@@ -3832,28 +3736,24 @@
 /area/awaymission/gateroom)
 "kL" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/awaymission/southblock)
 "kM" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/awaymission/southblock)
 "kN" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -3882,7 +3782,6 @@
 /area/awaymission/arrivalblock)
 "kR" = (
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitehall (WEST)";
 	icon_state = "whitehall";
 	dir = 8
 	},
@@ -3912,8 +3811,7 @@
 /area/awaymission/gateroom)
 "kW" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/landmark/awaystart,
 /turf/simulated/floor/plasteel,
@@ -3924,8 +3822,7 @@
 /area/awaymission/southblock)
 "kY" = (
 /obj/structure/window/reinforced/tinted{
-	dir = 8;
-	tag = ""
+	dir = 8
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -3974,15 +3871,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whitehall (WEST)";
 	icon_state = "whitehall";
 	dir = 8
 	},
 /area/awaymission/southblock)
 "li" = (
 /obj/structure/window/reinforced/tinted{
-	dir = 8;
-	tag = ""
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/southblock)
@@ -4091,15 +3986,13 @@
 "lA" = (
 /obj/effect/decal/remains/human,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/southblock)
 "lB" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "Security Airlock"
@@ -4111,8 +4004,7 @@
 /area/awaymission/gateroom)
 "lD" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/gateroom)
@@ -4171,45 +4063,38 @@
 /area/awaymission/southblock)
 "lM" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/southblock)
 "lN" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/southblock)
 "lR" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering,
 /turf/simulated/floor/plasteel,
 /area/awaymission/gateroom)
 "lS" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/gateroom)
 "lT" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/gateroom)
@@ -4251,8 +4136,7 @@
 /area/awaymission/southblock)
 "lY" = (
 /obj/structure/window/reinforced/tinted{
-	dir = 8;
-	tag = ""
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
@@ -4268,8 +4152,7 @@
 /area/awaymission/southblock)
 "md" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
@@ -70,7 +70,6 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue";
-	tag = "icon-darkblue";
 	temperature = 273.15
 	},
 /area/awaymission/UO45/central_hall)
@@ -101,7 +100,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue";
-	tag = "icon-darkblue";
 	temperature = 273.15
 	},
 /area/awaymission/UO45/central_hall)
@@ -112,8 +110,7 @@
 "au" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "darkblue";
-	tag = "icon-darkblue (SOUTHEAST)"
+	icon_state = "darkblue"
 	},
 /area/awaymission/UO45/central_hall)
 "ax" = (
@@ -139,8 +136,7 @@
 "aD" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "floorgrime";
-	tag = "icon-floorgrime (WEST)"
+	icon_state = "floorgrime"
 	},
 /area/awaymission/UO45/central_hall)
 "aE" = (
@@ -255,8 +251,7 @@
 /area/awaymission/UO45/central_hall)
 "aU" = (
 /obj/structure/chair/comfy/beige{
-	dir = 4;
-	tag = "icon-comfychair (EAST)"
+	dir = 4
 	},
 /obj/effect/landmark/awaystart,
 /turf/simulated/floor/plasteel{
@@ -646,8 +641,7 @@
 "bS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/wall,
 /area/awaymission/UO45/central_hall)
@@ -665,8 +659,7 @@
 "bV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/wall/rust,
 /area/awaymission/UO45/central_hall)
@@ -729,8 +722,7 @@
 "cf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -762,8 +754,7 @@
 "ck" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/central_hall)
@@ -848,8 +839,7 @@
 "cy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
@@ -866,8 +856,7 @@
 "cA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/under/suit_jacket/female,
@@ -894,8 +883,7 @@
 	dir = 10
 	},
 /obj/structure/chair/wood{
-	dir = 4;
-	tag = "icon-wooden_chair (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO45/central_hall)
@@ -938,8 +926,7 @@
 	on = 1
 	},
 /obj/structure/chair/wood{
-	dir = 1;
-	tag = "icon-wooden_chair (NORTH)"
+	dir = 1
 	},
 /obj/machinery/door_control{
 	id = "awaydorm2";
@@ -998,8 +985,7 @@
 "cP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plating,
@@ -1007,8 +993,7 @@
 "cQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/central_hall)
@@ -1025,8 +1010,7 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/basic{
-	dir = 8;
-	tag = "icon-window (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/central_hall)
@@ -1043,8 +1027,7 @@
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/window/basic{
-	dir = 4;
-	tag = "icon-window (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/central_hall)
@@ -1187,8 +1170,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "greencorner";
-	tag = "icon-greencorner"
+	icon_state = "greencorner"
 	},
 /area/awaymission/UO45/central_hall)
 "dq" = (
@@ -1252,8 +1234,7 @@
 /area/awaymission/UO45/central_hall)
 "dy" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -1418,8 +1399,7 @@
 /area/awaymission/UO45/central_hall)
 "dO" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1429,8 +1409,7 @@
 "dP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/structure/chair,
 /obj/structure/reagent_dispensers/peppertank{
@@ -1552,8 +1531,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "floorgrime";
-	tag = "icon-floorgrime (WEST)"
+	icon_state = "floorgrime"
 	},
 /area/awaymission/UO45/central_hall)
 "ee" = (
@@ -1599,8 +1577,7 @@
 "ei" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1675,15 +1652,13 @@
 "et" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/wall,
 /area/awaymission/UO45/central_hall)
 "eu" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -1747,8 +1722,7 @@
 /area/awaymission/UO45/central_hall)
 "eA" = (
 /obj/structure/chair/office{
-	dir = 4;
-	tag = "icon-chair (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -1765,8 +1739,7 @@
 /area/awaymission/UO45/central_hall)
 "eD" = (
 /obj/structure/chair/office{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1777,8 +1750,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "floorgrime";
-	tag = "icon-floorgrime (WEST)"
+	icon_state = "floorgrime"
 	},
 /area/awaymission/UO45/central_hall)
 "eF" = (
@@ -1794,8 +1766,7 @@
 "eG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/central_hall)
@@ -1860,8 +1831,7 @@
 /area/awaymission/UO45/central_hall)
 "eO" = (
 /obj/structure/chair/office{
-	dir = 4;
-	tag = "icon-chair (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -1983,8 +1953,7 @@
 /area/awaymission/UO45/central_hall)
 "fc" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "greencorner";
-	tag = "icon-greencorner"
+	icon_state = "greencorner"
 	},
 /area/awaymission/UO45/central_hall)
 "fd" = (
@@ -2041,8 +2010,7 @@
 /area/awaymission/UO45/central_hall)
 "fi" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -2051,8 +2019,7 @@
 /area/awaymission/UO45/central_hall)
 "fj" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
@@ -2064,8 +2031,7 @@
 "fk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "green"
@@ -2073,8 +2039,7 @@
 /area/awaymission/UO45/central_hall)
 "fl" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "green"
@@ -2082,8 +2047,7 @@
 /area/awaymission/UO45/central_hall)
 "fm" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -2167,8 +2131,7 @@
 /area/awaymission/UO45/central_hall)
 "fx" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2184,8 +2147,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2198,8 +2160,7 @@
 /area/awaymission/UO45/gateaway)
 "fA" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2209,8 +2170,7 @@
 "fB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO45/central_hall)
@@ -2254,8 +2214,7 @@
 "fG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/central_hall)
@@ -2322,8 +2281,7 @@
 /area/awaymission/UO45/crew_quarters)
 "fQ" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2422,8 +2380,7 @@
 /area/awaymission/UO45/crew_quarters)
 "gc" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2473,8 +2430,7 @@
 /area/awaymission/UO45/crew_quarters)
 "gk" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2531,8 +2487,7 @@
 /area/awaymission/UO45/central_hall)
 "gr" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -2582,8 +2537,7 @@
 "gB" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "floorgrime";
-	tag = "icon-floorgrime (WEST)"
+	icon_state = "floorgrime"
 	},
 /area/awaymission/UO45/crew_quarters)
 "gC" = (
@@ -2595,16 +2549,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "gE" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "gF" = (
@@ -2619,8 +2571,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "gG" = (
@@ -2629,8 +2580,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "gH" = (
@@ -2638,14 +2588,12 @@
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "gI" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2693,8 +2641,7 @@
 "gP" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "gQ" = (
@@ -2705,14 +2652,12 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "gR" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2919,8 +2864,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "hr" = (
@@ -2930,16 +2874,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "hs" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "ht" = (
@@ -2961,8 +2903,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "hu" = (
@@ -2996,8 +2937,7 @@
 	on = 1
 	},
 /obj/structure/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -3005,8 +2945,7 @@
 /area/awaymission/UO45/gateaway)
 "hy" = (
 /obj/structure/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -3124,8 +3063,7 @@
 /area/awaymission/UO45/crew_quarters)
 "hL" = (
 /obj/structure/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -3184,8 +3122,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "hS" = (
@@ -3194,8 +3131,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "hT" = (
@@ -3205,8 +3141,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "hU" = (
@@ -3214,8 +3149,7 @@
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "hV" = (
@@ -3236,8 +3170,7 @@
 /obj/item/book/manual/chef_recipes,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "hX" = (
@@ -3248,14 +3181,12 @@
 /area/awaymission/UO45/central_hall)
 "hY" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/central_hall)
@@ -3297,8 +3228,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -3306,8 +3236,7 @@
 /area/awaymission/UO45/gateaway)
 "id" = (
 /obj/structure/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -3366,8 +3295,7 @@
 /area/awaymission/UO45/crew_quarters)
 "in" = (
 /obj/structure/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -3397,8 +3325,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "ir" = (
@@ -3406,8 +3333,7 @@
 /obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "is" = (
@@ -3417,8 +3343,7 @@
 /obj/machinery/processor,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "it" = (
@@ -3445,8 +3370,7 @@
 /area/awaymission/UO45/gateaway)
 "iw" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window{
 	dir = 2;
@@ -3460,8 +3384,7 @@
 "ix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/nosmoking_2{
@@ -3583,8 +3506,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "iL" = (
@@ -3593,8 +3515,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "iM" = (
@@ -3611,14 +3532,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "iN" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3657,8 +3576,7 @@
 /area/awaymission/UO45/gateaway)
 "iR" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/gateaway)
@@ -3678,8 +3596,7 @@
 "iU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -3693,8 +3610,7 @@
 	dir = 4
 	},
 /obj/structure/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -3787,8 +3703,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "jf" = (
@@ -3803,8 +3718,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "jg" = (
@@ -3819,8 +3733,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/crew_quarters)
 "jh" = (
@@ -3844,8 +3757,7 @@
 /area/awaymission/UO45/gateaway)
 "jk" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3991,8 +3903,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/machinery/door/airlock{
 	name = "Kitchen";
@@ -4083,8 +3994,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -4130,8 +4040,7 @@
 /area/awaymission/UO45/crew_quarters)
 "jS" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4144,8 +4053,7 @@
 /area/awaymission/UO45/research)
 "jT" = (
 /obj/structure/chair{
-	dir = 4;
-	tag = "icon-chair (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -4186,12 +4094,10 @@
 /area/awaymission/UO45/crew_quarters)
 "jX" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction/reversed{
 	dir = 2
@@ -4206,8 +4112,7 @@
 /area/awaymission/UO45/crew_quarters)
 "jY" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -4222,8 +4127,7 @@
 /area/awaymission/UO45/crew_quarters)
 "jZ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4235,8 +4139,7 @@
 /area/awaymission/UO45/central_hall)
 "ka" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4249,8 +4152,7 @@
 /area/awaymission/UO45/crew_quarters)
 "kb" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4259,8 +4161,7 @@
 /area/awaymission/UO45/research)
 "kc" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4273,8 +4174,7 @@
 /area/awaymission/UO45/central_hall)
 "kd" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -4288,8 +4188,7 @@
 "ke" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/command{
 	icon_state = "door_closed";
@@ -4318,8 +4217,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/research)
 "kj" = (
@@ -4408,14 +4306,12 @@
 /area/awaymission/UO45/crew_quarters)
 "ku" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /obj/machinery/firealarm/no_alarm{
 	dir = 4;
@@ -4437,8 +4333,7 @@
 /area/awaymission/UO45/crew_quarters)
 "kw" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -4473,8 +4368,7 @@
 /obj/item/assembly/prox_sensor,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "warndark";
-	tag = "icon-warndark (EAST)"
+	icon_state = "warndark"
 	},
 /area/awaymission/UO45/gateaway)
 "kA" = (
@@ -4500,8 +4394,7 @@
 /area/awaymission/UO45/research)
 "kC" = (
 /obj/structure/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -4510,8 +4403,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/basic{
-	dir = 4;
-	tag = "icon-window (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -4558,8 +4450,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/gateaway)
 "kI" = (
@@ -4569,8 +4460,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/gateaway)
 "kJ" = (
@@ -4582,8 +4472,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/gateaway)
 "kK" = (
@@ -4601,20 +4490,17 @@
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	heat_capacity = 1e+006;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/gateaway)
 "kL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/gateaway)
 "kM" = (
@@ -4628,8 +4514,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/gateaway)
 "kN" = (
@@ -4641,8 +4526,7 @@
 "kO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -4672,8 +4556,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/research)
 "kS" = (
@@ -4683,20 +4566,17 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/research)
 "kT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/research)
 "kU" = (
@@ -4713,8 +4593,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/research)
 "kV" = (
@@ -4725,8 +4604,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/research)
 "kW" = (
@@ -4735,16 +4613,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/research)
 "kX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/research)
 "kY" = (
@@ -4755,8 +4631,7 @@
 /area/awaymission/UO45/research)
 "kZ" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4804,16 +4679,14 @@
 "le" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/structure/sign/science{
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "purplecorner";
-	tag = "icon-purplecorner (WEST)"
+	icon_state = "purplecorner"
 	},
 /area/awaymission/UO45/crew_quarters)
 "lf" = (
@@ -4884,8 +4757,7 @@
 /area/awaymission/UO45/crew_quarters)
 "lm" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2
@@ -4901,8 +4773,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -4926,14 +4797,12 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "warndark";
-	tag = "icon-warndark (EAST)"
+	icon_state = "warndark"
 	},
 /area/awaymission/UO45/gateaway)
 "lq" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -4943,15 +4812,13 @@
 /area/awaymission/UO45/gateaway)
 "lr" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/gateaway)
 "ls" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4960,12 +4827,10 @@
 /area/awaymission/UO45/gateaway)
 "lt" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/machinery/alarm/monitor{
 	locked = 0;
@@ -4983,8 +4848,7 @@
 /area/awaymission/UO45/gateaway)
 "lu" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4994,8 +4858,7 @@
 /area/awaymission/UO45/gateaway)
 "lv" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -5005,8 +4868,7 @@
 "lw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5021,8 +4883,7 @@
 "lx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5037,13 +4898,11 @@
 /area/awaymission/UO45/gateaway)
 "ly" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -5051,8 +4910,7 @@
 /area/awaymission/UO45/gateaway)
 "lz" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5063,8 +4921,7 @@
 /area/awaymission/UO45/gateaway)
 "lA" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -5073,8 +4930,7 @@
 /area/awaymission/UO45/gateaway)
 "lB" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm/no_alarm{
 	dir = 1;
@@ -5094,8 +4950,7 @@
 /area/awaymission/UO45/gateaway)
 "lC" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5111,8 +4966,7 @@
 "lD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5127,8 +4981,7 @@
 /area/awaymission/UO45/gateaway)
 "lE" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5140,20 +4993,17 @@
 /area/awaymission/UO45/gateaway)
 "lF" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -5162,8 +5012,7 @@
 /area/awaymission/UO45/research)
 "lG" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5198,8 +5047,7 @@
 /area/awaymission/UO45/research)
 "lI" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/junction{
@@ -5220,8 +5068,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -5295,8 +5142,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "purple";
-	tag = "icon-purple (WEST)"
+	icon_state = "purple"
 	},
 /area/awaymission/UO45/crew_quarters)
 "lS" = (
@@ -5308,8 +5154,7 @@
 /area/awaymission/UO45/crew_quarters)
 "lT" = (
 /obj/structure/chair{
-	dir = 4;
-	tag = "icon-chair (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -5345,8 +5190,7 @@
 "lW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5406,8 +5250,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "warndark";
-	tag = "icon-warndark (EAST)"
+	icon_state = "warndark"
 	},
 /area/awaymission/UO45/gateaway)
 "mc" = (
@@ -5415,8 +5258,7 @@
 /area/awaymission/UO45/gateaway)
 "md" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5465,8 +5307,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "mj" = (
@@ -5526,14 +5367,12 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "purplecorner";
-	tag = "icon-purplecorner (NORTH)"
+	icon_state = "purplecorner"
 	},
 /area/awaymission/UO45/crew_quarters)
 "mq" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5605,8 +5444,7 @@
 /area/awaymission/UO45/crew_quarters)
 "my" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5708,8 +5546,7 @@
 /obj/item/paicard_upgrade,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "mJ" = (
@@ -5724,8 +5561,7 @@
 /area/awaymission/UO45/research)
 "mL" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5742,8 +5578,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "mN" = (
@@ -5752,23 +5587,20 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "mO" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "mP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "mQ" = (
@@ -5778,8 +5610,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "mR" = (
@@ -5826,8 +5657,7 @@
 "mV" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/research)
 "mW" = (
@@ -5859,8 +5689,7 @@
 	specialfunctions = 4
 	},
 /obj/structure/chair/wood{
-	dir = 1;
-	tag = "icon-wooden_chair (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/UO45/crew_quarters)
@@ -5902,8 +5731,7 @@
 /area/awaymission/UO45/crew_quarters)
 "ne" = (
 /obj/structure/chair/comfy/black{
-	dir = 4;
-	tag = "icon-comfychair (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -5912,8 +5740,7 @@
 /area/awaymission/UO45/crew_quarters)
 "nf" = (
 /obj/structure/chair/comfy/black{
-	dir = 8;
-	tag = "icon-comfychair (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -5940,8 +5767,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "ni" = (
@@ -5956,8 +5782,7 @@
 /area/awaymission/UO45/engineering)
 "nk" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5971,16 +5796,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "nm" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "nn" = (
@@ -5988,8 +5811,7 @@
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "no" = (
@@ -6033,14 +5855,12 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/awaymission/UO45/research)
 "nt" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6052,8 +5872,7 @@
 /area/awaymission/UO45/research)
 "nu" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6065,8 +5884,7 @@
 /area/awaymission/UO45/research)
 "nv" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -6080,8 +5898,7 @@
 /area/awaymission/UO45/crew_quarters)
 "nw" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6094,16 +5911,14 @@
 /area/awaymission/UO45/research)
 "nx" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -6178,21 +5993,18 @@
 /area/awaymission/UO45/crew_quarters)
 "nH" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/engineering)
 "nI" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/crew_quarters)
@@ -6205,23 +6017,19 @@
 /area/awaymission/UO45/crew_quarters)
 "nK" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/engineering)
 "nL" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/engineering)
@@ -6240,8 +6048,7 @@
 /obj/item/laser_pointer,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "nN" = (
@@ -6250,8 +6057,7 @@
 /area/awaymission/UO45/research)
 "nO" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6272,8 +6078,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "nQ" = (
@@ -6288,8 +6093,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "nR" = (
@@ -6302,8 +6106,7 @@
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "nS" = (
@@ -6322,8 +6125,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "nT" = (
@@ -6359,8 +6161,7 @@
 /area/awaymission/UO45/research)
 "nW" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -6410,8 +6211,7 @@
 /area/awaymission/UO45/crew_quarters)
 "ob" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6426,8 +6226,7 @@
 /area/awaymission/UO45/crew_quarters)
 "oc" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6443,8 +6242,7 @@
 /area/awaymission/UO45/crew_quarters)
 "od" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6462,8 +6260,7 @@
 "oe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6478,8 +6275,7 @@
 /area/awaymission/UO45/crew_quarters)
 "of" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -6489,8 +6285,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -6500,8 +6295,7 @@
 /area/awaymission/UO45/crew_quarters)
 "og" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6514,8 +6308,7 @@
 /area/awaymission/UO45/crew_quarters)
 "oh" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6528,8 +6321,7 @@
 /area/awaymission/UO45/crew_quarters)
 "oi" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/alarm/monitor{
 	locked = 0;
@@ -6541,8 +6333,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -6552,8 +6343,7 @@
 /area/awaymission/UO45/crew_quarters)
 "oj" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6569,8 +6359,7 @@
 /area/awaymission/UO45/crew_quarters)
 "ok" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6585,8 +6374,7 @@
 /area/awaymission/UO45/crew_quarters)
 "ol" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6609,8 +6397,7 @@
 /area/awaymission/UO45/engineering)
 "on" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6622,8 +6409,7 @@
 /area/awaymission/UO45/crew_quarters)
 "oo" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 2
@@ -6639,8 +6425,7 @@
 "op" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6655,19 +6440,16 @@
 /area/awaymission/UO45/crew_quarters)
 "oq" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/engineering)
 "or" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
@@ -6678,23 +6460,20 @@
 /area/awaymission/UO45/crew_quarters)
 "os" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/crew_quarters)
 "ot" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6725,8 +6504,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "ox" = (
@@ -6750,16 +6528,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "oy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "oz" = (
@@ -6770,16 +6546,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "oA" = (
 /obj/machinery/computer/aifixer,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "oB" = (
@@ -6847,8 +6621,7 @@
 "oI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/crew_quarters)
@@ -6892,8 +6665,7 @@
 /area/awaymission/UO45/crew_quarters)
 "oN" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -6933,8 +6705,7 @@
 /area/awaymission/UO45/crew_quarters)
 "oR" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -6944,8 +6715,7 @@
 /area/awaymission/UO45/engineering)
 "oS" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -6954,8 +6724,7 @@
 /area/awaymission/UO45/engineering)
 "oT" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/alarm/monitor{
 	dir = 8;
@@ -6977,16 +6746,14 @@
 "oU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/crew_quarters)
 "oV" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7038,8 +6805,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "oZ" = (
@@ -7075,14 +6841,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "pd" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -7097,8 +6861,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "pf" = (
@@ -7108,8 +6871,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/UO45/research)
 "pg" = (
@@ -7228,8 +6990,7 @@
 /area/awaymission/UO45/crew_quarters)
 "ps" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -7244,12 +7005,10 @@
 /area/awaymission/UO45/crew_quarters)
 "pu" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 10
@@ -7284,8 +7043,7 @@
 /area/awaymission/UO45/engineering)
 "pA" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
@@ -7294,15 +7052,13 @@
 /area/awaymission/UO45/engineering)
 "pB" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/engineering)
 "pC" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/engineering)
@@ -7345,8 +7101,7 @@
 /area/awaymission/UO45/engineering)
 "pH" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7484,8 +7239,7 @@
 /area/awaymission/UO45/crew_quarters)
 "pY" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7494,8 +7248,7 @@
 /area/awaymission/UO45/research)
 "pZ" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "SMES Room";
@@ -7592,8 +7345,7 @@
 /area/awaymission/UO45/research)
 "qk" = (
 /obj/structure/toilet{
-	dir = 8;
-	tag = "icon-toilet00 (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -7772,12 +7524,10 @@
 /area/awaymission/UO45/engineering)
 "qE" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -7803,8 +7553,7 @@
 /area/awaymission/UO45/engineering)
 "qG" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 5;
@@ -7845,8 +7594,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "arrival";
-	tag = "icon-arrival (NORTHWEST)"
+	icon_state = "arrival"
 	},
 /area/awaymission/UO45/engineering)
 "qJ" = (
@@ -7922,8 +7670,7 @@
 /area/awaymission/UO45/research)
 "qP" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7981,8 +7728,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -8083,8 +7829,7 @@
 /area/awaymission/UO45/crew_quarters)
 "rf" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8228,12 +7973,10 @@
 /area/awaymission/UO45/engineering)
 "rs" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6;
@@ -8309,8 +8052,7 @@
 /area/awaymission/UO45/research)
 "rB" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction/reversed{
 	dir = 4
@@ -8356,8 +8098,7 @@
 "rF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -8397,8 +8138,7 @@
 /area/awaymission/UO45/research)
 "rJ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8419,8 +8159,7 @@
 /area/awaymission/UO45/crew_quarters)
 "rL" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8434,8 +8173,7 @@
 /area/awaymission/UO45/research)
 "rM" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8450,8 +8188,7 @@
 /area/awaymission/UO45/crew_quarters)
 "rN" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8467,12 +8204,10 @@
 /area/awaymission/UO45/crew_quarters)
 "rO" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -8486,8 +8221,7 @@
 "rP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Hallway";
@@ -8498,16 +8232,14 @@
 /area/awaymission/UO45/crew_quarters)
 "rQ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -8522,16 +8254,14 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/crew_quarters)
 "rS" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/alarm/monitor{
 	locked = 0;
@@ -8551,8 +8281,7 @@
 /area/awaymission/UO45/crew_quarters)
 "rT" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8568,8 +8297,7 @@
 /area/awaymission/UO45/crew_quarters)
 "rU" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8587,8 +8315,7 @@
 /area/awaymission/UO45/crew_quarters)
 "rV" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8614,8 +8341,7 @@
 "rX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8632,8 +8358,7 @@
 "rY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -8642,8 +8367,7 @@
 /area/awaymission/UO45/engineering)
 "rZ" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8653,8 +8377,7 @@
 /area/awaymission/UO45/engineering)
 "sa" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8678,8 +8401,7 @@
 /area/awaymission/UO45/engineering)
 "sc" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -8734,8 +8456,7 @@
 "sg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/engineering)
@@ -8774,8 +8495,7 @@
 /area/awaymission/UO45/engineering)
 "sk" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/meter{
 	id = "UO45_dloop_atm_meter";
@@ -8957,13 +8677,11 @@
 /area/awaymission/UO45/crew_quarters)
 "sE" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/crew_quarters)
@@ -9017,8 +8735,7 @@
 "sK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -9061,8 +8778,7 @@
 "sO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /obj/structure/table,
 /obj/item/book/manual/security_space_law,
@@ -9073,14 +8789,12 @@
 /area/awaymission/UO45/engineering)
 "sP" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/engineering)
@@ -9148,8 +8862,7 @@
 /area/awaymission/UO45/engineering)
 "sW" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 1
@@ -9240,23 +8953,20 @@
 /area/awaymission/UO45/engineering)
 "th" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/research)
 "ti" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -9280,8 +8990,7 @@
 /area/awaymission/UO45/research)
 "tl" = (
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -9306,8 +9015,7 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "escape";
-	tag = "icon-escape (NORTH)"
+	icon_state = "escape"
 	},
 /area/awaymission/UO45/engineering)
 "to" = (
@@ -9332,15 +9040,13 @@
 "tr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/wall/r_wall/rust,
 /area/awaymission/UO45/research)
 "ts" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9358,16 +9064,14 @@
 /area/awaymission/UO45/engineering)
 "tu" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/crew_quarters)
@@ -9394,8 +9098,7 @@
 /area/awaymission/UO45/engineering)
 "tx" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9423,8 +9126,7 @@
 "tz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/item/screwdriver{
 	pixel_y = 10
@@ -9477,8 +9179,7 @@
 /area/awaymission/UO45/engineering)
 "tF" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 4;
@@ -9522,8 +9223,7 @@
 /area/awaymission/UO45/engineering)
 "tK" = (
 /obj/structure/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+	dir = 8
 	},
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
@@ -9559,8 +9259,7 @@
 /area/awaymission/UO45/research)
 "tP" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9572,8 +9271,7 @@
 /area/awaymission/UO45/research)
 "tQ" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -9591,8 +9289,7 @@
 /area/awaymission/UO45/crew_quarters)
 "tS" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9620,24 +9317,21 @@
 /area/awaymission/UO45/crew_quarters)
 "tV" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-r-f (NORTH)"
+	initialize_directions = 14
 	},
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/awaymission/UO45/research)
 "tW" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9656,8 +9350,7 @@
 /area/awaymission/UO45/research)
 "tY" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -9723,8 +9416,7 @@
 "uf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9778,8 +9470,7 @@
 /area/awaymission/UO45/engineering)
 "ul" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -9913,8 +9604,7 @@
 "uz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "UO45_Engineering";
@@ -9954,14 +9644,12 @@
 /area/awaymission/UO45/research)
 "uE" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/engineering)
@@ -9978,8 +9666,7 @@
 /area/awaymission/UO45/engineering)
 "uH" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering";
@@ -10032,8 +9719,7 @@
 /area/awaymission/UO45/research)
 "uO" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -10116,8 +9802,7 @@
 /area/awaymission/UO45/engineering)
 "uX" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10247,8 +9932,7 @@
 /area/awaymission/UO45/mining)
 "vk" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -10304,8 +9988,7 @@
 /area/awaymission/UO45/engineering)
 "vs" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -10328,8 +10011,7 @@
 /area/awaymission/UO45/mining)
 "vu" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10342,8 +10024,7 @@
 /area/awaymission/UO45/engineering)
 "vv" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -10353,8 +10034,7 @@
 /area/awaymission/UO45/engineering)
 "vw" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10363,20 +10043,17 @@
 /area/awaymission/UO45/engineering)
 "vx" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
-	initialize_directions = 14;
-	tag = "icon-manifold-b-f (NORTH)"
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/engineering)
@@ -10392,28 +10069,24 @@
 /area/awaymission/UO45/mining)
 "vz" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/mining)
 "vA" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/engineering)
 "vB" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering";
@@ -10428,14 +10101,12 @@
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "caution";
-	tag = "icon-caution (SOUTHWEST)"
+	icon_state = "caution"
 	},
 /area/awaymission/UO45/engineering)
 "vD" = (
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/engineering)
@@ -10489,8 +10160,7 @@
 "vO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/mining/glass{
@@ -10511,8 +10181,7 @@
 "vQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -10560,8 +10229,7 @@
 /area/awaymission/UO45/mining)
 "vV" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10604,8 +10272,7 @@
 	req_access = null
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -10660,13 +10327,11 @@
 /area/awaymission/UO45/mining)
 "wh" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer";
@@ -10679,13 +10344,11 @@
 /area/awaymission/UO45/engineering)
 "wi" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/mining)
@@ -10793,8 +10456,7 @@
 /area/awaymission/UO45/mining)
 "wv" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -10802,8 +10464,7 @@
 "ww" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-b-f (EAST)"
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/mining)
@@ -10827,8 +10488,7 @@
 /area/awaymission/UO45/engineering)
 "wz" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -10873,8 +10533,7 @@
 /area/awaymission/UO45/mining)
 "wD" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -10892,8 +10551,7 @@
 /area/awaymission/UO45/engineering)
 "wG" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -10915,8 +10573,7 @@
 /area/awaymission/UO45/engineering)
 "wJ" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -10987,8 +10644,7 @@
 /area/awaymission/UO45/mining)
 "wQ" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11016,8 +10672,7 @@
 /area/awaymission/UO45/engineering)
 "wT" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -11085,13 +10740,11 @@
 "wY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
@@ -11120,8 +10773,7 @@
 /area/awaymission/UO45/engineering)
 "xb" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -11151,8 +10803,7 @@
 	pixel_y = -28
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -11183,8 +10834,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/mining)
@@ -11228,8 +10878,7 @@
 "xl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
-	initialize_directions = 11;
-	tag = "icon-manifold-r-f (EAST)"
+	initialize_directions = 11
 	},
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal{
@@ -11306,8 +10955,7 @@
 "xu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/mining)
@@ -11354,12 +11002,10 @@
 "xA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-r-f (WEST)"
+	initialize_directions = 7
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/mining)
@@ -11409,16 +11055,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/mining)
 "xI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	initialize_directions = 7;
-	tag = "icon-manifold-b-f (WEST)"
+	initialize_directions = 7
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/mining)
@@ -11428,8 +11072,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/mining)
@@ -11442,8 +11085,7 @@
 	req_access = list(201)
 	},
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/mining)
@@ -11453,8 +11095,7 @@
 	on = 1
 	},
 /obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/UO45/mining)
@@ -11489,19 +11130,16 @@
 /area/awaymission/UO45/mining)
 "xS" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/awaymission/UO45/mining)
 "xT" = (
 /obj/machinery/mech_bay_recharge_port{
-	dir = 8;
-	tag = "icon-recharge_port (WEST)"
+	dir = 8
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -11527,8 +11165,7 @@
 /area/awaymission/UO45/mining)
 "yf" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds2";
-	tag = "icon-weeds2"
+	icon_state = "weeds2"
 	},
 /obj/structure/bed/nest,
 /obj/effect/mob_spawn/human/miner,
@@ -11536,8 +11173,7 @@
 /area/awaymission/UO45/caves)
 "yg" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds1";
-	tag = "icon-weeds1"
+	icon_state = "weeds1"
 	},
 /obj/effect/mob_spawn/human/miner,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -11588,32 +11224,28 @@
 /area/awaymission/UO45/caves)
 "yo" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds1";
-	tag = "icon-weeds1"
+	icon_state = "weeds1"
 	},
 /obj/effect/mob_spawn/human/miner,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaymission/UO45/caves)
 "yp" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds2";
-	tag = "icon-weeds2"
+	icon_state = "weeds2"
 	},
 /obj/structure/glowshroom/single,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaymission/UO45/caves)
 "yq" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds2";
-	tag = "icon-weeds2"
+	icon_state = "weeds2"
 	},
 /obj/structure/bed/nest,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaymission/UO45/caves)
 "yr" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds1";
-	tag = "icon-weeds1"
+	icon_state = "weeds1"
 	},
 /obj/effect/decal/cleanable/blood/gibs{
 	color = "red";
@@ -11623,8 +11255,7 @@
 /area/awaymission/UO45/caves)
 "ys" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds2";
-	tag = "icon-weeds2"
+	icon_state = "weeds2"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaymission/UO45/caves)
@@ -11637,8 +11268,7 @@
 /area/awaymission/UO45/caves)
 "yu" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds1";
-	tag = "icon-weeds1"
+	icon_state = "weeds1"
 	},
 /obj/structure/glowshroom/single,
 /turf/simulated/floor/plating/asteroid/airless,
@@ -11650,8 +11280,7 @@
 /area/awaymission/UO45/caves)
 "yw" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds2";
-	tag = "icon-weeds2"
+	icon_state = "weeds2"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -11670,8 +11299,7 @@
 /area/awaymission/UO45/caves)
 "yy" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds1";
-	tag = "icon-weeds1"
+	icon_state = "weeds1"
 	},
 /turf/simulated/floor/plating/asteroid/airless,
 /area/awaymission/UO45/caves)
@@ -11681,8 +11309,7 @@
 /area/awaymission/UO45/caves)
 "yA" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds2";
-	tag = "icon-weeds2"
+	icon_state = "weeds2"
 	},
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -11692,8 +11319,7 @@
 /area/awaymission/UO45/caves)
 "yB" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds2";
-	tag = "icon-weeds2"
+	icon_state = "weeds2"
 	},
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -11709,8 +11335,7 @@
 /area/awaymission/UO45/caves)
 "yD" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds1";
-	tag = "icon-weeds1"
+	icon_state = "weeds1"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -11735,8 +11360,7 @@
 /area/awaymission/UO45/caves)
 "yG" = (
 /obj/structure/alien/weeds{
-	icon_state = "weeds1";
-	tag = "icon-weeds1"
+	icon_state = "weeds1"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";

--- a/_maps/map_files/RandomZLevels/wildwest.dmm
+++ b/_maps/map_files/RandomZLevels/wildwest.dmm
@@ -14,8 +14,7 @@
 /area/awaymission/wwvault)
 "ae" = (
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "cultdamage5";
-	tag = "icon-cultdamage5"
+	icon_state = "cultdamage5"
 	},
 /area/awaymission/wwvault)
 "af" = (
@@ -24,20 +23,17 @@
 /area/awaymission/wwvault)
 "ag" = (
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "bcircuitoff";
-	tag = "icon-bcircuitoff"
+	icon_state = "bcircuitoff"
 	},
 /area/awaymission/wwvault)
 "aj" = (
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "cultdamage3";
-	tag = "icon-cultdamage3"
+	icon_state = "cultdamage3"
 	},
 /area/awaymission/wwvault)
 "ak" = (
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "cultdamage6";
-	tag = "icon-cultdamage6"
+	icon_state = "cultdamage6"
 	},
 /area/awaymission/wwvault)
 "al" = (
@@ -47,28 +43,24 @@
 "am" = (
 /mob/living/simple_animal/hostile/faithless,
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "bcircuitoff";
-	tag = "icon-bcircuitoff"
+	icon_state = "bcircuitoff"
 	},
 /area/awaymission/wwvault)
 "ao" = (
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "ap" = (
 /obj/machinery/wish_granter_dark,
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "aq" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "ar" = (
@@ -76,8 +68,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "as" = (
@@ -85,8 +76,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "at" = (
@@ -94,8 +84,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "au" = (
@@ -103,8 +92,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "av" = (
@@ -112,8 +100,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "aw" = (
@@ -121,8 +108,7 @@
 	calibrated = 0
 	},
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "ax" = (
@@ -130,8 +116,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "ay" = (
@@ -139,35 +124,30 @@
 	dir = 6
 	},
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "az" = (
 /obj/machinery/gateway,
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "aA" = (
 /obj/effect/meatgrinder,
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "gcircuitoff";
-	tag = "icon-gcircuitoff"
+	icon_state = "gcircuitoff"
 	},
 /area/awaymission/wwvault)
 "aB" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "bcircuitoff";
-	tag = "icon-bcircuitoff"
+	icon_state = "bcircuitoff"
 	},
 /area/awaymission/wwvault)
 "aC" = (
 /turf/simulated/floor/shuttle/plating{
-	icon_state = "cultdamage2";
-	tag = "icon-cultdamage2"
+	icon_state = "cultdamage2"
 	},
 /area/awaymission/wwvault)
 "aD" = (
@@ -256,8 +236,7 @@
 /area/awaymission/wwrefine)
 "bd" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	icon_state = "gibup1";
-	tag = "icon-gibup1"
+	icon_state = "gibup1"
 	},
 /turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwmines)
@@ -322,23 +301,20 @@
 /area/awaymission/wwmines)
 "bv" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	icon_state = "gibup1";
-	tag = "icon-gibup1"
+	icon_state = "gibup1"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "bw" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
 "bx" = (
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -346,8 +322,7 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "bz" = (
@@ -357,8 +332,7 @@
 "bA" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "bB" = (
@@ -376,8 +350,7 @@
 /mob/living/simple_animal/hostile/syndicate/ranged/wildwest,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "bF" = (
@@ -395,32 +368,28 @@
 "bI" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /obj/item/gun/projectile/automatic/pistol,
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "bJ" = (
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/wwmines)
 "bK" = (
 /obj/structure/table/wood,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "bL" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /obj/item/kitchen/knife/butcher,
 /turf/simulated/floor/wood,
@@ -436,15 +405,13 @@
 "bO" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "bP" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -452,28 +419,24 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "bR" = (
 /obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "bS" = (
 /obj/item/book/manual/chef_recipes,
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "bT" = (
@@ -485,28 +448,24 @@
 /obj/item/reagent_containers/food/snacks/meat/syntiflesh,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "bU" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
 "bV" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -517,12 +476,10 @@
 "bW" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -530,18 +487,15 @@
 "bX" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
@@ -556,20 +510,17 @@
 "ca" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
 "cb" = (
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "cc" = (
@@ -578,19 +529,16 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "cd" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "ce" = (
@@ -599,8 +547,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "cf" = (
@@ -622,8 +569,7 @@
 "cj" = (
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -633,19 +579,16 @@
 "cl" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
@@ -655,13 +598,11 @@
 "cn" = (
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -672,13 +613,11 @@
 "co" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -692,8 +631,7 @@
 /obj/effect/mob_spawn/human/cook,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "cr" = (
@@ -710,13 +648,11 @@
 "cu" = (
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -741,8 +677,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "cz" = (
@@ -757,8 +692,7 @@
 /area/awaymission/wwgov)
 "cB" = (
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/wwmines)
@@ -768,23 +702,20 @@
 /area/awaymission/wwgov)
 "cD" = (
 /obj/structure/bookcase{
-	icon_state = "book-5";
-	tag = "icon-book-5"
+	icon_state = "book-5"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
 "cE" = (
 /obj/item/storage/bag/money,
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
 "cF" = (
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
@@ -820,8 +751,7 @@
 /area/awaymission/wwgov)
 "cN" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "cO" = (
@@ -834,34 +764,29 @@
 "cP" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "cQ" = (
 /obj/machinery/kitchen_machine/microwave,
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "cR" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "cS" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -896,26 +821,22 @@
 /area/awaymission/wwgov)
 "cY" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "cZ" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
@@ -930,22 +851,19 @@
 "dc" = (
 /obj/item/storage/toolbox/electrical,
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
 "dd" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
 "de" = (
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwgov)
@@ -957,42 +875,35 @@
 /area/space/nearstation)
 "dg" = (
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dh" = (
 /mob/living/simple_animal/hostile/creature,
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "di" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dj" = (
 /obj/structure/bookcase{
-	icon_state = "book-5";
-	tag = "icon-book-5"
+	icon_state = "book-5"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "dk" = (
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -1008,15 +919,13 @@
 "dn" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "do" = (
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -1036,18 +945,15 @@
 "ds" = (
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
@@ -1058,13 +964,11 @@
 "du" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -1082,22 +986,19 @@
 "dx" = (
 /obj/item/reagent_containers/food/snacks/monkeysdelight,
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dy" = (
 /obj/item/reagent_containers/food/snacks/soup/stew,
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dz" = (
 /obj/item/kitchen/knife,
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dA" = (
@@ -1121,8 +1022,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -1131,27 +1031,23 @@
 	dir = 8
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "dG" = (
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
@@ -1161,26 +1057,22 @@
 /area/awaymission/wwmines)
 "dI" = (
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /mob/living/simple_animal/hostile/creature,
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dJ" = (
 /obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dK" = (
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwmines)
@@ -1193,16 +1085,12 @@
 /area/awaymission/wwmines)
 "dM" = (
 /obj/structure/mineral_door/wood,
-/turf/simulated/floor/plating/ironsand{
-	tag = "icon-ironsand1"
-	},
+/turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwmines)
 "dN" = (
 /obj/structure/mineral_door/wood,
 /obj/effect/decal/cleanable/blood/tracks,
-/turf/simulated/floor/plating/ironsand{
-	tag = "icon-ironsand1"
-	},
+/turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwmines)
 "dO" = (
 /obj/structure/chair/comfy/beige{
@@ -1218,15 +1106,13 @@
 "dQ" = (
 /obj/item/reagent_containers/food/drinks/bottle/wine,
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dR" = (
 /obj/item/reagent_containers/food/drinks/bottle/patron,
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dS" = (
@@ -1236,8 +1122,7 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	icon_state = "stage_bleft";
-	tag = "icon-stage_bleft"
+	icon_state = "stage_bleft"
 	},
 /area/awaymission/wwgov)
 "dT" = (
@@ -1256,8 +1141,7 @@
 /area/awaymission/wwmines)
 "dW" = (
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwgov)
@@ -1271,50 +1155,42 @@
 /area/awaymission/wwgov)
 "dZ" = (
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
 "ea" = (
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
 "eb" = (
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwgov)
@@ -1322,8 +1198,7 @@
 /obj/structure/toilet,
 /mob/living/simple_animal/hostile/creature,
 /turf/simulated/floor/plasteel{
-	icon_state = "white";
-	tag = "icon-white"
+	icon_state = "white"
 	},
 /area/awaymission/wwgov)
 "ed" = (
@@ -1333,8 +1208,7 @@
 "ee" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwgov)
@@ -1346,25 +1220,21 @@
 /area/awaymission/wwgov)
 "eh" = (
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "ei" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "ej" = (
@@ -1380,8 +1250,7 @@
 /area/awaymission/wwmines)
 "em" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	icon_state = "gibdown1";
-	tag = "icon-gibdown1"
+	icon_state = "gibdown1"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/wwmines)
@@ -1393,8 +1262,7 @@
 /area/awaymission/wwmines)
 "eo" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	icon_state = "gibdown1";
-	tag = "icon-gibdown1"
+	icon_state = "gibdown1"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -1423,8 +1291,7 @@
 /area/awaymission/wwmines)
 "eu" = (
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwmines)
@@ -1432,13 +1299,11 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -1447,8 +1312,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -1456,25 +1320,21 @@
 "ex" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
 "ey" = (
 /obj/machinery/shower{
-	dir = 4;
-	tag = "icon-shower (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "ez" = (
@@ -1490,27 +1350,23 @@
 /obj/item/soap/syndie,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "eD" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "eE" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "eG" = (
@@ -1538,8 +1394,7 @@
 "eL" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -1547,25 +1402,21 @@
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
 "eN" = (
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -1573,8 +1424,7 @@
 "eO" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1584,26 +1434,22 @@
 "eP" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
 "eQ" = (
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -1615,13 +1461,11 @@
 "eS" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -1630,8 +1474,7 @@
 /obj/effect/mine/gas/plasma,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "eU" = (
@@ -1643,8 +1486,7 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "eW" = (
@@ -1684,13 +1526,11 @@
 "fd" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -1710,8 +1550,7 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "fh" = (
@@ -1731,8 +1570,7 @@
 /area/awaymission/wwmines)
 "fj" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	icon_state = "gibdown1";
-	tag = "icon-gibdown1"
+	icon_state = "gibdown1"
 	},
 /turf/simulated/floor/plating/ironsand,
 /area/awaymission/wwmines)
@@ -1744,8 +1582,7 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/awaymission/wwmines)
 "fm" = (
@@ -1775,19 +1612,16 @@
 "fq" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
@@ -1812,12 +1646,10 @@
 /area/awaymission/wwrefine)
 "fv" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	icon_state = "gibdown1";
-	tag = "icon-gibdown1"
+	icon_state = "gibdown1"
 	},
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -1826,8 +1658,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/gibs/body{
-	icon_state = "gibdown1";
-	tag = "icon-gibdown1"
+	icon_state = "gibdown1"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/wwmines)
@@ -1838,8 +1669,7 @@
 "fz" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -1877,27 +1707,23 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
 "fH" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -1916,14 +1742,12 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/wwrefine)
@@ -1935,8 +1759,7 @@
 /area/awaymission/wwmines)
 "fM" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	icon_state = "gibup1";
-	tag = "icon-gibup1"
+	icon_state = "gibup1"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/wwmines)
@@ -1954,8 +1777,7 @@
 /area/awaymission/wwmines)
 "fQ" = (
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2011,8 +1833,7 @@
 "fZ" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2030,13 +1851,11 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -2044,15 +1863,13 @@
 "gc" = (
 /obj/structure/sink,
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "gd" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	icon_state = "gibdown1";
-	tag = "icon-gibdown1"
+	icon_state = "gibdown1"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2070,13 +1887,11 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (EAST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -2090,8 +1905,7 @@
 /area/awaymission/wwmines)
 "gh" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2136,20 +1950,17 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
 "gp" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -2165,15 +1976,13 @@
 	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "gu" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	icon_state = "gibup1";
-	tag = "icon-gibup1"
+	icon_state = "gibup1"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -2183,8 +1992,7 @@
 "gv" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
@@ -2197,13 +2005,11 @@
 "gx" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
@@ -2213,8 +2019,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (NORTH)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
@@ -2227,8 +2032,7 @@
 "gA" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -2247,8 +2051,7 @@
 "gE" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
@@ -2261,8 +2064,7 @@
 /area/awaymission/wwmines)
 "gH" = (
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
@@ -2271,16 +2073,14 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/wwgov)
 "gJ" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/plasteel,
 /area/space/nearstation)
@@ -2300,8 +2100,7 @@
 "gM" = (
 /obj/machinery/photocopier,
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
@@ -2318,15 +2117,13 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/gibs/body{
-	icon_state = "gibdown1";
-	tag = "icon-gibdown1"
+	icon_state = "gibdown1"
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)
 "gR" = (
 /obj/effect/decal/cleanable/blood/gibs/body{
-	icon_state = "gibup1";
-	tag = "icon-gibup1"
+	icon_state = "gibup1"
 	},
 /obj/structure/chair/wood,
 /turf/simulated/floor/plasteel{
@@ -2349,8 +2146,7 @@
 "he" = (
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "fwindow";
-	tag = "icon-fwindow (WEST)"
+	icon_state = "fwindow"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/grass,
@@ -2358,8 +2154,7 @@
 "hj" = (
 /obj/machinery/door/airlock/titanium,
 /turf/simulated/floor/shuttle{
-	icon_state = "floor2";
-	tag = "icon-floor2"
+	icon_state = "floor2"
 	},
 /area/awaymission/wwrefine)
 "hk" = (
@@ -2370,8 +2165,7 @@
 "ho" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/shuttle{
-	icon_state = "floor2";
-	tag = "icon-floor2"
+	icon_state = "floor2"
 	},
 /area/awaymission/wwrefine)
 "hp" = (
@@ -2381,15 +2175,13 @@
 /area/awaymission/wwmines)
 "hr" = (
 /turf/simulated/floor/shuttle{
-	icon_state = "floor2";
-	tag = "icon-floor2"
+	icon_state = "floor2"
 	},
 /area/awaymission/wwrefine)
 "hu" = (
 /obj/effect/mob_spawn/human/miner,
 /turf/simulated/floor/shuttle{
-	icon_state = "floor2";
-	tag = "icon-floor2"
+	icon_state = "floor2"
 	},
 /area/awaymission/wwrefine)
 "hv" = (
@@ -2403,8 +2195,7 @@
 /obj/item/tank/internals/oxygen,
 /obj/item/clothing/shoes/magboots,
 /turf/simulated/floor/shuttle{
-	icon_state = "floor2";
-	tag = "icon-floor2"
+	icon_state = "floor2"
 	},
 /area/awaymission/wwrefine)
 "hz" = (
@@ -2419,12 +2210,10 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	icon_state = "fwindow";
-	tag = "icon-fwindow"
+	icon_state = "fwindow"
 	},
 /turf/simulated/floor/shuttle{
-	icon_state = "floor2";
-	tag = "icon-floor2"
+	icon_state = "floor2"
 	},
 /area/awaymission/wwrefine)
 "hA" = (
@@ -2442,8 +2231,7 @@
 "DI" = (
 /obj/structure/closet/crate/large,
 /obj/machinery/light/small{
-	dir = 1;
-	tag = "icon-bulb1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/wwmines)

--- a/_maps/map_files/coldcolony/Lavaland.dmm
+++ b/_maps/map_files/coldcolony/Lavaland.dmm
@@ -388,8 +388,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ruin/unpowered)
 "en" = (
@@ -3655,8 +3654,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ruin/unpowered)
 "FQ" = (
@@ -5032,8 +5030,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ruin/unpowered)
 "UD" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -14791,13 +14791,11 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/southleft{
 	name = "Bar Delivery";
-	req_access = list(25);
-	tag = "icon-left (WEST)"
+	req_access = list(25)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "beN" = (
@@ -17096,8 +17094,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "bnR" = (
@@ -17218,8 +17215,7 @@
 /obj/effect/landmark/start/bartender,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "bof" = (
@@ -17476,8 +17472,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "boW" = (
@@ -17726,8 +17721,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "bqa" = (
@@ -18502,8 +18496,7 @@
 /obj/machinery/light_switch/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "bsU" = (
@@ -20962,8 +20955,7 @@
 /obj/machinery/atmospherics/unary/tank/nitrous_oxide,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "bFf" = (
@@ -23788,9 +23780,7 @@
 	pixel_y = 2
 	},
 /obj/item/reagent_containers/glass/bottle/reagent/ammonia,
-/obj/item/reagent_containers/glass/bottle/reagent/ammonia{
-	pixel_x = 0
-	},
+/obj/item/reagent_containers/glass/bottle/reagent/ammonia,
 /obj/item/reagent_containers/glass/bottle/reagent/diethylamine{
 	pixel_x = 12
 	},
@@ -26506,8 +26496,7 @@
 "bYP" = (
 /obj/structure/table,
 /obj/item/twohanded/required/kirbyplants{
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -32221,8 +32210,7 @@
 "ctY" = (
 /obj/structure/table,
 /obj/item/twohanded/required/kirbyplants{
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -36426,8 +36414,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "cKD" = (
@@ -36905,8 +36892,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "cMH" = (
@@ -38400,8 +38386,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "cRL" = (
@@ -38445,16 +38430,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "cRP" = (
 /obj/effect/landmark/start/bartender,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "cRQ" = (
@@ -39351,8 +39334,7 @@
 "cVa" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "cVb" = (
@@ -39426,8 +39408,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "cVj" = (
@@ -39468,8 +39449,7 @@
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "cVt" = (
@@ -39775,8 +39755,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "cWG" = (
@@ -40916,8 +40895,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "dat" = (
@@ -43224,8 +43202,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "djl" = (
@@ -43584,8 +43561,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/quartermaster/miningdock)
 "dkB" = (
@@ -43838,8 +43814,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "dlk" = (
@@ -44289,8 +44264,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "dmD" = (
@@ -44574,8 +44548,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "dnG" = (
@@ -44669,8 +44642,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "dnO" = (
@@ -47942,8 +47914,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "etT" = (
@@ -49088,8 +49059,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "eSA" = (
@@ -49334,8 +49304,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "eXa" = (
@@ -50101,8 +50070,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "frw" = (
@@ -52638,8 +52606,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "gvx" = (
@@ -54722,8 +54689,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/twohanded/required/kirbyplants{
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -56077,8 +56043,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "hYV" = (
@@ -57386,8 +57351,7 @@
 /area/toxins/xenobiology)
 "iCG" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 8;
-	tag = "icon-heater (NORTH)"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -57479,8 +57443,7 @@
 /obj/structure/closet/crate/can,
 /obj/item/reagent_containers/glass/bottle/ethanol,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/apmaint)
 "iET" = (
@@ -57507,8 +57470,7 @@
 /obj/structure/grille,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "iFi" = (
@@ -58953,8 +58915,7 @@
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "jmE" = (
@@ -59733,8 +59694,7 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "jDp" = (
@@ -60195,8 +60155,7 @@
 	pixel_y = -6
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -60599,8 +60558,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "kbh" = (
@@ -61165,8 +61123,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/papershredder,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/fpmaint)
 "klV" = (
@@ -61465,8 +61422,7 @@
 /obj/random/tool,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "ktq" = (
@@ -62026,8 +61982,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "kFL" = (
@@ -62390,8 +62345,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "kMh" = (
@@ -65262,8 +65216,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "lXV" = (
@@ -67015,8 +66968,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "mMo" = (
@@ -67781,8 +67733,7 @@
 /obj/machinery/door/firedoor/closed,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "nii" = (
@@ -68138,8 +68089,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "nqw" = (
@@ -68192,8 +68142,7 @@
 	},
 /obj/structure/table,
 /obj/item/twohanded/required/kirbyplants{
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
@@ -69304,8 +69253,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/fpmaint)
 "nNp" = (
@@ -70183,8 +70131,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "olv" = (
@@ -70966,8 +70913,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/apmaint)
 "oDX" = (
@@ -71704,8 +71650,7 @@
 "oUh" = (
 /obj/structure/table,
 /obj/item/twohanded/required/kirbyplants{
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
@@ -72707,8 +72652,7 @@
 	pixel_y = -10
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/port)
 "prF" = (
@@ -76415,8 +76359,7 @@
 /obj/item/reagent_containers/glass/rag,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "qUW" = (
@@ -76729,8 +76672,7 @@
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "rbU" = (
@@ -77674,8 +77616,7 @@
 /obj/item/trash/syndi_cakes,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "rxH" = (
@@ -77954,8 +77895,7 @@
 	pixel_y = 6
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -79369,8 +79309,7 @@
 	pixel_y = 5
 	},
 /obj/item/twohanded/required/kirbyplants{
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -80047,8 +79986,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/hallway/secondary/entry/lounge)
 "sDq" = (
@@ -80857,8 +80795,7 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "sSG" = (
@@ -80952,8 +80889,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/hallway/secondary/entry/lounge)
 "sVu" = (
@@ -82100,8 +82036,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "ttk" = (
@@ -82380,8 +82315,7 @@
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -82410,8 +82344,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "tAk" = (
@@ -84551,8 +84484,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance/tripple,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/apmaint)
 "uyc" = (
@@ -84615,8 +84547,7 @@
 /obj/structure/table,
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-dead";
-	pixel_y = 15;
-	tag = "plant-dead"
+	pixel_y = 15
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -84625,8 +84556,7 @@
 /obj/item/trash/semki,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "uAE" = (
@@ -84708,8 +84638,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "uCu" = (
@@ -86015,8 +85944,7 @@
 /area/hallway/secondary/entry)
 "vej" = (
 /obj/item/twohanded/required/kirbyplants{
-	pixel_y = 23;
-	tag = "plant-dead"
+	pixel_y = 23
 	},
 /obj/structure/dresser,
 /obj/machinery/light_switch/directional/east,
@@ -89652,8 +89580,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/quartermaster/miningdock)
 "wEg" = (
@@ -90994,8 +90921,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/hallway/secondary/entry/lounge)
 "xfY" = (
@@ -92880,8 +92806,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/trading)
 "xUp" = (
@@ -93360,8 +93285,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
 "yfj" = (

--- a/_maps/map_files/de_kerberos_2/de_kerberos_2.dmm
+++ b/_maps/map_files/de_kerberos_2/de_kerberos_2.dmm
@@ -527,8 +527,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "aeG" = (
@@ -1315,8 +1314,7 @@
 /area/engineering/mechanic_workshop/expedition)
 "amQ" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
@@ -2617,8 +2615,7 @@
 /area/hallway/secondary/entry/additional)
 "awU" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	tag = "icon-propulsion (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/arrival/station)
@@ -2969,8 +2966,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "azh" = (
@@ -3055,8 +3051,7 @@
 "aAa" = (
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/shuttle/plating,
@@ -9915,8 +9910,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "bsB" = (
@@ -14261,8 +14255,7 @@
 /area/medical/research)
 "bNJ" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
@@ -19738,8 +19731,7 @@
 /area/clownoffice)
 "cpP" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/tourist)
 "cpQ" = (
@@ -22610,8 +22602,7 @@
 "cDV" = (
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /obj/effect/turf_decal/siding/white/end,
 /turf/simulated/floor/plasteel{
@@ -22705,8 +22696,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "cEn" = (
@@ -25195,8 +25185,7 @@
 	},
 /obj/structure/closet/loot_crate/blue,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "cPX" = (
@@ -26876,8 +26865,7 @@
 "cXD" = (
 /obj/machinery/door/window/southleft{
 	name = "Bar Delivery";
-	req_access = list(25);
-	tag = "icon-left (WEST)"
+	req_access = list(25)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -27675,8 +27663,7 @@
 "dbm" = (
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dust,
@@ -28920,8 +28907,7 @@
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "dgY" = (
@@ -29227,8 +29213,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "die" = (
@@ -31583,8 +31568,7 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /obj/effect/turf_decal/siding/white/end{
 	dir = 1
@@ -32220,8 +32204,7 @@
 /area/maintenance/asmaint2)
 "dwo" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-25";
-	tag = "icon-plant-25"
+	icon_state = "plant-25"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar/atrium)
@@ -33124,8 +33107,7 @@
 /obj/effect/landmark/start/captain,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 6;
-	tag = "icon-shower (EAST)"
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -35874,8 +35856,7 @@
 	},
 /obj/machinery/kitchen_machine/grill,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/starboard)
 "dNm" = (
@@ -35941,8 +35922,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "dNv" = (
@@ -39081,8 +39061,7 @@
 /area/toxins/launch)
 "ebt" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plasteel{
@@ -39404,8 +39383,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "eeD" = (
@@ -39615,8 +39593,7 @@
 "egO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/tourist)
 "egU" = (
@@ -40557,8 +40534,7 @@
 /obj/structure/table/glass,
 /obj/item/twohanded/required/kirbyplants{
 	layer = 5.1;
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreencorner"
@@ -41394,8 +41370,7 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "eBI" = (
@@ -42951,8 +42926,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "eTH" = (
@@ -43642,8 +43616,7 @@
 	pixel_y = -12
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/crew_quarters/theatre)
 "fat" = (
@@ -44692,8 +44665,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/engineering)
 "foZ" = (
@@ -44854,8 +44826,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "frJ" = (
@@ -45405,8 +45376,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/starboard)
 "fye" = (
@@ -47650,8 +47620,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/confetti,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/crew_quarters/theatre)
 "fZm" = (
@@ -48143,8 +48112,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "gfx" = (
@@ -48623,8 +48591,7 @@
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "gmi" = (
@@ -49107,8 +49074,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "gre" = (
@@ -49319,8 +49285,7 @@
 "gue" = (
 /obj/effect/landmark/spawner/ninja_teleport,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
@@ -51281,15 +51246,13 @@
 /area/maintenance/tourist)
 "gPC" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/tourist)
 "gPJ" = (
@@ -51740,8 +51703,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/eastright{
 	name = "Hydroponics Delivery";
-	req_access = list(35);
-	tag = "icon-right"
+	req_access = list(35)
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -51872,8 +51834,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "gWq" = (
@@ -52199,8 +52160,7 @@
 /obj/structure/closet/loot_crate/blue,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "gZC" = (
@@ -54586,8 +54546,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "hDv" = (
@@ -55189,8 +55148,7 @@
 /obj/effect/landmark/spawner/captain,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "hKL" = (
@@ -56074,8 +56032,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "hVw" = (
@@ -56191,8 +56148,7 @@
 /area/medical/virology)
 "hWA" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/tourist)
 "hWL" = (
@@ -58577,8 +58533,7 @@
 "izG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/crew_quarters/theatre)
 "izP" = (
@@ -59814,8 +59769,7 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "iOo" = (
@@ -60062,8 +60016,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "iSO" = (
@@ -60789,8 +60742,7 @@
 /obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
@@ -60910,8 +60862,7 @@
 /mob/living/simple_animal/hostile/lizard/croco/Gena,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -61853,8 +61804,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "jnj" = (
@@ -68144,8 +68094,7 @@
 "kNU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/tourist)
 "kOi" = (
@@ -71034,8 +70983,7 @@
 /area/toxins/test_area)
 "lym" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/structure/sign/poster/contraband/communist_state{
 	pixel_x = 33
@@ -71260,8 +71208,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "lAO" = (
@@ -71869,8 +71816,7 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
@@ -72318,8 +72264,7 @@
 	id = "vir_work_zone1"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology/lab)
 "lPb" = (
@@ -73995,8 +73940,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "miw" = (
@@ -74460,8 +74404,7 @@
 /area/maintenance/asmaint)
 "mna" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /obj/effect/landmark/spawner/ninja_teleport,
 /turf/simulated/floor/plasteel{
@@ -75951,8 +75894,7 @@
 /area/hallway/secondary/entry/commercial)
 "mDr" = (
 /obj/item/twohanded/required/kirbyplants{
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /obj/structure/table,
 /obj/machinery/status_display{
@@ -77610,8 +77552,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "mVO" = (
@@ -77911,8 +77852,7 @@
 "mYF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -78817,8 +78757,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "njf" = (
@@ -80105,8 +80044,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "nvQ" = (
@@ -81389,8 +81327,7 @@
 /obj/effect/spawner/random_spawners/grille_50,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "nLF" = (
@@ -83681,8 +83618,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "olS" = (
@@ -85120,8 +85056,7 @@
 /obj/effect/spawner/random_spawners/blood_5,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "oCo" = (
@@ -86362,8 +86297,7 @@
 "oRQ" = (
 /mob/living/simple_animal/moth,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/tourist)
 "oRS" = (
@@ -86607,8 +86541,7 @@
 /obj/item/chair,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "oUP" = (
@@ -88019,8 +87952,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "pkf" = (
@@ -88294,8 +88226,7 @@
 	pixel_y = 5
 	},
 /obj/item/twohanded/required/kirbyplants{
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -92126,8 +92057,7 @@
 /area/atmos/control)
 "qcw" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/curtain/open/shower,
 /obj/machinery/door_control{
@@ -93517,8 +93447,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "qqO" = (
@@ -93741,8 +93670,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "qsM" = (
@@ -93879,8 +93807,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "qtz" = (
@@ -96394,8 +96321,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "qVc" = (
@@ -97200,8 +97126,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "reH" = (
@@ -97273,8 +97198,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "rfj" = (
@@ -97291,8 +97215,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "rfm" = (
@@ -100023,8 +99946,7 @@
 /area/maintenance/kitchen)
 "rLr" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -100323,8 +100245,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "rPi" = (
@@ -101996,8 +101917,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "sja" = (
@@ -104669,8 +104589,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "sNQ" = (
@@ -107785,8 +107704,7 @@
 /obj/item/soap,
 /obj/machinery/light,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/tourist)
 "txq" = (
@@ -108667,8 +108585,7 @@
 /area/engineering/supermatter)
 "tGG" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -109458,8 +109375,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "tOb" = (
@@ -110879,8 +110795,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/trading)
 "udT" = (
@@ -111529,8 +111444,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
@@ -113871,8 +113785,7 @@
 /obj/effect/decal/warning_stripes/blue,
 /obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
@@ -115230,8 +115143,7 @@
 /obj/structure/curtain/open/shower,
 /obj/effect/landmark/spawner/blob,
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -116154,8 +116066,7 @@
 /obj/item/vending_refill/youtool,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "vmX" = (
@@ -116284,8 +116195,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "voL" = (
@@ -117014,16 +116924,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
-"vwX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
-	},
-/area/maintenance/engineering)
 "vxe" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -117751,8 +117651,7 @@
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "vDi" = (
@@ -119452,8 +119351,7 @@
 /area/quartermaster/sorting)
 "vXZ" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -119671,8 +119569,7 @@
 /obj/effect/spawner/random_spawners/grille_13,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "waS" = (
@@ -120340,8 +120237,7 @@
 /obj/random/tool,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "wjU" = (
@@ -121419,8 +121315,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "wuY" = (
@@ -127703,8 +127598,7 @@
 "xNb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -158978,7 +158872,7 @@ gMw
 iKD
 srk
 euu
-vwX
+euu
 wkZ
 eTz
 yhX

--- a/_maps/map_files/event/Station/coldcolony.dmm
+++ b/_maps/map_files/event/Station/coldcolony.dmm
@@ -3281,8 +3281,7 @@
 "bhu" = (
 /obj/machinery/shower{
 	dir = 8;
-	pixel_y = 4;
-	tag = "icon-shower (WEST)"
+	pixel_y = 4
 	},
 /obj/effect/decal/warning_stripes/blue,
 /obj/effect/decal/warning_stripes/south,
@@ -6329,8 +6328,7 @@
 /area/coldcolony/malta/security/prison/cell_block/A)
 "clQ" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/curtain/open/shower,
 /obj/effect/decal/cleanable/dirt,
@@ -10684,8 +10682,7 @@
 /area/coldcolony/malta/hallway/cargo_escape/north)
 "dRG" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plasteel{
@@ -13178,8 +13175,7 @@
 "eMx" = (
 /obj/item/chair/stool,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/coldcolony/malta/research/test_chamber)
 "eMP" = (
@@ -13956,8 +13952,7 @@
 /area/coldcolony/malta/resid_serv/kitchen)
 "eYu" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-25";
-	tag = "icon-plant-25"
+	icon_state = "plant-25"
 	},
 /turf/simulated/floor/plasteel,
 /area/coldcolony/malta/hallway/service/south)
@@ -15651,8 +15646,7 @@
 /area/coldcolony/malta/maintenance/kitchen)
 "fIQ" = (
 /obj/machinery/shower{
-	dir = 4;
-	tag = "icon-shower (EAST)"
+	dir = 4
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plasteel{
@@ -19854,8 +19848,7 @@
 	},
 /obj/effect/landmark/spawner/blob,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/coldcolony/malta/research/test_chamber)
 "hkt" = (
@@ -20888,8 +20881,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/coldcolony/malta/research/test_chamber)
 "hDC" = (
@@ -24700,8 +24692,7 @@
 /area/coldcolony/malta/quartermaster/storage)
 "jcb" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-25";
-	tag = "icon-plant-25"
+	icon_state = "plant-25"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -29151,8 +29142,7 @@
 /area/coldcolony/malta/medical/virology)
 "kEA" = (
 /obj/machinery/shower{
-	dir = 4;
-	tag = "icon-shower (EAST)"
+	dir = 4
 	},
 /obj/structure/curtain/open/shower,
 /obj/effect/decal/cleanable/dirt,
@@ -32300,8 +32290,7 @@
 /obj/item/multitool/circuit,
 /obj/item/integrated_circuit/loaded/hello_world,
 /obj/item/integrated_circuit/loaded/speech_relay{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /obj/item/compact_remote{
 	pixel_x = 8;
@@ -42243,8 +42232,7 @@
 /area/coldcolony/malta/chapel/main)
 "pvk" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -43087,8 +43075,7 @@
 "pLY" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -43815,8 +43802,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/coldcolony/malta/hallway/cargo_escape/entrance)
 "qap" = (
@@ -44411,8 +44397,7 @@
 "qmX" = (
 /obj/structure/spider/stickyweb,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/coldcolony/malta/research/test_chamber)
 "qnw" = (
@@ -49436,8 +49421,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/spawner/ninja_teleport,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/coldcolony/malta/research/storage)
 "sac" = (
@@ -50413,8 +50397,7 @@
 "stA" = (
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /obj/effect/decal/warning_stripes/blue,
 /obj/effect/decal/warning_stripes/south,
@@ -51609,8 +51592,7 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -52113,8 +52095,7 @@
 /area/coldcolony/malta/resid_serv/crew_quarters/sleep)
 "tbC" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/coldcolony/malta/hallway/cargo_escape/entrance)
 "tbD" = (
@@ -56085,8 +56066,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ruin/unpowered)
 "uyk" = (
@@ -60796,8 +60776,7 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 6;
-	tag = "icon-shower (EAST)"
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"

--- a/_maps/map_files/generic/Admin_Zone.dmm
+++ b/_maps/map_files/generic/Admin_Zone.dmm
@@ -27,8 +27,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet7-0";
-	tag = "icon-carpet7-0 (EAST)"
+	icon_state = "carpet7-0"
 	},
 /area/holodeck/source_meetinghall)
 "an" = (
@@ -111,8 +110,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet5-1";
-	tag = "icon-carpet5-1 (EAST)"
+	icon_state = "carpet5-1"
 	},
 /area/holodeck/source_theatre)
 "bf" = (
@@ -142,8 +140,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet13-5";
-	tag = "icon-carpet13-5 (EAST)"
+	icon_state = "carpet13-5"
 	},
 /area/holodeck/source_theatre)
 "bx" = (
@@ -164,8 +161,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet9-4";
-	tag = "icon-carpet9-4 (EAST)"
+	icon_state = "carpet9-4"
 	},
 /area/holodeck/source_theatre)
 "bM" = (
@@ -178,8 +174,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet5-0";
-	tag = "icon-carpet5-0 (EAST)"
+	icon_state = "carpet5-0"
 	},
 /area/holodeck/source_meetinghall)
 "bU" = (
@@ -396,8 +391,7 @@
 "ea" = (
 /obj/structure/flora/grass/brown,
 /turf/simulated/floor/holofloor{
-	icon_state = "snow";
-	tag = "icon-snow"
+	icon_state = "snow"
 	},
 /area/holodeck/source_snowfield)
 "eb" = (
@@ -467,8 +461,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet14-0";
-	tag = "icon-carpet14-0 (EAST)"
+	icon_state = "carpet14-0"
 	},
 /area/holodeck/source_meetinghall)
 "ez" = (
@@ -522,8 +515,7 @@
 "eW" = (
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/holofloor{
-	icon_state = "snow";
-	tag = "icon-snow"
+	icon_state = "snow"
 	},
 /area/holodeck/source_snowfield)
 "eY" = (
@@ -540,8 +532,7 @@
 "fa" = (
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet8-0";
-	tag = "icon-carpet8-0 (EAST)"
+	icon_state = "carpet8-0"
 	},
 /area/holodeck/source_meetinghall)
 "fc" = (
@@ -563,8 +554,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet6-0";
-	tag = "icon-carpet6-0 (EAST)"
+	icon_state = "carpet6-0"
 	},
 /area/holodeck/source_meetinghall)
 "fk" = (
@@ -711,8 +701,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet11-12";
-	tag = "icon-carpet11-12 (EAST)"
+	icon_state = "carpet11-12"
 	},
 /area/holodeck/source_theatre)
 "gK" = (
@@ -794,8 +783,7 @@
 "hM" = (
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
-	icon_state = "asteroid";
-	tag = "icon-asteroid"
+	icon_state = "asteroid"
 	},
 /area/holodeck/source_picnicarea)
 "hS" = (
@@ -816,8 +804,7 @@
 /area/tdome/arena)
 "hV" = (
 /turf/simulated/floor/holofloor{
-	icon_state = "snow";
-	tag = "icon-snow"
+	icon_state = "snow"
 	},
 /area/holodeck/source_snowfield)
 "ic" = (
@@ -876,8 +863,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet7-3";
-	tag = "icon-carpet7-3 (EAST)"
+	icon_state = "carpet7-3"
 	},
 /area/holodeck/source_theatre)
 "iK" = (
@@ -1169,8 +1155,7 @@
 /area/admin)
 "lx" = (
 /turf/simulated/floor/holofloor{
-	icon_state = "grimy";
-	tag = "icon-grimy"
+	icon_state = "grimy"
 	},
 /area/holodeck/source_meetinghall)
 "lM" = (
@@ -1200,8 +1185,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet9-0";
-	tag = "icon-carpet9-0 (EAST)"
+	icon_state = "carpet9-0"
 	},
 /area/holodeck/source_meetinghall)
 "mr" = (
@@ -1297,8 +1281,7 @@
 "nu" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/holofloor{
-	icon_state = "asteroid";
-	tag = "icon-asteroid"
+	icon_state = "asteroid"
 	},
 /area/holodeck/source_desert)
 "nv" = (
@@ -1384,8 +1367,7 @@
 "oL" = (
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "wood";
-	tag = "icon-wood (EAST)"
+	icon_state = "wood"
 	},
 /area/holodeck/source_theatre)
 "oM" = (
@@ -1587,8 +1569,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet15-0";
-	tag = "icon-carpet15-0 (EAST)"
+	icon_state = "carpet15-0"
 	},
 /area/holodeck/source_meetinghall)
 "qT" = (
@@ -1699,8 +1680,7 @@
 "ta" = (
 /obj/structure/flora/grass/both,
 /turf/simulated/floor/holofloor{
-	icon_state = "snow";
-	tag = "icon-snow"
+	icon_state = "snow"
 	},
 /area/holodeck/source_snowfield)
 "tg" = (
@@ -1766,8 +1746,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet11-0";
-	tag = "icon-carpet11-0 (EAST)"
+	icon_state = "carpet11-0"
 	},
 /area/holodeck/source_meetinghall)
 "ut" = (
@@ -1786,15 +1765,13 @@
 "uC" = (
 /obj/structure/flora/tree/dead,
 /turf/simulated/floor/holofloor{
-	icon_state = "snow";
-	tag = "icon-snow"
+	icon_state = "snow"
 	},
 /area/holodeck/source_snowfield)
 "uI" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/holofloor{
-	icon_state = "asteroid";
-	tag = "icon-asteroid"
+	icon_state = "asteroid"
 	},
 /area/holodeck/source_desert)
 "uK" = (
@@ -1865,8 +1842,7 @@
 "vo" = (
 /obj/structure/table/holotable/wood,
 /turf/simulated/floor/holofloor{
-	icon_state = "asteroid";
-	tag = "icon-asteroid"
+	icon_state = "asteroid"
 	},
 /area/holodeck/source_picnicarea)
 "vw" = (
@@ -1899,8 +1875,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet10-0";
-	tag = "icon-carpet10-0 (EAST)"
+	icon_state = "carpet10-0"
 	},
 /area/holodeck/source_meetinghall)
 "vR" = (
@@ -2014,8 +1989,7 @@
 	},
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "wood";
-	tag = "icon-wood (EAST)"
+	icon_state = "wood"
 	},
 /area/holodeck/source_theatre)
 "wP" = (
@@ -2377,8 +2351,7 @@
 "Bd" = (
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet14-10";
-	tag = "icon-carpet14-10 (EAST)"
+	icon_state = "carpet14-10"
 	},
 /area/holodeck/source_theatre)
 "Bk" = (
@@ -2463,8 +2436,7 @@
 "Bz" = (
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet6-2";
-	tag = "icon-carpet6-2 (EAST)"
+	icon_state = "carpet6-2"
 	},
 /area/holodeck/source_theatre)
 "BG" = (
@@ -2552,8 +2524,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet15-15";
-	tag = "icon-carpet15-15 (EAST)"
+	icon_state = "carpet15-15"
 	},
 /area/holodeck/source_theatre)
 "CE" = (
@@ -2646,8 +2617,7 @@
 /obj/structure/chair/stool/holostool,
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet13-0";
-	tag = "icon-carpet13-0 (EAST)"
+	icon_state = "carpet13-0"
 	},
 /area/holodeck/source_meetinghall)
 "DV" = (
@@ -3003,8 +2973,7 @@
 "HP" = (
 /obj/structure/flora/tree/pine,
 /turf/simulated/floor/holofloor{
-	icon_state = "snow";
-	tag = "icon-snow"
+	icon_state = "snow"
 	},
 /area/holodeck/source_snowfield)
 "HQ" = (
@@ -3121,8 +3090,7 @@
 /area/holodeck/source_emptycourt)
 "Jn" = (
 /turf/simulated/floor/holofloor{
-	icon_state = "rampbottom";
-	tag = "icon-rampbottom"
+	icon_state = "rampbottom"
 	},
 /area/holodeck/source_theatre)
 "Jp" = (
@@ -3656,8 +3624,7 @@
 "QG" = (
 /obj/structure/table/holotable/wood,
 /turf/simulated/floor/holofloor{
-	icon_state = "grimy";
-	tag = "icon-grimy"
+	icon_state = "grimy"
 	},
 /area/holodeck/source_meetinghall)
 "QK" = (
@@ -3785,8 +3752,7 @@
 "SP" = (
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet4-0";
-	tag = "icon-carpet4-0 (EAST)"
+	icon_state = "carpet4-0"
 	},
 /area/holodeck/source_meetinghall)
 "SQ" = (
@@ -3914,8 +3880,7 @@
 /area/admin)
 "Uf" = (
 /turf/simulated/floor/holofloor{
-	icon_state = "asteroid";
-	tag = "icon-asteroid"
+	icon_state = "asteroid"
 	},
 /area/holodeck/source_desert)
 "Ug" = (
@@ -4190,8 +4155,7 @@
 "Xk" = (
 /turf/simulated/floor/holofloor{
 	dir = 4;
-	icon_state = "carpet10-8";
-	tag = "icon-carpet10-8 (EAST)"
+	icon_state = "carpet10-8"
 	},
 /area/holodeck/source_theatre)
 "Xm" = (
@@ -4455,8 +4419,7 @@
 /area/tdome/arena)
 "ZR" = (
 /turf/simulated/floor/holofloor{
-	icon_state = "asteroid";
-	tag = "icon-asteroid"
+	icon_state = "asteroid"
 	},
 /area/holodeck/source_picnicarea)
 

--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -231,8 +231,7 @@
 "adx" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater2x2_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater2x2_side"
 	},
 /obj/structure/window/reinforced{
 	color = "yellow";
@@ -887,8 +886,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "arZ" = (
@@ -1823,8 +1821,7 @@
 /obj/item/reagent_containers/food/snacks/meat,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "aOe" = (
@@ -2031,8 +2028,7 @@
 "aTQ" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/shuttle/engine/platform{
 	dir = 1;
@@ -2472,8 +2468,7 @@
 /area/shuttle/pod_2)
 "bhf" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/nt_droppod)
@@ -2483,8 +2478,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ninja/holding)
 "bhj" = (
@@ -2684,8 +2678,7 @@
 /area/syndicate_mothership/elite_squad)
 "blm" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-6";
-	tag = "icon-plant-6"
+	icon_state = "plant-6"
 	},
 /turf/simulated/floor/carpet/cyan,
 /area/centcom/zone1)
@@ -3202,8 +3195,7 @@
 /area/shuttle/administration)
 "bAh" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/structure/sign/poster/contraband/hacking_guide{
 	pixel_x = 32
@@ -3386,8 +3378,7 @@
 "bDb" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/centcom/zone2)
 "bDo" = (
@@ -3403,8 +3394,7 @@
 /obj/structure/railing,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ninja/holding)
 "bDZ" = (
@@ -3659,8 +3649,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "bLD" = (
@@ -3694,8 +3683,7 @@
 /area/syndicate_mothership)
 "bMP" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /turf/simulated/floor/plating/airless,
 /area/centcom/specops)
@@ -3717,8 +3705,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "bNW" = (
@@ -4421,8 +4408,7 @@
 "cig" = (
 /obj/structure/railing/corner,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/indestructible{
 	icon_state = "floorgrime"
@@ -4642,8 +4628,7 @@
 "ckG" = (
 /obj/machinery/icemachine,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "ckU" = (
@@ -4677,8 +4662,7 @@
 "clj" = (
 /obj/machinery/cooker/deepfryer,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "clC" = (
@@ -5013,8 +4997,7 @@
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-17";
-	tag = "icon-plant-17"
+	icon_state = "plant-17"
 	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone2)
@@ -5045,8 +5028,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "cuy" = (
@@ -5485,8 +5467,7 @@
 /area/ninja/holding)
 "cEg" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /turf/simulated/floor/indestructible{
 	icon_state = "floorgrime"
@@ -5634,8 +5615,7 @@
 /area/shuttle/syndicate)
 "cIn" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/evac)
 "cIA" = (
@@ -5690,8 +5670,7 @@
 "cJL" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/bridge)
 "cJM" = (
@@ -5991,8 +5970,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/indestructible{
 	icon_state = "floorgrime"
@@ -6158,8 +6136,7 @@
 /obj/item/reagent_containers/food/condiment/rice,
 /obj/item/reagent_containers/food/condiment/rice,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "cVb" = (
@@ -6381,8 +6358,7 @@
 /area/centcom/zone3)
 "dbj" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-30";
-	tag = "icon-plant-30"
+	icon_state = "plant-30"
 	},
 /turf/simulated/floor/wood,
 /area/centcom/zone1)
@@ -6584,8 +6560,7 @@
 "deE" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -7042,8 +7017,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ninja/holding)
 "dth" = (
@@ -7144,8 +7118,7 @@
 /area/ninja/holding)
 "duM" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "Dark"
@@ -7354,8 +7327,7 @@
 /area/vox_station)
 "dzY" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/shuttle/engine/platform{
 	layer = 2.9
@@ -7951,8 +7923,7 @@
 	icon_state = "golden_stripes"
 	},
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -8416,8 +8387,7 @@
 	icon_state = "siding8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
 "dYp" = (
@@ -8548,8 +8518,7 @@
 /area/trader_station/sol)
 "eaX" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /turf/simulated/floor/plating/airless,
 /area/centcom/specops)
@@ -8731,8 +8700,7 @@
 "eed" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/bridge)
 "eeh" = (
@@ -8835,8 +8803,7 @@
 /area/syndicate_mothership/outside)
 "egp" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-30";
-	tag = "icon-plant-30"
+	icon_state = "plant-30"
 	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone2)
@@ -8893,8 +8860,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	color = "gray";
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
 "eia" = (
@@ -9126,8 +9092,7 @@
 /area/shuttle/escape)
 "eoT" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-28";
-	tag = "icon-plant-28"
+	icon_state = "plant-28"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9461,7 +9426,6 @@
 	dir = 8;
 	light_range = 2;
 	nightshift_light_range = 2;
-	tag = "icon-bulb1 (WEST)";
 	throw_range = 2
 	},
 /obj/structure/railing/corner{
@@ -9989,8 +9953,7 @@
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -10400,8 +10363,7 @@
 /obj/structure/railing,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ninja/outpost)
 "eSL" = (
@@ -10432,8 +10394,7 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "eTw" = (
@@ -10452,8 +10413,7 @@
 /area/shuttle/pod_4)
 "eTW" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/blue,
 /area/ninja/outpost)
@@ -10520,8 +10480,7 @@
 /area/ninja/outpost)
 "eWS" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /turf/simulated/floor/plating/airless,
 /area/centcom/specops)
@@ -11604,8 +11563,7 @@
 	name = "Riot Control"
 	},
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor13"
@@ -11720,7 +11678,6 @@
 	brightness_range = 2;
 	light_range = 2;
 	nightshift_light_range = 2;
-	tag = "icon-bulb1 (WEST)";
 	throw_range = 2
 	},
 /obj/effect/turf_decal/siding/wood/corner,
@@ -11866,8 +11823,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/zone1)
 "fDZ" = (
@@ -11878,8 +11834,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ninja/outpost)
 "fEe" = (
@@ -12064,8 +12019,7 @@
 /area/centcom/specops)
 "fJx" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "Dark"
@@ -12139,8 +12093,7 @@
 "fKl" = (
 /obj/machinery/kitchen_machine/candy_maker,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "fKr" = (
@@ -12391,8 +12344,7 @@
 /area/centcom/zone1)
 "fQO" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /turf/simulated/floor/plating/airless,
 /area/centcom/jail)
@@ -12482,8 +12434,7 @@
 	dir = 1
 	},
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood{
 	icon_state = "fancy-wood-cherry"
@@ -12567,8 +12518,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "fWt" = (
@@ -12643,8 +12593,7 @@
 	icon_state = "golden_stripes"
 	},
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12829,8 +12778,7 @@
 /area/centcom/specops)
 "gcu" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	tag = "icon-propulsion (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_elite)
@@ -12875,15 +12823,13 @@
 	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/light,
 /area/ninja/outpost)
 "gdt" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/wood,
 /area/centcom/zone1)
@@ -13279,8 +13225,7 @@
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /turf/simulated/floor/wood/fancy/light,
 /area/ninja/outpost)
@@ -13318,8 +13263,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ninja/outpost)
 "gnD" = (
@@ -13384,8 +13328,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ninja/outpost)
 "gpF" = (
@@ -13532,8 +13475,7 @@
 	req_access = list(102)
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "gvs" = (
@@ -13560,8 +13502,7 @@
 /obj/structure/railing,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ninja/outpost)
 "gvQ" = (
@@ -13634,8 +13575,7 @@
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/simulated/floor/wood{
@@ -13644,12 +13584,10 @@
 /area/ninja/outpost)
 "gza" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -13787,8 +13725,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "gCz" = (
@@ -14070,8 +14007,7 @@
 	},
 /obj/structure/railing/corner,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/light,
 /area/ninja/outpost)
@@ -14201,8 +14137,7 @@
 	dir = 1
 	},
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/wood{
 	icon_state = "fancy-wood-cherry"
@@ -14288,8 +14223,7 @@
 /obj/item/gun/energy/sniperrifle,
 /obj/item/gun/energy/sniperrifle,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -14909,8 +14843,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/ninja/outpost)
 "hgc" = (
@@ -14993,8 +14926,7 @@
 "hjL" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "hjQ" = (
@@ -15041,8 +14973,7 @@
 "hkM" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (NORTH)"
+	icon_state = "propulsion_l"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/addition_goals)
@@ -15351,7 +15282,6 @@
 	brightness_range = 2;
 	light_range = 2;
 	nightshift_light_range = 2;
-	tag = "icon-bulb1 (WEST)";
 	throw_range = 2
 	},
 /turf/simulated/floor/wood{
@@ -15496,8 +15426,7 @@
 /area/ninja/outside)
 "hya" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/centcom/zone2)
 "hyg" = (
@@ -15626,8 +15555,7 @@
 /area/syndicate_mothership/control)
 "hCr" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
@@ -15815,8 +15743,7 @@
 "hIf" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (NORTH)"
+	icon_state = "propulsion_l"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/funeral)
@@ -15829,8 +15756,7 @@
 /area/centcom/supply)
 "hIm" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -15874,8 +15800,7 @@
 /area/ussp_centcom/secretariat)
 "hJr" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/red,
 /area/ninja/outpost)
@@ -15920,8 +15845,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/zone2)
 "hLD" = (
@@ -16078,8 +16002,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "hNZ" = (
@@ -16143,8 +16066,7 @@
 /area/centcom/specops)
 "hQV" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "burst_l";
-	tag = "icon-burst_l"
+	icon_state = "burst_l"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/specops)
@@ -17142,8 +17064,7 @@
 /area/syndicate_mothership/jail)
 "iuu" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/machinery/atm{
 	pixel_y = 32
@@ -17335,8 +17256,7 @@
 /obj/machinery/vending/chinese,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "ixW" = (
@@ -17468,8 +17388,7 @@
 /area/syndicate_mothership/outside)
 "iAD" = (
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/nt_droppod)
@@ -17582,15 +17501,13 @@
 /area/syndicate_mothership/outside)
 "iDq" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "fancy-wood-oak"
@@ -17701,8 +17618,7 @@
 /area/centcom/evac)
 "iFr" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-6";
-	tag = "icon-plant-6"
+	icon_state = "plant-6"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -18220,8 +18136,7 @@
 /area/syndicate_mothership/jail)
 "iSZ" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/wood{
 	icon_state = "fancy-wood-cherry"
@@ -18367,8 +18282,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "iXm" = (
@@ -18642,8 +18556,7 @@
 	pixel_y = 14
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "jdl" = (
@@ -19031,8 +18944,7 @@
 	},
 /obj/machinery/cooker/deepfryer,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "jlG" = (
@@ -19117,8 +19029,7 @@
 /area/syndicate_mothership/outside)
 "jmW" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-17";
-	tag = "icon-plant-17"
+	icon_state = "plant-17"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -19649,8 +19560,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/item/ammo_box/shotgun/buck,
 /obj/item/ammo_box/shotgun/buck,
@@ -19965,8 +19875,7 @@
 	},
 /obj/machinery/computer/mech_bay_power_console,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -20037,8 +19946,7 @@
 "jGP" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater2x2";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater2x2"
 	},
 /obj/structure/window/reinforced{
 	color = "yellow";
@@ -20154,8 +20062,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership/infteam)
 "jJf" = (
@@ -20978,8 +20885,7 @@
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "keG" = (
@@ -21011,8 +20917,7 @@
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/condiment/soymilk,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "kfl" = (
@@ -21278,8 +21183,7 @@
 /obj/item/pizzabox/vegetable,
 /obj/item/pizzabox/vegetable,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "kiX" = (
@@ -21463,8 +21367,7 @@
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /turf/simulated/floor/wood/fancy/light,
 /area/ninja/outpost)
@@ -21566,8 +21469,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "kpr" = (
@@ -22010,8 +21912,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/zone3)
 "kzO" = (
@@ -22449,8 +22350,7 @@
 	},
 /obj/structure/sign/barsign{
 	icon_state = "syndibarsign";
-	pixel_y = 32;
-	tag = "syndibarsign"
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/syndicate_mothership/elite_squad)
@@ -22760,8 +22660,7 @@
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /turf/simulated/floor/wood/fancy/light,
 /area/ninja/outpost)
@@ -22819,8 +22718,7 @@
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /turf/simulated/floor/wood/fancy/light,
 /area/ninja/outpost)
@@ -22841,8 +22739,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/zone2)
 "kTy" = (
@@ -24111,8 +24008,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	color = "gray";
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
 "lwT" = (
@@ -24146,8 +24042,7 @@
 	name = "Riot Control"
 	},
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor13"
@@ -24713,8 +24608,7 @@
 /area/ninja/outpost)
 "lLs" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	tag = "icon-propulsion (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/addition_goals)
@@ -24731,8 +24625,7 @@
 /area/centcom/supply)
 "lLG" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	tag = "icon-propulsion (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_sit)
@@ -24747,8 +24640,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership/infteam)
 "lMq" = (
@@ -24798,8 +24690,7 @@
 /area/centcom/specops)
 "lNA" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-32";
-	tag = "icon-plant-32"
+	icon_state = "plant-32"
 	},
 /obj/structure/closet/medical_wall{
 	pixel_y = 32
@@ -24859,8 +24750,7 @@
 /area/syndicate_mothership/outside)
 "lPn" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /turf/simulated/floor/plating/airless,
 /area/centcom/jail)
@@ -25306,8 +25196,7 @@
 	},
 /obj/item/grenade/clusterbuster,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/item/gun/projectile/automatic/m52,
 /obj/item/ammo_box/magazine/m52mag,
@@ -25324,8 +25213,7 @@
 /area/centcom/zone1)
 "mbk" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/window/reinforced{
 	color = "red";
@@ -25338,8 +25226,7 @@
 /area/syndicate_mothership/cargo)
 "mby" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-17";
-	tag = "icon-plant-17"
+	icon_state = "plant-17"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25361,8 +25248,7 @@
 /area/wizard_station)
 "mcb" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/wizard_station)
 "mce" = (
@@ -25380,8 +25266,7 @@
 /area/centcom/specops)
 "mcJ" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/wizard_station)
 "mcM" = (
@@ -25591,8 +25476,7 @@
 /area/centcom/zone1)
 "mhh" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "fancy-wood-oak"
@@ -25733,8 +25617,7 @@
 	throw_range = 6
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/wizard_station)
 "mle" = (
@@ -25790,8 +25673,7 @@
 "mlL" = (
 /obj/item/target,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/wizard_station)
 "mmD" = (
@@ -25804,8 +25686,7 @@
 	throw_range = 6
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/wizard_station)
 "mmX" = (
@@ -25840,8 +25721,7 @@
 /area/centcom/specops)
 "mog" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#FF0000";
@@ -26493,8 +26373,7 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater2x2_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater2x2_side"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/ninja)
@@ -26545,8 +26424,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	dir = 8;
-	pixel_x = 4;
-	tag = "icon-shower (EAST)"
+	pixel_x = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -26634,8 +26512,7 @@
 /area/syndicate_mothership/elite_squad)
 "mDX" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -26990,8 +26867,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/cream,
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "mKC" = (
@@ -27238,8 +27114,7 @@
 	req_access = list(101)
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "mQQ" = (
@@ -27409,8 +27284,7 @@
 /area/ninja/outpost)
 "mUH" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "mUV" = (
@@ -27785,8 +27659,7 @@
 /area/syndicate_mothership/jail)
 "ncN" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/supply)
@@ -28093,8 +27966,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership/infteam)
 "njO" = (
@@ -28337,8 +28209,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "npn" = (
@@ -28781,8 +28652,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "nyA" = (
@@ -28939,8 +28809,7 @@
 /area/syndicate_mothership/control)
 "nBh" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/window/reinforced{
 	color = "red";
@@ -29163,8 +29032,7 @@
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "fancy-wood-oak"
@@ -29173,8 +29041,7 @@
 "nFv" = (
 /obj/structure/chair/comfy/shuttle/dark,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "Dark"
@@ -29501,8 +29368,7 @@
 /area/centcom/specops)
 "nLn" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/supply)
@@ -29648,8 +29514,7 @@
 /area/syndicate_mothership/control)
 "nPg" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	color = "black"
@@ -29661,8 +29526,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/green,
 /area/ninja/outpost)
@@ -29684,8 +29548,7 @@
 /area/syndicate_mothership/infteam)
 "nQb" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-6";
-	tag = "icon-plant-6"
+	icon_state = "plant-6"
 	},
 /turf/simulated/floor/wood,
 /area/centcom/zone1)
@@ -29730,8 +29593,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_x = 4;
-	tag = "icon-shower (EAST)"
+	pixel_x = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -29846,8 +29708,7 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "nUi" = (
@@ -30326,8 +30187,7 @@
 "ofi" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/evac)
 "ofy" = (
@@ -30636,8 +30496,7 @@
 "onS" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "onY" = (
@@ -30712,8 +30571,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/zone3)
 "ooP" = (
@@ -30744,8 +30602,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	color = "gray";
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
 "opi" = (
@@ -30787,8 +30644,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	dir = 8;
-	pixel_x = 4;
-	tag = "icon-shower (EAST)"
+	pixel_x = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -31240,8 +31096,7 @@
 "oAH" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "oBC" = (
@@ -31415,8 +31270,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	color = "gray";
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
 "oFz" = (
@@ -31584,8 +31438,7 @@
 "oJt" = (
 /obj/item/book/random,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/centcom/zone2)
 "oJH" = (
@@ -31597,8 +31450,7 @@
 /obj/item/harpoon,
 /obj/item/tank/internals/nitrogen,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/item/pneumatic_cannon,
 /obj/item/harpoon,
@@ -32010,8 +31862,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership/cargo)
 "oRk" = (
@@ -32103,8 +31954,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -32163,8 +32013,7 @@
 /obj/item/reagent_containers/food/condiment/rice,
 /obj/item/reagent_containers/food/condiment/rice,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "oUw" = (
@@ -32654,8 +32503,7 @@
 /area/shuttle/syndicate)
 "plK" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/indestructible/snow,
 /area/ninja/outside)
@@ -32716,8 +32564,7 @@
 /obj/structure/railing,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "pnQ" = (
@@ -32875,8 +32722,7 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater2x2_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater2x2_side"
 	},
 /obj/structure/shuttle/engine/platform{
 	layer = 2.9
@@ -33244,8 +33090,7 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/ninja)
@@ -33613,8 +33458,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/plasteel{
@@ -33763,8 +33607,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_x = 4;
-	tag = "icon-shower (EAST)"
+	pixel_x = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -34031,8 +33874,7 @@
 /area/centcom/zone1)
 "pTI" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/zone1)
 "pTK" = (
@@ -34401,8 +34243,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/cream,
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "qap" = (
@@ -34495,8 +34336,7 @@
 	},
 /obj/machinery/kitchen_machine/oven,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "qcB" = (
@@ -34731,8 +34571,7 @@
 	name = "Science gear"
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/effect/spawner/lootdrop/trade_sol/sci,
 /turf/simulated/floor/wood{
@@ -34770,8 +34609,7 @@
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "qkT" = (
@@ -34849,8 +34687,7 @@
 "qms" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -34897,8 +34734,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "qnT" = (
@@ -35067,8 +34903,7 @@
 /area/syndicate_mothership/jail)
 "qqE" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	color = "black"
@@ -35276,8 +35111,7 @@
 /area/syndicate_mothership/jail)
 "quv" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /turf/simulated/floor/plating/airless,
 /area/centcom/jail)
@@ -35450,8 +35284,7 @@
 "qzP" = (
 /obj/machinery/kitchen_machine/oven,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "qzU" = (
@@ -35900,8 +35733,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "qJu" = (
@@ -35957,8 +35789,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
 "qKI" = (
@@ -35985,8 +35816,7 @@
 /area/syndicate_mothership/outside)
 "qLe" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/supply)
@@ -36169,8 +35999,7 @@
 /obj/structure/table/reinforced,
 /obj/item/kitchen/sushimat,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "qPt" = (
@@ -36183,8 +36012,7 @@
 /area/centcom/zone1)
 "qQa" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /obj/structure/curtain/open/shower/security{
 	pixel_x = -32
@@ -36638,8 +36466,7 @@
 /area/shuttle/administration)
 "rbb" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	tag = "icon-propulsion (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/funeral)
@@ -36832,8 +36659,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "rcN" = (
@@ -37366,8 +37192,7 @@
 /area/centcom/zone2)
 "rnV" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-28";
-	tag = "icon-plant-28"
+	icon_state = "plant-28"
 	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone1)
@@ -37423,8 +37248,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "rpk" = (
@@ -37522,8 +37346,7 @@
 "rqJ" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "rqT" = (
@@ -37618,8 +37441,7 @@
 "ruh" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (NORTH)"
+	icon_state = "propulsion_l"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_sit)
@@ -37709,8 +37531,7 @@
 "rwu" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_l";
-	tag = "icon-propulsion_l (NORTH)"
+	icon_state = "propulsion_l"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_elite)
@@ -37785,8 +37606,7 @@
 /area/syndicate_mothership/elite_squad)
 "rxE" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "rxF" = (
@@ -37799,8 +37619,7 @@
 /area/shuttle/escape)
 "rxG" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "Dark"
@@ -37972,8 +37791,7 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater2x2";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater2x2"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/ninja)
@@ -38158,8 +37976,7 @@
 /area/syndicate_mothership/control)
 "rGT" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/window/reinforced{
 	color = "red";
@@ -38385,8 +38202,7 @@
 /area/centcom/zone2)
 "rKE" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-32";
-	tag = "icon-plant-32"
+	icon_state = "plant-32"
 	},
 /turf/simulated/floor/wood,
 /area/centcom/zone1)
@@ -38451,8 +38267,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "rLO" = (
@@ -38838,8 +38653,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "rVB" = (
@@ -38943,8 +38757,7 @@
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-6";
-	tag = "icon-plant-6"
+	icon_state = "plant-6"
 	},
 /turf/simulated/floor/wood,
 /area/centcom/zone1)
@@ -39297,8 +39110,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "shB" = (
@@ -39422,8 +39234,7 @@
 "slQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "slR" = (
@@ -39776,8 +39587,7 @@
 /area/syndicate_mothership)
 "ssE" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#FF0000";
@@ -39918,8 +39728,7 @@
 /area/centcom/specops)
 "sxB" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	color = "red"
@@ -39933,8 +39742,7 @@
 /area/shuttle/syndicate_sit)
 "sxQ" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-32";
-	tag = "icon-plant-32"
+	icon_state = "plant-32"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -40008,8 +39816,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	color = "gray";
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
 "sAo" = (
@@ -40327,8 +40134,7 @@
 "sHH" = (
 /obj/structure/chair/comfy/shuttle/dark,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "Dark"
@@ -40390,8 +40196,7 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/ninja)
@@ -40879,8 +40684,7 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater2x2";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater2x2"
 	},
 /obj/structure/shuttle/engine/platform{
 	layer = 2.9
@@ -40977,8 +40781,7 @@
 /area/centcom/zone1)
 "sWJ" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -41148,8 +40951,7 @@
 	icon_state = "siding8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership/infteam)
 "sZu" = (
@@ -41358,8 +41160,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
 "tcW" = (
@@ -41409,7 +41210,6 @@
 	dir = 8;
 	light_range = 2;
 	nightshift_light_range = 2;
-	tag = "icon-bulb1 (WEST)";
 	throw_range = 2
 	},
 /obj/structure/railing/corner{
@@ -41529,8 +41329,7 @@
 /area/syndicate_mothership/elite_squad)
 "tgY" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-30";
-	tag = "icon-plant-30"
+	icon_state = "plant-30"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -41774,8 +41573,7 @@
 /area/syndicate_mothership)
 "tlK" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/shuttle{
@@ -41938,8 +41736,7 @@
 /area/syndicate_mothership/cargo)
 "tpC" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-28";
-	tag = "icon-plant-28"
+	icon_state = "plant-28"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -42107,8 +41904,7 @@
 "ttE" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r (NORTH)"
+	icon_state = "propulsion_r"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_sit)
@@ -42551,8 +42347,7 @@
 /area/centcom/jail)
 "tDJ" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle/dark{
 	dir = 8
@@ -42581,8 +42376,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
 "tEi" = (
@@ -42757,8 +42551,7 @@
 "tHx" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r (NORTH)"
+	icon_state = "propulsion_r"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_elite)
@@ -42892,8 +42685,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "tJV" = (
@@ -43060,8 +42852,7 @@
 /area/shuttle/administration)
 "tMC" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	color = "red"
@@ -43071,8 +42862,7 @@
 "tNp" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r (NORTH)"
+	icon_state = "propulsion_r"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/funeral)
@@ -43100,8 +42890,7 @@
 	},
 /obj/item/book/manual/sop_service,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/zone1)
 "tOk" = (
@@ -43153,8 +42942,7 @@
 /area/centcom/zone1)
 "tPu" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	color = "red"
@@ -43640,8 +43428,7 @@
 	id_tag = "SIT_outside"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership/infteam)
 "uca" = (
@@ -44309,8 +44096,7 @@
 "urj" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -44648,8 +44434,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
 "uzb" = (
@@ -44717,14 +44502,12 @@
 	},
 /obj/item/book/manual/sop_service,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/centcom/jail)
 "uAz" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle/dark{
 	dir = 4
@@ -44786,8 +44569,7 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "uCi" = (
@@ -44898,8 +44680,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/specops)
 "uEU" = (
@@ -45182,8 +44963,7 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/ninja)
@@ -45334,8 +45114,7 @@
 /area/syndicate_mothership/outside)
 "uMZ" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#FF0000";
@@ -45498,8 +45277,7 @@
 /area/shuttle/escape)
 "uPJ" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "Dark"
@@ -45685,8 +45463,7 @@
 /obj/machinery/clonepod/upgraded,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/centcom/specops)
 "uTC" = (
@@ -45726,8 +45503,7 @@
 /area/centcom/specops)
 "uVg" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -45809,8 +45585,7 @@
 /area/centcom/zone1)
 "uWJ" = (
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -45821,8 +45596,7 @@
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-34";
-	tag = "icon-plant-34"
+	icon_state = "plant-34"
 	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone2)
@@ -45981,8 +45755,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -46175,8 +45948,7 @@
 /area/centcom/specops)
 "vhU" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-6";
-	tag = "icon-plant-6"
+	icon_state = "plant-6"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/wood,
@@ -46367,8 +46139,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -46430,8 +46201,7 @@
 /area/syndicate_mothership)
 "vod" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-28";
-	tag = "icon-plant-28"
+	icon_state = "plant-28"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -46645,8 +46415,7 @@
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "vtH" = (
@@ -46935,8 +46704,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
 "vAA" = (
@@ -47194,8 +46962,7 @@
 	id_tag = "SST_outside"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership/elite_squad)
 "vIY" = (
@@ -47331,8 +47098,7 @@
 /area/syndicate_mothership)
 "vMq" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/shuttle/engine/platform{
 	layer = 2.9
@@ -47580,8 +47346,7 @@
 /area/shuttle/funeral)
 "vQi" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -47895,8 +47660,7 @@
 	req_access = list(109)
 	},
 /obj/machinery/shower{
-	dir = 1;
-	tag = "icon-shower (WEST)"
+	dir = 1
 	},
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor/impassable/preopen{
@@ -48829,8 +48593,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "wyU" = (
@@ -50727,8 +50490,7 @@
 /area/centcom/bridge)
 "xrs" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-32";
-	tag = "icon-plant-32"
+	icon_state = "plant-32"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/wood,
@@ -50861,8 +50623,7 @@
 "xuH" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r (NORTH)"
+	icon_state = "propulsion_r"
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/addition_goals)
@@ -51159,8 +50920,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	color = "gray";
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
 "xBV" = (
@@ -51436,8 +51196,7 @@
 "xIi" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/shuttle/engine/platform{
 	dir = 1;
@@ -51521,8 +51280,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/centcom/zone1)
 "xKz" = (
@@ -51639,8 +51397,7 @@
 /area/centcom/zone1)
 "xMH" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -51922,8 +51679,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/centcom/specops)
 "xUV" = (
@@ -52435,8 +52191,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_x = -4;
-	tag = "icon-shower (EAST)"
+	pixel_x = -4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -1021,8 +1021,7 @@
 /area/mine/laborcamp)
 "cA" = (
 /obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
@@ -4888,8 +4887,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/mine/laborcamp)
 "ug" = (
@@ -5804,8 +5802,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/mine/laborcamp)
 "Dk" = (
@@ -5969,8 +5966,7 @@
 /obj/item/bedsheet/orange,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/mine/laborcamp)
 "Fy" = (
@@ -6520,8 +6516,7 @@
 	network = list("Labor    Camp")
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/mine/laborcamp)
 "JQ" = (
@@ -6895,8 +6890,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/mine/laborcamp)
 "NG" = (
@@ -7749,8 +7743,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/mine/laborcamp)
 "VO" = (

--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -377,8 +377,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -830,8 +829,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/maintenance/north)
@@ -899,8 +897,7 @@
 	initialize_directions = 11
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -939,8 +936,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1316,8 +1312,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/syndicate/unpowered/syndicate_space_base/armory/hallway)
 "bdB" = (
@@ -1364,7 +1359,6 @@
 	dir = 8;
 	light_range = 2;
 	nightshift_light_range = 2;
-	tag = "icon-bulb1 (WEST)";
 	throw_range = 2
 	},
 /obj/machinery/flasher{
@@ -1440,8 +1434,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1500,8 +1493,7 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/maintenance/north)
@@ -1513,7 +1505,6 @@
 	brightness_range = 2;
 	light_range = 2;
 	nightshift_light_range = 2;
-	tag = "icon-bulb1 (WEST)";
 	throw_range = 2
 	},
 /obj/effect/spawner/random_spawners/syndicate/loot,
@@ -1699,8 +1690,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1843,8 +1833,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1870,8 +1859,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/syndicate/unpowered/syndicate_space_base/armory/hallway)
 "bLM" = (
@@ -1962,8 +1950,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -2001,8 +1988,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2489,8 +2475,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/maintenance/north)
@@ -2566,8 +2551,7 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/maintenance/north)
@@ -2999,8 +2983,7 @@
 /area/syndicate/unpowered/syndicate_space_base/medbay/morgue)
 "cKI" = (
 /obj/machinery/shower{
-	dir = 1;
-	tag = "icon-shower (WEST)"
+	dir = 1
 	},
 /obj/structure/curtain/open/shower/security,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -3712,8 +3695,7 @@
 	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3759,8 +3741,7 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3796,8 +3777,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5212,8 +5192,7 @@
 "eOB" = (
 /obj/effect/turf_decal/plaque,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
@@ -5498,8 +5477,7 @@
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/syndicate/unpowered/syndicate_space_base/rnd)
 "fbj" = (
@@ -5735,8 +5713,7 @@
 /obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/syndicate/unpowered/syndicate_space_base/rnd)
 "fmN" = (
@@ -5929,8 +5906,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -6041,8 +6017,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8686,7 +8661,6 @@
 	brightness_range = 2;
 	light_range = 2;
 	nightshift_light_range = 2;
-	tag = "icon-bulb1 (WEST)";
 	throw_range = 2
 	},
 /obj/effect/spawner/random_spawners/dirt_50,
@@ -8889,7 +8863,6 @@
 	dir = 8;
 	light_range = 2;
 	nightshift_light_range = 2;
-	tag = "icon-bulb1 (WEST)";
 	throw_range = 2
 	},
 /obj/machinery/flasher{
@@ -9428,8 +9401,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/syndicate/unpowered/syndicate_space_base/maintenance/south)
 "iFd" = (
@@ -10702,8 +10674,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -10821,8 +10792,7 @@
 	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -11550,8 +11520,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -11712,8 +11681,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12243,8 +12211,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/syndicate/unpowered/syndicate_space_base/rnd)
 "lfl" = (
@@ -14403,8 +14370,7 @@
 /area/syndicate/unpowered/syndicate_space_base/main/central_e)
 "mQC" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -14904,8 +14870,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14968,8 +14933,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -15008,8 +14972,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/junction/reversed{
 	dir = 4
@@ -15162,8 +15125,7 @@
 "nvz" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/shower{
-	dir = 1;
-	tag = "icon-shower (WEST)"
+	dir = 1
 	},
 /obj/structure/mirror{
 	pixel_x = 32
@@ -15321,8 +15283,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -15346,8 +15307,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15392,8 +15352,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15445,8 +15404,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -15594,8 +15552,7 @@
 	initialize_directions = 11
 	},
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -17271,7 +17228,6 @@
 	dir = 8;
 	light_range = 2;
 	nightshift_light_range = 2;
-	tag = "icon-bulb1 (WEST)";
 	throw_range = 2
 	},
 /turf/simulated/floor/plating,
@@ -17897,8 +17853,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2
@@ -18513,8 +18468,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/torture_room)
@@ -18576,8 +18530,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18699,8 +18652,7 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -19045,8 +18997,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "ramptop";
-	tag = "icon-stage_stairs"
+	icon_state = "ramptop"
 	},
 /area/syndicate/unpowered/syndicate_space_base/cryo)
 "qqr" = (
@@ -19116,8 +19067,7 @@
 /obj/item/radio/intercom/syndicate/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/syndicate/unpowered/syndicate_space_base/rnd)
 "quM" = (
@@ -19146,8 +19096,7 @@
 /area/syndicate/unpowered/syndicate_space_base/engineering)
 "qvg" = (
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -19477,8 +19426,7 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 10;
@@ -19567,8 +19515,7 @@
 /area/syndicate/unpowered/syndicate_space_base/rnd/server)
 "qEo" = (
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = ""
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19958,8 +19905,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate/unpowered/syndicate_space_base/main/north)
@@ -19976,8 +19922,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "ramptop";
-	tag = "icon-stage_stairs"
+	icon_state = "ramptop"
 	},
 /area/syndicate/unpowered/syndicate_space_base/cryo)
 "qUv" = (
@@ -21103,8 +21048,7 @@
 /area/syndicate/unpowered/syndicate_space_base/maintenance/central)
 "rVu" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/space)
@@ -21262,8 +21206,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2
@@ -21313,8 +21256,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/syndicate/unpowered/syndicate_space_base/maintenance/south)
 "sdT" = (
@@ -21549,8 +21491,7 @@
 	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate/unpowered/syndicate_space_base/telecomms/agent_room)
@@ -22465,8 +22406,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -22488,7 +22428,6 @@
 	dir = 8;
 	light_range = 2;
 	nightshift_light_range = 2;
-	tag = "icon-bulb1 (WEST)";
 	throw_range = 2
 	},
 /obj/effect/spawner/lootdrop/maintenance/tripple,
@@ -22510,7 +22449,6 @@
 	dir = 8;
 	light_range = 2;
 	nightshift_light_range = 2;
-	tag = "icon-bulb1 (WEST)";
 	throw_range = 2
 	},
 /turf/simulated/floor/plating,
@@ -22794,16 +22732,14 @@
 /obj/vehicle/ridden/motorcycle,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/syndicate/unpowered/syndicate_space_base/main/central_w)
 "tAt" = (
 /obj/vehicle/ridden/motorcycle,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/syndicate/unpowered/syndicate_space_base/main/central_w)
 "tBm" = (
@@ -22894,8 +22830,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/junction/reversed{
 	dir = 4
@@ -22973,8 +22908,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23153,8 +23087,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24145,8 +24078,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/syndicate/unpowered/syndicate_space_base/armory/hallway)
 "uvl" = (
@@ -24164,7 +24096,6 @@
 	dir = 8;
 	light_range = 2;
 	nightshift_light_range = 2;
-	tag = "icon-bulb1 (WEST)";
 	throw_range = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -24772,8 +24703,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24911,8 +24841,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24957,8 +24886,7 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -25286,8 +25214,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -25457,8 +25384,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/syndicate/unpowered/syndicate_space_base/maintenance/south)
@@ -26377,8 +26303,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -26455,8 +26380,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -27663,8 +27587,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "vault";
-	tag = "icon-vault (WEST)"
+	icon_state = "vault"
 	},
 /area/syndicate/unpowered/syndicate_space_base/armory/hallway)
 "wMU" = (
@@ -27858,8 +27781,7 @@
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
@@ -28374,8 +28296,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -29118,8 +29039,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/syndicate/unpowered/syndicate_space_base/maintenance/south)
 "xKQ" = (
@@ -29181,8 +29101,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/syndicate/unpowered/syndicate_space_base/maintenance/south)
 "xNO" = (
@@ -29472,8 +29391,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/absinthe,
 /obj/item/reagent_containers/food/drinks/bottle/absinthe,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/syndicate/unpowered/syndicate_space_base/maintenance/south)
 "xVP" = (

--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -6770,9 +6770,9 @@
 /area/syndicate/unpowered/syndicate_space_base/botany)
 "grh" = (
 /obj/effect/spawner/airlock/s_to_n/long{
+	door_type = /obj/machinery/door/airlock/external;
 	id_to_link = "taipan_exit";
-	required_access = list(150);
-	door_type = /obj/machinery/door/airlock/external
+	required_access = list(150)
 	},
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
 /area/syndicate/unpowered/syndicate_space_base/engineering)
@@ -13893,8 +13893,8 @@
 	pixel_y = 10
 	},
 /obj/item/storage/toolbox/surgery{
-	pixel_y = -3;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = -3
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -14372,9 +14372,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
 /turf/simulated/floor/plasteel{
@@ -14721,8 +14718,8 @@
 "nhY" = (
 /obj/effect/decal/cleanable/blood/slime,
 /obj/item/wirecutters{
-	pixel_y = 8;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -15285,9 +15282,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 2
 	},
@@ -15402,9 +15396,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -15550,9 +15541,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
 	initialize_directions = 11
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"

--- a/_maps/map_files/nova/Lavaland.dmm
+++ b/_maps/map_files/nova/Lavaland.dmm
@@ -653,8 +653,7 @@
 /area/mine/living_quarters)
 "eQ" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -1201,8 +1200,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/mine/laborcamp)
 "ib" = (
@@ -2798,8 +2796,7 @@
 /obj/item/bedsheet/orange,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/mine/laborcamp)
 "qS" = (
@@ -3457,8 +3454,7 @@
 /obj/structure/bed,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/mine/laborcamp)
 "uQ" = (
@@ -4028,8 +4024,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/mine/laborcamp)
 "xH" = (
@@ -4851,8 +4846,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/mine/laborcamp)
 "BT" = (
@@ -5037,8 +5031,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/mine/laborcamp)
 "CO" = (

--- a/_maps/map_files/nova/nova.dmm
+++ b/_maps/map_files/nova/nova.dmm
@@ -145,8 +145,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/backstage)
 "abj" = (
@@ -411,8 +410,7 @@
 /obj/structure/curtain/open,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/ward)
 "adX" = (
@@ -874,8 +872,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
@@ -932,8 +929,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "ahS" = (
@@ -1066,8 +1062,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "aiD" = (
@@ -1559,8 +1554,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	tag = "icon-pipe-j1 (WEST)"
+	dir = 8
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1685,8 +1679,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "anF" = (
@@ -2168,8 +2161,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 8;
-	tag = "icon-shower (EAST)"
+	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -3130,8 +3122,7 @@
 /obj/effect/spawner/random_spawners/cobweb_left_rare,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "azJ" = (
@@ -3231,8 +3222,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/casino)
 "aAp" = (
@@ -3738,8 +3728,7 @@
 	},
 /obj/machinery/vending/gun_mods,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "aDI" = (
@@ -4056,8 +4045,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "aGc" = (
@@ -4464,8 +4452,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
 "aIH" = (
@@ -4496,13 +4483,6 @@
 "aJc" = (
 /turf/simulated/wall,
 /area/crew_quarters/theatre)
-"aJd" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
-	},
-/area/medical/medbay)
 "aJg" = (
 /obj/structure/chair/sofa/pew/right{
 	dir = 4
@@ -4617,8 +4597,7 @@
 	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "aJW" = (
@@ -4788,8 +4767,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/crew_quarters/sleep)
 "aKR" = (
@@ -5180,8 +5158,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "aNI" = (
@@ -5231,8 +5208,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/theatre)
 "aOd" = (
@@ -5953,8 +5929,7 @@
 "aSH" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/reception)
 "aSI" = (
@@ -6083,8 +6058,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "aTK" = (
@@ -6144,8 +6118,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "aUk" = (
@@ -6229,8 +6202,7 @@
 	security_level = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "aUI" = (
@@ -6283,8 +6255,7 @@
 /area/atmos)
 "aUU" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -6478,8 +6449,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
 "aWu" = (
@@ -6738,8 +6708,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -6814,8 +6783,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "aZX" = (
@@ -7097,8 +7065,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medrest)
 "bci" = (
@@ -8142,12 +8109,6 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
-"bjJ" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
-	},
-/area/medical/reception)
 "bjQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8306,8 +8267,7 @@
 "blc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/casino)
 "blf" = (
@@ -8663,8 +8623,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/tomato_smudge,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/backstage)
 "boC" = (
@@ -8806,8 +8765,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/ward)
 "bpg" = (
@@ -8922,8 +8880,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "bpX" = (
@@ -9316,8 +9273,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/atmos)
 "bso" = (
@@ -9386,8 +9342,7 @@
 	color = "red"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/range)
 "bsR" = (
@@ -10038,8 +9993,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "bxn" = (
@@ -10254,8 +10208,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/gateway)
 "byN" = (
@@ -10452,8 +10405,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "bAt" = (
@@ -10692,8 +10644,7 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medrest)
 "bBy" = (
@@ -11132,8 +11083,7 @@
 /obj/item/folder/white,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "bEC" = (
@@ -11149,8 +11099,7 @@
 /obj/machinery/light,
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "bEK" = (
@@ -11240,8 +11189,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/warden)
 "bFg" = (
@@ -11279,8 +11227,7 @@
 "bFt" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHEAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "bFy" = (
@@ -11506,8 +11453,7 @@
 /area/library)
 "bGP" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
 "bGQ" = (
@@ -11692,8 +11638,7 @@
 "bIH" = (
 /obj/effect/decal/cleanable/spiderling_remains,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/maintenance/medroom)
 "bII" = (
@@ -11904,8 +11849,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/chapel)
 "bKg" = (
@@ -11973,8 +11917,7 @@
 /obj/effect/mob_spawn/human,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/livingcomplex)
 "bKN" = (
@@ -12232,8 +12175,7 @@
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
 "bMJ" = (
@@ -13220,8 +13162,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "bTQ" = (
@@ -13383,8 +13324,7 @@
 /obj/structure/closet/paramedic,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
 "bVj" = (
@@ -13467,8 +13407,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/hallway/primary/central/second/south)
 "bVJ" = (
@@ -14120,8 +14059,7 @@
 "car" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "cax" = (
@@ -14147,8 +14085,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "caF" = (
@@ -14233,8 +14170,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
 "cbk" = (
@@ -14779,8 +14715,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/atmos/control)
 "cfS" = (
@@ -15173,8 +15108,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "ciZ" = (
@@ -15329,8 +15263,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -15397,8 +15330,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medrest)
 "ckB" = (
@@ -15664,8 +15596,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/reception)
 "cmE" = (
@@ -16046,8 +15977,7 @@
 "cpI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/spiderling_remains,
 /turf/simulated/floor/plasteel{
@@ -16981,8 +16911,7 @@
 "cwL" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/casino)
 "cwN" = (
@@ -17025,8 +16954,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/maintenance/medroom)
 "cwZ" = (
@@ -17039,8 +16967,7 @@
 /obj/item/clothing/mask/gas,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHEAST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
 "cxc" = (
@@ -17440,8 +17367,7 @@
 	glass = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "cAA" = (
@@ -17873,8 +17799,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "cER" = (
@@ -18215,8 +18140,7 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "cGY" = (
@@ -18444,8 +18368,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "cIH" = (
@@ -19023,8 +18946,7 @@
 "cNq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/vending/artvend,
 /turf/simulated/floor/plasteel{
@@ -20445,8 +20367,7 @@
 "cXN" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/casino)
 "cXW" = (
@@ -20515,8 +20436,7 @@
 	amount = 3
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "cYm" = (
@@ -20724,8 +20644,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/secpost)
 "cZv" = (
@@ -21208,8 +21127,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cmo)
 "deS" = (
@@ -21444,8 +21362,7 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/biostorage)
 "dgS" = (
@@ -22355,8 +22272,7 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "dnu" = (
@@ -22670,8 +22586,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "dpH" = (
@@ -23369,8 +23284,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "duG" = (
@@ -24681,8 +24595,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "dFn" = (
@@ -24795,8 +24708,7 @@
 /area/chapel/main)
 "dGT" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -24839,8 +24751,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/casino)
 "dHz" = (
@@ -25109,8 +25020,7 @@
 	icon_state = "siding8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/hallway/primary/central/second/south)
 "dJf" = (
@@ -25235,8 +25145,7 @@
 "dKd" = (
 /obj/effect/decal/cleanable/dust,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/carpet,
 /area/maintenance/casino)
@@ -25363,8 +25272,7 @@
 	network = list("SS13","Security")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "dLJ" = (
@@ -25493,8 +25401,7 @@
 /obj/item/extinguisher/mini,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
 "dMB" = (
@@ -25689,8 +25596,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "dOa" = (
@@ -25958,8 +25864,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "dPR" = (
@@ -26777,8 +26682,7 @@
 "dWT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
 "dWV" = (
@@ -26832,8 +26736,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "dXO" = (
@@ -27033,8 +26936,7 @@
 "dZi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -27527,8 +27429,7 @@
 "ecE" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "ecG" = (
@@ -28890,8 +28791,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "elE" = (
@@ -29189,8 +29089,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j2"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteyellow"
@@ -29302,8 +29201,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "eoV" = (
@@ -29521,8 +29419,7 @@
 "eqE" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/cryo)
 "eqG" = (
@@ -29587,8 +29484,7 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/experimentor,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "erx" = (
@@ -30058,8 +29954,7 @@
 /area/maintenance/tourist)
 "evj" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/medrest)
 "evm" = (
@@ -30607,8 +30502,7 @@
 	req_access = list(1)
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/range)
 "ezl" = (
@@ -30645,8 +30539,7 @@
 /obj/structure/filingcabinet/chestdrawer/autopsy,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "ezB" = (
@@ -31076,8 +30969,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/spiderling_remains,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "eCG" = (
@@ -31170,8 +31062,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "eDF" = (
@@ -31223,8 +31114,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 8;
-	tag = "icon-shower (EAST)"
+	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluecorner"
@@ -31690,8 +31580,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "eHT" = (
@@ -31785,8 +31674,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "eID" = (
@@ -31822,8 +31710,7 @@
 /obj/machinery/station_map/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "eIM" = (
@@ -31999,8 +31886,7 @@
 "eKo" = (
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "eKt" = (
@@ -32591,8 +32477,7 @@
 /area/maintenance/detectives_office)
 "eOu" = (
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -32783,8 +32668,7 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/fsmaint2)
 "eQG" = (
@@ -33700,8 +33584,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -34178,8 +34061,7 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/casino)
 "fbq" = (
@@ -34198,8 +34080,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreen";
-	tag = "icon-whitegreen (EAST)"
+	icon_state = "whitegreen"
 	},
 /area/medical/virology)
 "fbw" = (
@@ -34284,8 +34165,7 @@
 	},
 /obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/main)
 "fcl" = (
@@ -35269,8 +35149,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "fjF" = (
@@ -35389,8 +35268,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "fkD" = (
@@ -35923,8 +35801,7 @@
 /obj/effect/decal/cleanable/dust,
 /obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/garden)
 "fpa" = (
@@ -36230,8 +36107,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/ward)
 "frB" = (
@@ -36504,8 +36380,7 @@
 /area/aisat/aihallway)
 "ftG" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow,
 /obj/item/radio/intercom/directional/south,
@@ -36782,8 +36657,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHEAST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
 "fvS" = (
@@ -36901,8 +36775,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "fwH" = (
@@ -37116,8 +36989,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "fyn" = (
@@ -37501,8 +37373,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "fBg" = (
@@ -38145,8 +38016,7 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "fFR" = (
@@ -38178,8 +38048,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "fFZ" = (
@@ -38248,8 +38117,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/secpost)
 "fGO" = (
@@ -38649,8 +38517,7 @@
 /area/maintenance/apmaint)
 "fKh" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -38789,8 +38656,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "fLM" = (
@@ -39042,8 +38908,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHEAST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
 "fNx" = (
@@ -39062,8 +38927,7 @@
 /obj/structure/closet/walllocker/emerglocker/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "fNy" = (
@@ -39490,8 +39354,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "fQC" = (
@@ -40112,8 +39975,7 @@
 "fVo" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/livingcomplex)
 "fVr" = (
@@ -40170,8 +40032,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/banya)
 "fVP" = (
@@ -40187,8 +40048,7 @@
 "fVQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "fVS" = (
@@ -40347,8 +40207,7 @@
 "fXb" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
 "fXd" = (
@@ -40422,8 +40281,7 @@
 "fXV" = (
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 5;
-	tag = "icon-shower (EAST)"
+	pixel_y = 5
 	},
 /obj/structure/curtain/open/shower/engineering,
 /obj/item/radio/intercom/directional/north,
@@ -40938,8 +40796,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "gbd" = (
@@ -43335,8 +43192,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/banya)
 "gto" = (
@@ -43639,8 +43495,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
 "gvQ" = (
@@ -43933,8 +43788,7 @@
 	color = "#85130b"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/backstage)
 "gyA" = (
@@ -44006,8 +43860,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "gzl" = (
@@ -44495,8 +44348,7 @@
 /area/maintenance/casino)
 "gEe" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/casino)
 "gEi" = (
@@ -44984,16 +44836,14 @@
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "gHC" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -45207,8 +45057,7 @@
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/backstage)
 "gIU" = (
@@ -45519,8 +45368,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -46594,8 +46442,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
 "gVQ" = (
@@ -46778,8 +46625,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "gXd" = (
@@ -48658,8 +48504,7 @@
 /obj/item/toy/figure/geneticist,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
 "hjH" = (
@@ -48791,8 +48636,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "hkv" = (
@@ -48815,8 +48659,7 @@
 /area/maintenance/apmaint)
 "hkG" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/carpet/green,
@@ -48829,8 +48672,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "hkI" = (
@@ -49503,8 +49345,7 @@
 /area/toxins/explab)
 "hqh" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "hqk" = (
@@ -49518,8 +49359,7 @@
 "hqn" = (
 /obj/effect/decal/cleanable/dust,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
@@ -49929,8 +49769,7 @@
 "hun" = (
 /mob/living/simple_animal/moth,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/livingcomplex)
 "hus" = (
@@ -50009,8 +49848,7 @@
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/theatre)
 "huH" = (
@@ -50115,8 +49953,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/hallway/secondary/exit)
 "hvN" = (
@@ -50616,8 +50453,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 1
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=A23";
@@ -50784,8 +50620,7 @@
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "hBC" = (
@@ -51414,8 +51249,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/detectives_office)
 "hHB" = (
@@ -51466,8 +51300,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "hIk" = (
@@ -51813,8 +51646,7 @@
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "hLo" = (
@@ -52824,8 +52656,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "hTF" = (
@@ -53258,8 +53089,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "hXA" = (
@@ -54086,8 +53916,7 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "Disposals Junction";
-	tag = "icon-pipe-j1s (EAST)"
+	name = "Disposals Junction"
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
@@ -54237,8 +54066,7 @@
 "idC" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "idD" = (
@@ -54538,8 +54366,7 @@
 /area/quartermaster/office)
 "ifZ" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -54829,8 +54656,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "ihO" = (
@@ -54999,8 +54825,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "ijg" = (
@@ -55024,8 +54849,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/eastright{
 	name = "Hydroponics Delivery";
-	req_access = list(35);
-	tag = "icon-right"
+	req_access = list(35)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -56099,8 +55923,7 @@
 "irp" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "irs" = (
@@ -57491,8 +57314,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
 "iBe" = (
@@ -57635,8 +57457,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "iCY" = (
@@ -57707,8 +57528,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/biostorage)
 "iDX" = (
@@ -58754,8 +58574,7 @@
 /area/maintenance/fore2)
 "iMT" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -59284,13 +59103,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/command/east)
-"iSv" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
-	},
-/area/medical/medbay)
 "iSL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -59500,8 +59312,7 @@
 "iTS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/casino)
 "iUg" = (
@@ -59929,8 +59740,7 @@
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "iXt" = (
@@ -60071,8 +59881,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "iXZ" = (
@@ -60158,8 +59967,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
 "iYy" = (
@@ -60486,8 +60294,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/cmostore)
 "jbh" = (
@@ -60574,8 +60381,7 @@
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "jbz" = (
@@ -60632,8 +60438,7 @@
 	req_access = list(1)
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/range)
 "jce" = (
@@ -60891,8 +60696,7 @@
 "jdT" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
 "jdU" = (
@@ -62557,8 +62361,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "jpG" = (
@@ -62876,8 +62679,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -62935,8 +62737,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "jrE" = (
@@ -63628,8 +63429,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "jxf" = (
@@ -63784,8 +63584,7 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/biostorage)
 "jyC" = (
@@ -63849,8 +63648,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "jzd" = (
@@ -64040,8 +63838,7 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/backstage)
 "jAD" = (
@@ -65094,8 +64891,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/atmos/control)
 "jIQ" = (
@@ -65334,8 +65130,7 @@
 /area/library)
 "jKo" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -65665,8 +65460,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/maintenance/medroom)
 "jMa" = (
@@ -66080,8 +65874,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/casino)
 "jPw" = (
@@ -66735,8 +66528,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "jVd" = (
@@ -67556,8 +67348,7 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 2
@@ -68184,8 +67975,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "khy" = (
@@ -68282,8 +68072,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/mouse,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -68738,8 +68527,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "klY" = (
@@ -68885,8 +68673,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -68994,13 +68781,6 @@
 	icon_state = "whitehall"
 	},
 /area/maintenance/fsmaint3)
-"knz" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
-	},
-/area/medical/research)
 "knF" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -69713,8 +69493,7 @@
 /area/hydroponics)
 "kue" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/hallway/primary/central/second/north)
 "kug" = (
@@ -70540,8 +70319,7 @@
 	pixel_x = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "kAN" = (
@@ -70802,8 +70580,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
 "kCN" = (
@@ -70939,8 +70716,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "kEm" = (
@@ -70948,8 +70724,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -71262,8 +71037,7 @@
 /obj/item/stock_parts/cell,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
 "kGN" = (
@@ -71933,8 +71707,7 @@
 /area/hallway/primary/central/nw)
 "kNf" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -72606,8 +72379,7 @@
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/theatre)
 "kRZ" = (
@@ -72814,8 +72586,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/chapel)
 "kTR" = (
@@ -72832,8 +72603,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "kTT" = (
@@ -73461,8 +73231,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "kYo" = (
@@ -73689,8 +73458,7 @@
 "kZy" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/secpost)
 "kZD" = (
@@ -74492,8 +74260,7 @@
 /area/ntrep)
 "lfG" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "lfL" = (
@@ -74888,8 +74655,7 @@
 /obj/item/reagent_containers/glass/bottle/reagent/formaldehyde,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "lix" = (
@@ -75688,8 +75454,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/livingcomplex)
 "lpM" = (
@@ -75786,8 +75551,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "lqQ" = (
@@ -76602,8 +76366,7 @@
 "lyq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
 /turf/simulated/floor/plating,
@@ -76829,8 +76592,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "lAa" = (
@@ -77798,8 +77560,7 @@
 	color = "red"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/range)
 "lGQ" = (
@@ -78017,8 +77778,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/cmostore)
 "lJo" = (
@@ -78315,8 +78075,7 @@
 "lLO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/livingcomplex)
@@ -78324,8 +78083,7 @@
 /obj/machinery/door/window/brigdoor,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -78681,8 +78439,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/biostorage)
 "lOG" = (
@@ -78740,8 +78497,7 @@
 "lOY" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/casino)
 "lPi" = (
@@ -79445,8 +79201,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "lUS" = (
@@ -79483,8 +79238,7 @@
 /area/maintenance/apmaint)
 "lVh" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/disposal,
@@ -79523,8 +79277,7 @@
 "lVq" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "lVr" = (
@@ -80270,8 +80023,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "mbm" = (
@@ -80711,8 +80463,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/backstage)
 "mdU" = (
@@ -81266,8 +81017,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "mhJ" = (
@@ -81302,8 +81052,7 @@
 /area/bridge/meeting_room)
 "mii" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/livingcomplex)
 "mij" = (
@@ -81464,8 +81213,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "mjb" = (
@@ -81497,8 +81245,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "mjj" = (
@@ -81671,8 +81418,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "mkm" = (
@@ -81713,8 +81459,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "mkL" = (
@@ -82181,8 +81926,7 @@
 /obj/item/clipboard,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/secpost)
 "mov" = (
@@ -82774,8 +82518,7 @@
 /area/maintenance/fsmaint)
 "mui" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/hallway/primary/central/second/south)
 "mum" = (
@@ -83552,8 +83295,7 @@
 /obj/machinery/vending/artvend,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/theatre)
 "mAG" = (
@@ -84012,8 +83754,7 @@
 /area/maintenance/xenozoo)
 "mEB" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	tag = "icon-plant-22"
+	icon_state = "plant-22"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -84213,8 +83954,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "mGz" = (
@@ -84554,8 +84294,7 @@
 /area/quartermaster/office)
 "mJw" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/casino)
 "mJB" = (
@@ -84960,8 +84699,7 @@
 /obj/effect/landmark/start/intern,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medrest)
 "mLW" = (
@@ -85226,8 +84964,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 8
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -85393,8 +85130,7 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/biostorage)
 "mOm" = (
@@ -85993,8 +85729,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/hallway/secondary/exit)
 "mSN" = (
@@ -87065,8 +86800,7 @@
 "naK" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay2)
 "naN" = (
@@ -87179,8 +86913,7 @@
 /area/crew_quarters/fitness)
 "nbn" = (
 /obj/structure/chair/wood/wings{
-	dir = 8;
-	tag = "icon-wooden_chair_wings (WEST)"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -87191,8 +86924,7 @@
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/livingcomplex)
 "nbr" = (
@@ -87344,8 +87076,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/reception)
 "ncn" = (
@@ -87463,8 +87194,7 @@
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/livingcomplex)
 "ndw" = (
@@ -87521,8 +87251,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "ndV" = (
@@ -87585,8 +87314,7 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "new" = (
@@ -88384,8 +88112,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "njR" = (
@@ -88399,8 +88126,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "njX" = (
@@ -88427,8 +88153,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "nkg" = (
@@ -88459,8 +88184,7 @@
 "nkw" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
-	pixel_y = 6;
-	tag = "icon-shower (EAST)"
+	pixel_y = 6
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel/freezer,
@@ -88608,8 +88332,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/hallway/primary/central/second/north)
 "nlN" = (
@@ -89983,8 +89706,7 @@
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "nxo" = (
@@ -90305,8 +90027,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "nzB" = (
@@ -90788,8 +90509,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "nCu" = (
@@ -91415,14 +91135,12 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
 "nHY" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -91482,8 +91200,7 @@
 "nIR" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/livingcomplex)
 "nIS" = (
@@ -92583,8 +92300,7 @@
 /area/blueshield)
 "nRd" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/permahallway)
@@ -92836,8 +92552,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medrest)
 "nTo" = (
@@ -93528,8 +93243,7 @@
 /obj/item/storage/belt/medical,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
 "nYH" = (
@@ -94697,8 +94411,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/hos)
 "oid" = (
@@ -94932,8 +94645,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "okq" = (
@@ -95114,8 +94826,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/engineering/controlroom)
 "olI" = (
@@ -95140,8 +94851,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "olS" = (
@@ -95153,8 +94863,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
 "olU" = (
@@ -95505,8 +95214,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "opc" = (
@@ -95666,8 +95374,7 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/maintenance/medroom)
 "oqM" = (
@@ -96164,8 +95871,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/brigstaff)
 "ouo" = (
@@ -96288,8 +95994,7 @@
 "ouX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/apmaint)
 "ouY" = (
@@ -96592,8 +96297,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "owo" = (
@@ -96906,8 +96610,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
 "ozi" = (
@@ -97030,8 +96733,7 @@
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "oAa" = (
@@ -97156,8 +96858,7 @@
 "oBy" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "oBG" = (
@@ -97825,8 +97526,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
 "oHx" = (
@@ -98057,8 +97757,7 @@
 "oJl" = (
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -98186,8 +97885,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/hos)
 "oKr" = (
@@ -98301,8 +97999,7 @@
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/ward)
 "oLt" = (
@@ -98768,8 +98465,7 @@
 	network = list("Research","SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "oOM" = (
@@ -98827,8 +98523,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "oPm" = (
@@ -99487,8 +99182,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -99540,8 +99234,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/gambling_den)
 "oUg" = (
@@ -100162,8 +99855,7 @@
 	security_level = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/warden)
 "oYR" = (
@@ -100248,8 +99940,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "oZo" = (
@@ -100442,8 +100133,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/hallway/primary/central/second/south)
 "pao" = (
@@ -100881,8 +100571,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "peM" = (
@@ -101440,8 +101129,7 @@
 	amount = 30
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "pia" = (
@@ -101498,8 +101186,7 @@
 "pir" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/vending/hatdispenser,
 /turf/simulated/floor/plasteel{
@@ -101554,8 +101241,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "piO" = (
@@ -101928,8 +101614,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/hallway/secondary/exit)
 "pls" = (
@@ -102186,8 +101871,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "pnu" = (
@@ -102535,13 +102219,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/spacebridge/comcar)
-"pqk" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
-	},
-/area/medical/reception)
 "pqo" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plating,
@@ -102891,8 +102568,7 @@
 "ptI" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay)
 "ptL" = (
@@ -103113,8 +102789,7 @@
 "pvw" = (
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -103403,8 +103078,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/gateway)
 "pxG" = (
@@ -104741,14 +104415,12 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
 "pGR" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/green,
 /obj/effect/decal/warning_stripes/northwest,
@@ -105184,8 +104856,7 @@
 	},
 /obj/structure/chair/wood,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/casino)
 "pKC" = (
@@ -105348,8 +105019,7 @@
 	security_level = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "pMk" = (
@@ -106597,8 +106267,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/detectives_office)
 "pVb" = (
@@ -106983,16 +106652,14 @@
 "pWX" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/hos)
 "pXa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/twohanded/required/kirbyplants{
-	pixel_y = 12;
-	tag = "plant-dead"
+	pixel_y = 12
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8;
@@ -107337,8 +107004,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medrest)
 "pYX" = (
@@ -107740,14 +107406,12 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/medrest)
 "qci" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "qcj" = (
@@ -107839,8 +107503,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "qcI" = (
@@ -107962,8 +107625,7 @@
 /obj/machinery/station_map/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "qdX" = (
@@ -108404,8 +108066,7 @@
 "qhb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/livingcomplex)
 "qhi" = (
@@ -108545,8 +108206,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/casino)
 "qid" = (
@@ -109245,8 +108905,7 @@
 "qod" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -109396,8 +109055,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
 "qpU" = (
@@ -110072,8 +109730,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "qvc" = (
@@ -111075,8 +110732,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -111650,8 +111306,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medrest)
 "qGn" = (
@@ -112213,8 +111868,7 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/lightsout,
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -113304,8 +112958,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/ward)
 "qSH" = (
@@ -113871,8 +113524,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/casino)
 "qXo" = (
@@ -114093,8 +113745,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "qYW" = (
@@ -114660,14 +114311,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/medical/medrest)
-"reo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel,
-/area/security/permabrig)
 "rev" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/sunglasses,
@@ -115369,8 +115012,7 @@
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "rjg" = (
@@ -116628,8 +116270,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "rsL" = (
@@ -117597,8 +117238,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/casino)
 "ryV" = (
@@ -118204,8 +117844,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "rDZ" = (
@@ -118326,8 +117965,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "rEK" = (
@@ -118590,8 +118228,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "rGw" = (
@@ -118653,8 +118290,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "rGO" = (
@@ -118671,8 +118307,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "rGP" = (
@@ -118708,8 +118343,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "rHi" = (
@@ -119846,8 +119480,7 @@
 /area/crew_quarters/kitchen)
 "rPd" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -120257,8 +119890,7 @@
 /area/medical/chemistry)
 "rSN" = (
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -120475,8 +120107,7 @@
 /obj/structure/disposalpipe/trunk,
 /obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "rUv" = (
@@ -120680,8 +120311,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/maintenance/medroom)
 "rVY" = (
@@ -121050,8 +120680,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "rZj" = (
@@ -121072,8 +120701,7 @@
 /obj/item/bikehorn/rubberducky/captain,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 6;
-	tag = "icon-shower (EAST)"
+	pixel_y = 6
 	},
 /obj/effect/landmark/start/captain,
 /obj/item/radio/intercom/directional/north,
@@ -121151,8 +120779,7 @@
 "rZV" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "rZY" = (
@@ -121291,8 +120918,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "sbd" = (
@@ -121784,8 +121410,7 @@
 /obj/machinery/smartfridge/secure/medbay_blood,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
 "sdW" = (
@@ -122196,8 +121821,7 @@
 /area/security/lobby)
 "sga" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "sgf" = (
@@ -122422,8 +122046,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/warden)
 "shV" = (
@@ -122465,8 +122088,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/casino)
 "siD" = (
@@ -122490,8 +122112,7 @@
 "siF" = (
 /obj/effect/decal/cleanable/dust,
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/casino)
@@ -122720,8 +122341,7 @@
 "skT" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "skZ" = (
@@ -122759,8 +122379,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/casino)
 "sln" = (
@@ -123118,8 +122737,7 @@
 "sob" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
 "soc" = (
@@ -123277,8 +122895,7 @@
 /obj/item/flashlight/pen,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
 "spj" = (
@@ -123545,8 +123162,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "srV" = (
@@ -123645,8 +123261,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/maintenance/medroom)
 "ssL" = (
@@ -124085,8 +123700,7 @@
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/secpost)
 "svB" = (
@@ -124468,8 +124082,7 @@
 "syA" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "syB" = (
@@ -125092,8 +124705,7 @@
 	network = list("SS13","Medical")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
 "sDd" = (
@@ -125111,8 +124723,7 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "sDf" = (
@@ -125679,8 +125290,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "sHy" = (
@@ -125716,8 +125326,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/theatre)
 "sHF" = (
@@ -126663,8 +126272,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 6;
-	tag = "icon-shower (EAST)"
+	pixel_y = 6
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
@@ -126885,8 +126493,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "sRg" = (
@@ -127167,8 +126774,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "sSO" = (
@@ -127695,8 +127301,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "sWi" = (
@@ -127794,8 +127399,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (EAST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "sWX" = (
@@ -128053,8 +127657,7 @@
 "sZb" = (
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -128226,8 +127829,7 @@
 	name = "Brig Lockdown"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/reception)
 "tal" = (
@@ -128638,8 +128240,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/securearmory)
 "tcR" = (
@@ -129260,8 +128861,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
 "tgT" = (
@@ -129484,8 +129084,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
 "tiT" = (
@@ -129717,8 +129316,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/main)
 "tkf" = (
@@ -130850,8 +130448,7 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/maintenance/medroom)
 "ttG" = (
@@ -132081,8 +131678,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/atmos)
 "tCO" = (
@@ -132438,8 +132034,7 @@
 /obj/structure/closet/secure_closet/research_reagents,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
 "tFl" = (
@@ -132581,8 +132176,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
 "tFY" = (
@@ -132972,8 +132566,7 @@
 /area/engineering/mechanic_workshop/expedition)
 "tIe" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
@@ -133199,8 +132792,7 @@
 "tKc" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "tKk" = (
@@ -133323,8 +132915,7 @@
 /area/maintenance/trading)
 "tLu" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/medical/cmostore)
 "tLv" = (
@@ -133351,8 +132942,7 @@
 /obj/machinery/vending/security,
 /obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "tLH" = (
@@ -134010,8 +133600,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "tRa" = (
@@ -134046,8 +133635,7 @@
 /obj/machinery/vending/autodrobe,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/theatre)
 "tRC" = (
@@ -134392,8 +133980,7 @@
 /obj/item/chair,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "tTK" = (
@@ -134432,8 +134019,7 @@
 /area/security/permabrig)
 "tUc" = (
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -134503,8 +134089,7 @@
 /obj/item/storage/box/monkeycubes,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
 "tUz" = (
@@ -135608,8 +135193,7 @@
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "ucg" = (
@@ -135993,8 +135577,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "ufe" = (
@@ -136083,8 +135666,7 @@
 /mob/living/simple_animal/pet/slugcat,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
 "uga" = (
@@ -136328,8 +135910,7 @@
 "uhE" = (
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /obj/effect/decal/warning_stripes/green,
 /obj/effect/decal/warning_stripes/northeast,
@@ -136517,8 +136098,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "uje" = (
@@ -136615,8 +136195,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTHWEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/mixing)
 "ujP" = (
@@ -136845,8 +136424,7 @@
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "umj" = (
@@ -137392,8 +136970,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "urd" = (
@@ -137751,8 +137328,7 @@
 "utq" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
 "utu" = (
@@ -138741,8 +138317,7 @@
 	network = list("Research","SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "uBh" = (
@@ -138971,8 +138546,7 @@
 /area/bridge)
 "uCP" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -139113,8 +138687,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/biostorage)
 "uEi" = (
@@ -139512,8 +139085,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner (WEST)"
+	icon_state = "whitebluecorner"
 	},
 /area/maintenance/medroom)
 "uHx" = (
@@ -139615,8 +139187,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/processing)
 "uIs" = (
@@ -140364,8 +139935,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "uOv" = (
@@ -140405,8 +139975,7 @@
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /obj/effect/spawner/random_spawners/blood_20,
 /turf/simulated/floor/plasteel{
@@ -140588,8 +140157,7 @@
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/test_chamber)
 "uQn" = (
@@ -140691,8 +140259,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "uRq" = (
@@ -141126,8 +140693,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "uVm" = (
@@ -141319,8 +140885,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/casino)
 "uWc" = (
@@ -142223,8 +141788,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -142604,8 +142168,7 @@
 /area/space)
 "veF" = (
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/casino)
 "veG" = (
@@ -143020,8 +142583,7 @@
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/hallway/secondary/exit)
 "viA" = (
@@ -143490,8 +143052,7 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "vme" = (
@@ -143766,8 +143327,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/crew_quarters/theatre)
 "vou" = (
@@ -143803,8 +143363,7 @@
 "voX" = (
 /obj/effect/landmark/start/security_officer,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "vpa" = (
@@ -145637,8 +145196,7 @@
 /obj/effect/decal/cleanable/dust,
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/casino)
 "vEb" = (
@@ -146065,8 +145623,7 @@
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j1 (WEST)"
+	icon_state = "pipe-j2"
 	},
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -146268,8 +145825,7 @@
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cmostore)
 "vJf" = (
@@ -146434,8 +145990,7 @@
 /obj/item/soap,
 /obj/machinery/light,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/livingcomplex)
 "vKg" = (
@@ -146548,8 +146103,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "vKP" = (
@@ -146682,8 +146236,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cryo)
 "vLW" = (
@@ -147111,8 +146664,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/customs)
 "vOy" = (
@@ -147279,8 +146831,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/medical/medbay)
 "vQu" = (
@@ -147358,8 +146909,7 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "vRq" = (
@@ -147372,8 +146922,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	tag = "icon-pipe-j2"
+	dir = 8
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=L11";
@@ -147670,8 +147219,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "vTW" = (
@@ -148439,8 +147987,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "vYJ" = (
@@ -149351,8 +148898,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/casino)
 "wgs" = (
@@ -149687,8 +149233,7 @@
 /obj/machinery/monkey_recycler,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
 "wjk" = (
@@ -150007,8 +149552,7 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "wkZ" = (
@@ -150681,8 +150225,7 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medrest)
 "wpI" = (
@@ -151177,8 +150720,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/garden)
 "wsQ" = (
@@ -151338,8 +150880,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "wtD" = (
@@ -151724,8 +151265,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "wwo" = (
@@ -151743,8 +151283,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "wwv" = (
@@ -152282,8 +151821,7 @@
 	dir = 4
 	},
 /obj/machinery/shower{
-	dir = 4;
-	tag = "icon-shower (EAST)"
+	dir = 4
 	},
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/light/small{
@@ -153773,8 +153311,7 @@
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
 "wND" = (
@@ -154370,8 +153907,7 @@
 /obj/effect/spawner/random_spawners/rodent,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "wRT" = (
@@ -154647,8 +154183,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cmo)
 "wTS" = (
@@ -154692,8 +154227,7 @@
 /obj/item/hand_labeler,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (SOUTHEAST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
 "wUm" = (
@@ -154712,8 +154246,7 @@
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/ward)
 "wUn" = (
@@ -155529,8 +155062,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/maintenance/casino)
 "xaI" = (
@@ -155649,8 +155181,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "xbE" = (
@@ -155727,8 +155258,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
 "xcF" = (
@@ -155851,16 +155381,14 @@
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/maintenance/medroom)
 "xdz" = (
@@ -156091,8 +155619,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "xfV" = (
@@ -156193,8 +155720,7 @@
 /obj/machinery/coffeemaker/standard,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medrest)
 "xgD" = (
@@ -156309,8 +155835,7 @@
 "xhz" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "xhB" = (
@@ -156376,8 +155901,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/maintenance/secpost)
 "xif" = (
@@ -156590,8 +156114,7 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /obj/effect/turf_decal/siding/white/end{
 	dir = 1
@@ -157289,8 +156812,7 @@
 "xpE" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/medical/reception)
 "xpR" = (
@@ -157690,8 +157212,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/medbay2)
 "xsH" = (
@@ -157937,8 +157458,7 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "xuX" = (
@@ -159937,8 +159457,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	name = "Waste Disposals Junction";
-	sortType = 1;
-	tag = "icon-pipe-j1s (EAST)"
+	sortType = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -160210,8 +159729,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/medical/morgue)
 "xLP" = (
@@ -160230,8 +159748,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	tag = "icon-pipe-j1 (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -160272,8 +159789,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/medical/cmostore)
 "xMh" = (
@@ -161434,8 +160950,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "xUI" = (
@@ -161700,8 +161215,7 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	pixel_y = 4;
-	tag = "icon-shower (EAST)"
+	pixel_y = 4
 	},
 /obj/effect/turf_decal/siding/white/end,
 /turf/simulated/floor/plasteel/freezer,
@@ -162946,8 +162460,7 @@
 "yed" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "yej" = (
@@ -163096,8 +162609,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/security/warden)
 "yeW" = (
@@ -163116,8 +162628,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "redfull";
-	tag = "icon-redfull (NORTHWEST)"
+	icon_state = "redfull"
 	},
 /area/security/seceqstorage)
 "yff" = (
@@ -163303,8 +162814,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/medical/research)
 "ygK" = (
@@ -163662,8 +163172,7 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/toxins/xenobiology)
 "yjS" = (
@@ -176911,7 +176420,7 @@ cmZ
 cGC
 fuk
 pAS
-reo
+khR
 dZi
 lKF
 jWH
@@ -185605,21 +185114,21 @@ evj
 gGm
 fRA
 aFZ
-iSv
+oNw
 fBf
 fjD
-iSv
-iSv
-iSv
+oNw
+oNw
+oNw
 hBs
 piI
 saF
 rEG
 qkL
 jrB
-iSv
+oNw
 sMA
-iSv
+oNw
 quV
 gdM
 dId
@@ -188182,14 +187691,14 @@ tro
 oNw
 oNw
 oNw
-aJd
+saF
 kom
 eNr
 kom
 qkL
 anB
-iSv
-iSv
+oNw
+oNw
 quV
 gdM
 cpV
@@ -194337,11 +193846,11 @@ gIj
 dUQ
 ewc
 eus
-pqk
+stU
 uJA
 jJY
 uJA
-bjJ
+fOx
 lff
 nbM
 gVf
@@ -200766,7 +200275,7 @@ ier
 ier
 ier
 oPj
-knz
+eoD
 xik
 xUC
 hLj
@@ -205135,11 +204644,11 @@ nAT
 ncG
 nyq
 skT
-knz
-knz
-knz
+eoD
+eoD
+eoD
 nCs
-knz
+eoD
 uYn
 lyx
 lfG

--- a/_maps/map_files/nova/submaps/AbondonedChapel.dmm
+++ b/_maps/map_files/nova/submaps/AbondonedChapel.dmm
@@ -363,8 +363,7 @@
 /area/maintenance/server)
 "kG" = (
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-dead";
-	tag = "plant-dead"
+	icon_state = "plant-dead"
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
@@ -713,8 +712,7 @@
 /area/maintenance/club)
 "yh" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -928,7 +926,6 @@
 /area/template_noop)
 "EF" = (
 /obj/machinery/alarm{
-	pixel_y = 0;
 	dir = 4;
 	pixel_x = -22
 	},
@@ -1384,8 +1381,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/nova/submaps/AbondonedLibrary.dmm
+++ b/_maps/map_files/nova/submaps/AbondonedLibrary.dmm
@@ -88,9 +88,7 @@
 /area/maintenance/trading)
 "gc" = (
 /obj/structure/computerframe,
-/obj/item/circuitboard/secure_data{
-	pixel_y = 0
-	},
+/obj/item/circuitboard/secure_data,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},

--- a/_maps/map_files/nova/submaps/AbondonedLivingComplex.dmm
+++ b/_maps/map_files/nova/submaps/AbondonedLivingComplex.dmm
@@ -276,7 +276,6 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/contraband/commando{
-	pixel_y = 0;
 	pixel_x = 32
 	},
 /turf/simulated/floor/carpet/royalblack,
@@ -490,7 +489,6 @@
 /area/template_noop)
 "mN" = (
 /obj/structure/sign/poster/contraband/commando{
-	pixel_y = 0;
 	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -581,8 +579,7 @@
 	pixel_x = -8
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/livingcomplex)
 "pm" = (
@@ -619,8 +616,7 @@
 	pixel_x = -17
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/livingcomplex)
 "qq" = (
@@ -1024,9 +1020,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/clothing/gloves/color/latex/nitrile{
-	pixel_y = 0
-	},
+/obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/clothing/accessory/stethoscope,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/pod,
@@ -1171,7 +1165,6 @@
 	nightshift_enabled = 1
 	},
 /obj/structure/sign/poster/contraband/commando{
-	pixel_y = 0;
 	pixel_x = 32
 	},
 /turf/simulated/floor/carpet/black,
@@ -1273,7 +1266,6 @@
 /obj/machinery/door_control{
 	id = "oldcargo";
 	name = "Abandoned Warehouse Access Control";
-	pixel_y = 0;
 	req_access = list(31);
 	pixel_x = 24
 	},
@@ -1697,8 +1689,7 @@
 "UH" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/livingcomplex)
 "UO" = (

--- a/_maps/map_files/nova/submaps/AbondonedMed.dmm
+++ b/_maps/map_files/nova/submaps/AbondonedMed.dmm
@@ -42,7 +42,6 @@
 "aE" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "rampbottom";
-	tag = "icon-stage_stairs";
 	dir = 4
 	},
 /area/maintenance/abandonedhangar)
@@ -270,7 +269,6 @@
 /obj/structure/chair/comfy/shuttle/dark{
 	dir = 8;
 	layer = 3.4;
-	pixel_y = 0;
 	pixel_x = 6
 	},
 /obj/machinery/light/small{
@@ -393,8 +391,7 @@
 /area/maintenance/apmaint)
 "dI" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -477,8 +474,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/abandonedhangar)
@@ -618,8 +614,7 @@
 /area/maintenance/apmaint)
 "eX" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -664,8 +659,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/abandonedhangar)
 "fu" = (
@@ -689,8 +683,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -856,8 +849,7 @@
 	id_tag = "hangarshuttlebay3"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/abandonedhangar)
 "hJ" = (
@@ -896,8 +888,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -1075,8 +1066,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -1086,7 +1076,6 @@
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plasteel{
 	icon_state = "rampbottom";
-	tag = "icon-stage_stairs";
 	dir = 4
 	},
 /area/maintenance/abandonedhangar)
@@ -1139,8 +1128,7 @@
 /obj/item/reagent_containers/iv_bag,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -1194,8 +1182,7 @@
 	dir = 1
 	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	name = "standard air scrubber";
@@ -1231,16 +1218,14 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "kP" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/abandonedhangar)
 "kR" = (
@@ -1364,13 +1349,11 @@
 	desc = "A remote control-switch for the pod doors.";
 	id = "hangarshuttlebay4";
 	name = "Pod Door Control";
-	pixel_y = 0;
 	pixel_x = 26;
 	use_power = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/abandonedhangar)
 "mZ" = (
@@ -1499,7 +1482,6 @@
 	desc = "A remote control-switch for the pod doors.";
 	id = "hangarshuttlebay5";
 	name = "Hangar Pod Door Control";
-	pixel_y = 0;
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1552,8 +1534,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/walllocker/emerglocker/directional/west,
@@ -1788,8 +1769,7 @@
 "rm" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/pod/light,
@@ -1797,8 +1777,7 @@
 "rr" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/pod/light,
@@ -1919,8 +1898,7 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/pod/light,
@@ -1940,8 +1918,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/pod/light,
@@ -2047,8 +2024,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -2069,8 +2045,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -2254,8 +2229,7 @@
 /area/maintenance/medroom)
 "vy" = (
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2392,8 +2366,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/mouse,
@@ -2547,8 +2520,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -2602,8 +2574,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/pod/light,
@@ -2839,8 +2810,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/writing,
 /obj/effect/decal/cleanable/dirt,
@@ -2918,15 +2888,13 @@
 "Bu" = (
 /obj/effect/decal/cleanable/blood/writing,
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/abandonedhangar)
 "BA" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /turf/simulated/floor/pod/light,
 /area/maintenance/abandonedhangar)
@@ -3052,7 +3020,6 @@
 /obj/structure/chair/comfy/shuttle/dark{
 	dir = 8;
 	layer = 3.4;
-	pixel_y = 0;
 	pixel_x = 6
 	},
 /obj/effect/decal/cleanable/dust,
@@ -3165,7 +3132,6 @@
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
-	pixel_y = 0;
 	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
@@ -3295,8 +3261,7 @@
 "Fw" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /turf/simulated/floor/pod/light,
 /area/maintenance/abandonedhangar)
@@ -3522,8 +3487,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/decal/cleanable/dirt,
@@ -3641,8 +3605,7 @@
 "Ix" = (
 /obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -3651,7 +3614,6 @@
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
-	pixel_y = 0;
 	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
@@ -3691,8 +3653,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -4248,8 +4209,7 @@
 "Oe" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /turf/simulated/floor/pod/light,
 /area/maintenance/abandonedhangar)
@@ -4299,8 +4259,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4477,8 +4436,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_construct{
@@ -4561,8 +4519,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4686,8 +4643,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -4774,8 +4730,7 @@
 "TX" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /turf/simulated/floor/pod/light,
 /area/maintenance/abandonedhangar)
@@ -4810,13 +4765,11 @@
 	desc = "A remote control-switch for the pod doors.";
 	id = "hangarshuttlebay3";
 	name = "Pod Door Control";
-	pixel_y = 0;
 	pixel_x = 26;
 	use_power = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/maintenance/abandonedhangar)
 "Ul" = (
@@ -4912,8 +4865,7 @@
 "Vn" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/pod/light,
@@ -5145,7 +5097,6 @@
 /obj/structure/chair/comfy/shuttle/dark{
 	dir = 4;
 	layer = 3.4;
-	pixel_y = 0;
 	pixel_x = -7
 	},
 /obj/effect/decal/cleanable/dust,
@@ -5183,8 +5134,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/empty{
@@ -5222,8 +5172,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/medical/glass,
@@ -5292,7 +5241,6 @@
 /obj/structure/chair/comfy/shuttle/dark{
 	dir = 4;
 	layer = 3.4;
-	pixel_y = 0;
 	pixel_x = -7
 	},
 /obj/machinery/light/small{
@@ -5327,8 +5275,7 @@
 "ZE" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/pod/light,

--- a/_maps/map_files/nova/submaps/Banya.dmm
+++ b/_maps/map_files/nova/submaps/Banya.dmm
@@ -1030,8 +1030,7 @@
 	pixel_y = 15
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -4;
-	pixel_y = 0
+	pixel_x = -4
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
 	pixel_x = -2;
@@ -1779,8 +1778,7 @@
 /area/maintenance/tourist)
 "Yt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 2;
-	pixel_y = 0
+	dir = 2
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -1808,8 +1806,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dust,
 /obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/dark,
 /area/maintenance/abandonedclub)

--- a/_maps/map_files/nova/submaps/EastMaintenance.dmm
+++ b/_maps/map_files/nova/submaps/EastMaintenance.dmm
@@ -822,8 +822,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/backstage)
 "iB" = (
@@ -1066,8 +1065,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/tomato_smudge,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken3";
-	tag = "icon-wood-broken3"
+	icon_state = "wood-broken3"
 	},
 /area/maintenance/backstage)
 "mr" = (
@@ -1457,8 +1455,7 @@
 "rx" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/abandonedoffices)
 "rz" = (
@@ -1517,8 +1514,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken7";
-	tag = "icon-wood-broken7"
+	icon_state = "wood-broken7"
 	},
 /area/maintenance/backstage)
 "so" = (
@@ -2629,8 +2625,7 @@
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/maintenance/abandonedoffices)
 "Dm" = (
@@ -3610,8 +3605,7 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/backstage)
 "Nx" = (
@@ -3623,8 +3617,7 @@
 	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/maintenance/abandonedoffices)
 "NF" = (

--- a/_maps/map_files/shuttles/admin_admin.dmm
+++ b/_maps/map_files/shuttles/admin_admin.dmm
@@ -41,8 +41,7 @@
 "at" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -150,8 +149,7 @@
 "aN" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -387,8 +385,7 @@
 "dX" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";

--- a/_maps/map_files/shuttles/admin_alien.dmm
+++ b/_maps/map_files/shuttles/admin_alien.dmm
@@ -477,8 +477,7 @@
 "tw" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -662,8 +661,7 @@
 "Aa" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -782,8 +780,7 @@
 "EL" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";

--- a/_maps/map_files/shuttles/admin_armory.dmm
+++ b/_maps/map_files/shuttles/admin_armory.dmm
@@ -322,8 +322,7 @@
 "jF" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -554,8 +553,7 @@
 "rA" = (
 /obj/item/flag/nt,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle{
 	dir = 8;
@@ -818,8 +816,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/item/clothing/mask/breath{
 	pixel_x = -3;
@@ -994,8 +991,7 @@
 "Du" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -1087,8 +1083,7 @@
 "Gn" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -1391,8 +1386,7 @@
 "Pj" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/shuttle{
 	icon = 'icons/turf/floors.dmi';

--- a/_maps/map_files/shuttles/admin_club.dmm
+++ b/_maps/map_files/shuttles/admin_club.dmm
@@ -266,8 +266,7 @@
 "wa" = (
 /turf/simulated/floor/plasteel{
 	color = "gray";
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/shuttle/administration)
 "ww" = (
@@ -416,8 +415,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	color = "gray";
-	icon_state = "rampbottom";
-	tag = "icon-stage_stairs"
+	icon_state = "rampbottom"
 	},
 /area/shuttle/administration)
 "FQ" = (
@@ -849,8 +847,7 @@
 "Ye" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/shuttle/engine/platform{
 	dir = 4;
@@ -864,8 +861,7 @@
 "YE" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/shuttle/engine/platform{
 	dir = 4;
@@ -888,8 +884,7 @@
 "ZC" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/shuttle/engine/platform{
 	dir = 4;

--- a/_maps/map_files/shuttles/admin_hospital.dmm
+++ b/_maps/map_files/shuttles/admin_hospital.dmm
@@ -69,8 +69,7 @@
 "aA" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -609,8 +608,7 @@
 "oL" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";
@@ -864,8 +862,7 @@
 "IP" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#22aab7";

--- a/_maps/map_files/shuttles/admin_interview.dmm
+++ b/_maps/map_files/shuttles/admin_interview.dmm
@@ -104,8 +104,7 @@
 "hG" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side_inv";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side_inv"
 	},
 /obj/structure/shuttle/engine/platform{
 	dir = 4;
@@ -223,8 +222,7 @@
 "mZ" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3"
 	},
 /obj/structure/shuttle/engine/platform{
 	dir = 4;
@@ -918,8 +916,7 @@
 "SE" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater3x3_side";
-	tag = "icon-heater (NORTH)"
+	icon_state = "heater3x3_side"
 	},
 /obj/structure/shuttle/engine/platform{
 	dir = 4;

--- a/_maps/map_files/shuttles/cargo_base.dmm
+++ b/_maps/map_files/shuttles/cargo_base.dmm
@@ -4,8 +4,7 @@
 /area/shuttle/supply)
 "f" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/supply)
@@ -27,15 +26,13 @@
 /area/shuttle/supply)
 "i" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/supply)
 "j" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/door_control{
 	id = "QMLoaddoor2";
@@ -92,8 +89,7 @@
 /area/space)
 "w" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "burst_l";
-	tag = "icon-burst_l"
+	icon_state = "burst_l"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/supply)
@@ -103,8 +99,7 @@
 /area/shuttle/supply)
 "y" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "burst_r";
-	tag = "icon-burst_r"
+	icon_state = "burst_r"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/supply)

--- a/_maps/map_files/shuttles/emergency_bar.dmm
+++ b/_maps/map_files/shuttles/emergency_bar.dmm
@@ -121,8 +121,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/shuttle/objective_check,
@@ -160,8 +159,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/piano,
 /turf/simulated/floor/plasteel{
@@ -258,8 +256,7 @@
 /area/shuttle/escape)
 "aS" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -305,8 +302,7 @@
 /area/shuttle/escape)
 "aX" = (
 /obj/structure/chair/wood/wings{
-	dir = 4;
-	tag = "icon-wooden_chair_wings (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -351,8 +347,7 @@
 /area/shuttle/escape)
 "be" = (
 /obj/structure/chair/wood/wings{
-	dir = 1;
-	tag = "icon-wooden_chair_wings (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -361,8 +356,7 @@
 "bf" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -423,8 +417,7 @@
 /area/shuttle/escape)
 "bp" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/machinery/shower,
 /obj/structure/curtain/open/shower,
@@ -487,8 +480,7 @@
 	pixel_x = -30
 	},
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
@@ -525,8 +517,7 @@
 "bC" = (
 /obj/machinery/sleeper{
 	dir = 1;
-	icon_state = "sleeper";
-	tag = "icon-sleeper (NORTH)"
+	icon_state = "sleeper"
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"

--- a/_maps/map_files/shuttles/emergency_clown.dmm
+++ b/_maps/map_files/shuttles/emergency_clown.dmm
@@ -108,8 +108,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/chasm,
 /area/shuttle/escape)
@@ -123,8 +122,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/item/toy/snappop/phoenix,
 /turf/simulated/floor/plasteel{
@@ -184,8 +182,7 @@
 "aQ" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/rainbow,
@@ -207,8 +204,7 @@
 /obj/item/extinguisher,
 /obj/item/crowbar,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/item/multitool/ai_detect,
 /turf/simulated/floor/noslip,
@@ -305,8 +301,7 @@
 /area/shuttle/escape)
 "bg" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/noslip,
 /area/shuttle/escape)
@@ -315,8 +310,7 @@
 	pixel_x = -30
 	},
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/noslip,
 /area/shuttle/escape)
@@ -341,8 +335,7 @@
 "bm" = (
 /obj/machinery/sleeper{
 	dir = 1;
-	icon_state = "sleeper";
-	tag = "icon-sleeper (NORTH)"
+	icon_state = "sleeper"
 	},
 /turf/simulated/floor/noslip,
 /area/shuttle/escape)

--- a/_maps/map_files/shuttles/emergency_cramped.dmm
+++ b/_maps/map_files/shuttles/emergency_cramped.dmm
@@ -91,8 +91,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/escape)
@@ -131,15 +130,13 @@
 /area/shuttle/escape)
 "B" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "burst_l";
-	tag = "icon-burst_l"
+	icon_state = "burst_l"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/escape)
 "C" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r"
+	icon_state = "propulsion_r"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/escape)

--- a/_maps/map_files/shuttles/emergency_cyb.dmm
+++ b/_maps/map_files/shuttles/emergency_cyb.dmm
@@ -635,8 +635,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -702,15 +701,13 @@
 "cg" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "browncorner";
-	tag = "icon-browncorner (EAST)"
+	icon_state = "browncorner"
 	},
 /area/shuttle/escape)
 "ch" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "browncorner";
-	tag = "icon-browncorner (EAST)"
+	icon_state = "browncorner"
 	},
 /area/shuttle/escape)
 "ci" = (
@@ -781,8 +778,7 @@
 "cs" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "ct" = (
@@ -795,8 +791,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "cu" = (
@@ -818,8 +813,7 @@
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "cx" = (
@@ -829,14 +823,12 @@
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "cy" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "cz" = (
@@ -852,8 +844,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "cA" = (

--- a/_maps/map_files/shuttles/emergency_dept.dmm
+++ b/_maps/map_files/shuttles/emergency_dept.dmm
@@ -345,8 +345,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "bg" = (
@@ -457,8 +456,7 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "by" = (
@@ -731,8 +729,7 @@
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "cA" = (
@@ -792,8 +789,7 @@
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "IB" = (

--- a/_maps/map_files/shuttles/emergency_meta.dmm
+++ b/_maps/map_files/shuttles/emergency_meta.dmm
@@ -128,15 +128,13 @@
 /area/shuttle/escape)
 "aA" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/escape)
 "aB" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 8;
-	tag = "icon-heater (WEST)"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -176,15 +174,13 @@
 "aH" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion_r";
-	tag = "icon-propulsion_r (EAST)"
+	icon_state = "propulsion_r"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/escape)
 "aI" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 8;
-	tag = "icon-heater (WEST)"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 4

--- a/_maps/map_files/shuttles/emergency_mil.dmm
+++ b/_maps/map_files/shuttles/emergency_mil.dmm
@@ -67,8 +67,7 @@
 /area/shuttle/escape)
 "ap" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/machinery/computer/robotics,
 /turf/simulated/floor/plasteel{
@@ -124,8 +123,7 @@
 "aB" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -174,8 +172,7 @@
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "aK" = (
@@ -188,13 +185,11 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "aL" = (
@@ -207,8 +202,7 @@
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "aO" = (
@@ -220,8 +214,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "aR" = (
@@ -246,16 +239,14 @@
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "aU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "aV" = (
@@ -263,8 +254,7 @@
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "aW" = (
@@ -304,8 +294,7 @@
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "ba" = (
@@ -319,14 +308,12 @@
 /area/shuttle/escape)
 "bb" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "bc" = (
@@ -387,8 +374,7 @@
 "bj" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -418,8 +404,7 @@
 /area/shuttle/escape)
 "bm" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -431,8 +416,7 @@
 /area/shuttle/escape)
 "bn" = (
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -524,8 +508,7 @@
 "hC" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -603,8 +586,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/escape)
 "qo" = (

--- a/_maps/map_files/shuttles/emergency_narnar.dmm
+++ b/_maps/map_files/shuttles/emergency_narnar.dmm
@@ -98,7 +98,6 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
 	dir = 1
 	},
 /obj/effect/decal/remains/human{
@@ -127,7 +126,6 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (NORTH)";
 	dir = 1
 	},
 /turf/simulated/floor/engine/cult,
@@ -195,7 +193,6 @@
 "aG" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
 	dir = 8
 	},
 /obj/item/flag/cult,
@@ -212,7 +209,6 @@
 "aJ" = (
 /obj/structure/closet/walllocker/emerglocker/directional/east,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
 	dir = 4
 	},
 /turf/simulated/floor/engine/cult,
@@ -244,7 +240,6 @@
 /obj/item/extinguisher,
 /obj/item/crowbar,
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (WEST)";
 	dir = 8
 	},
 /turf/simulated/floor/engine/cult,
@@ -317,7 +312,6 @@
 /area/shuttle/escape)
 "bb" = (
 /obj/machinery/light/spot{
-	tag = "icon-tube1 (EAST)";
 	dir = 4
 	},
 /turf/simulated/floor/engine/cult,
@@ -343,7 +337,6 @@
 /area/shuttle/escape)
 "bg" = (
 /obj/machinery/sleeper{
-	tag = "icon-sleeper (NORTH)";
 	icon_state = "sleeper";
 	dir = 1
 	},

--- a/_maps/map_files/shuttles/emergency_old.dmm
+++ b/_maps/map_files/shuttles/emergency_old.dmm
@@ -111,8 +111,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/escape)
@@ -148,8 +147,7 @@
 "aL" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -161,8 +159,7 @@
 "aM" = (
 /obj/structure/closet/walllocker/emerglocker/directional/east,
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -181,8 +178,7 @@
 /obj/item/extinguisher,
 /obj/item/crowbar,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
@@ -250,8 +246,7 @@
 /area/shuttle/escape)
 "bc" = (
 /obj/machinery/light/spot{
-	dir = 4;
-	tag = "icon-tube1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor2"
@@ -262,8 +257,7 @@
 	pixel_x = -30
 	},
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
@@ -319,8 +313,7 @@
 "ev" = (
 /obj/machinery/sleeper{
 	dir = 1;
-	icon_state = "sleeper";
-	tag = "icon-sleeper (NORTH)"
+	icon_state = "sleeper"
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
@@ -362,8 +355,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/shuttle/objective_check,

--- a/_maps/map_files/shuttles/ferry_SMgen.dmm
+++ b/_maps/map_files/shuttles/ferry_SMgen.dmm
@@ -24,8 +24,7 @@
 /area/shuttle/transport)
 "i" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /obj/structure/window/plasmareinforced{
 	dir = 4
@@ -338,8 +337,7 @@
 /area/shuttle/transport)
 "W" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)

--- a/_maps/map_files/shuttles/ferry_cargo.dmm
+++ b/_maps/map_files/shuttles/ferry_cargo.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)
@@ -24,8 +23,7 @@
 "e" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "darkbrown";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "darkbrown"
 	},
 /area/shuttle/transport)
 "i" = (
@@ -88,8 +86,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whiteyellow";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteyellow"
 	},
 /area/shuttle/transport)
 "s" = (
@@ -97,8 +94,7 @@
 /obj/structure/closet/crate/engineering,
 /obj/effect/spawner/lootdrop/trade_sol/eng,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -116,8 +112,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteyellow";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteyellow"
 	},
 /area/shuttle/transport)
 "x" = (
@@ -186,8 +181,7 @@
 	dir = 4
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;

--- a/_maps/map_files/shuttles/ferry_chem.dmm
+++ b/_maps/map_files/shuttles/ferry_chem.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)
@@ -52,8 +51,7 @@
 	dir = 4
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/transport)
@@ -169,11 +167,6 @@
 /obj/item/storage/bag/chemistry,
 /turf/simulated/floor/shuttle,
 /area/shuttle/transport)
-"T" = (
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall2"
-	},
-/area/shuttle/transport)
 "W" = (
 /obj/item/paper_bin,
 /obj/item/lighter/zippo{
@@ -247,7 +240,7 @@ s
 s
 p
 L
-T
+s
 s
 "}
 (9,1,1) = {"

--- a/_maps/map_files/shuttles/ferry_clown.dmm
+++ b/_maps/map_files/shuttles/ferry_clown.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)

--- a/_maps/map_files/shuttles/ferry_cult.dmm
+++ b/_maps/map_files/shuttles/ferry_cult.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)
@@ -21,8 +20,7 @@
 /area/shuttle/transport)
 "g" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /obj/structure/window/plasmareinforced{
 	color = "#FF0000";

--- a/_maps/map_files/shuttles/ferry_deepdarkdungeon.dmm
+++ b/_maps/map_files/shuttles/ferry_deepdarkdungeon.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)

--- a/_maps/map_files/shuttles/ferry_doomsday.dmm
+++ b/_maps/map_files/shuttles/ferry_doomsday.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)
@@ -36,11 +35,6 @@
 /obj/effect/decal/cleanable/blood/bubblegum,
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
-	},
-/area/shuttle/transport)
-"q" = (
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall2"
 	},
 /area/shuttle/transport)
 "t" = (
@@ -232,6 +226,6 @@ E
 E
 b
 C
-q
+E
 E
 "}

--- a/_maps/map_files/shuttles/ferry_meat.dmm
+++ b/_maps/map_files/shuttles/ferry_meat.dmm
@@ -28,8 +28,7 @@
 /area/shuttle/transport)
 "h" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -66,8 +65,7 @@
 /area/shuttle/transport)
 "l" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/machinery/gibber,
 /turf/simulated/floor/plasteel{
@@ -88,8 +86,7 @@
 /area/shuttle/transport)
 "o" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/shuttles/ferry_medical.dmm
+++ b/_maps/map_files/shuttles/ferry_medical.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)
@@ -38,16 +37,14 @@
 /obj/machinery/optable,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/transport)
 "g" = (
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/transport)
 "h" = (
@@ -98,8 +95,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/transport)
 "s" = (
@@ -130,16 +126,14 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/transport)
 "y" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/transport)
 "z" = (
@@ -148,8 +142,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/transport)
 "B" = (
@@ -175,8 +168,7 @@
 /obj/item/reagent_containers/iv_bag/salglu,
 /turf/simulated/floor/plasteel{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/transport)
 "G" = (
@@ -200,8 +192,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (SOUTHWEST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/transport)
 "J" = (
@@ -220,8 +211,7 @@
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/transport)
 "O" = (
@@ -242,11 +232,6 @@
 "R" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluecorner"
-	},
-/area/shuttle/transport)
-"T" = (
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall2"
 	},
 /area/shuttle/transport)
 "V" = (
@@ -300,8 +285,7 @@
 /obj/item/robot_parts/r_leg,
 /turf/simulated/floor/plasteel{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/shuttle/transport)
 
@@ -344,7 +328,7 @@ J
 J
 B
 G
-T
+J
 J
 "}
 (7,1,1) = {"

--- a/_maps/map_files/shuttles/ferry_meteorshelp.dmm
+++ b/_maps/map_files/shuttles/ferry_meteorshelp.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)
@@ -89,8 +88,7 @@
 	amount = 50
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -157,8 +155,7 @@
 	},
 /obj/machinery/autolathe/upgraded,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced/survival_pod/unhittable{
 	dir = 8;

--- a/_maps/map_files/shuttles/ferry_mime.dmm
+++ b/_maps/map_files/shuttles/ferry_mime.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)

--- a/_maps/map_files/shuttles/ferry_prisoner.dmm
+++ b/_maps/map_files/shuttles/ferry_prisoner.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)
@@ -34,8 +33,7 @@
 "f" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/machinery/recharger,
 /obj/structure/reagent_dispensers/peppertank{
@@ -94,8 +92,7 @@
 /area/shuttle/transport)
 "t" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -116,8 +113,7 @@
 "y" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/machinery/recharger,
 /turf/simulated/floor/noslip{
@@ -148,11 +144,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/shuttle/objective_check,
-/area/shuttle/transport)
-"G" = (
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall2"
-	},
 /area/shuttle/transport)
 "H" = (
 /turf/simulated/floor/shuttle/objective_check,
@@ -209,7 +200,7 @@ U
 U
 W
 j
-G
+U
 U
 "}
 (7,1,1) = {"

--- a/_maps/map_files/shuttles/ferry_slave.dmm
+++ b/_maps/map_files/shuttles/ferry_slave.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)
@@ -30,11 +29,6 @@
 	},
 /turf/simulated/floor/shuttle/syndicate,
 /area/shuttle/transport)
-"j" = (
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall2"
-	},
-/area/shuttle/transport)
 "l" = (
 /obj/machinery/door/window/survival_pod{
 	dir = 1;
@@ -53,8 +47,7 @@
 /area/shuttle/transport)
 "n" = (
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/machinery/vending/autodrobe,
 /turf/simulated/floor/shuttle/syndicate,
@@ -111,8 +104,7 @@
 	name = "point of sale"
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/shuttle/syndicate,
 /area/shuttle/transport)
@@ -227,7 +219,7 @@ U
 U
 K
 L
-j
+U
 U
 "}
 (9,1,1) = {"

--- a/_maps/map_files/shuttles/ferry_theatrehelp.dmm
+++ b/_maps/map_files/shuttles/ferry_theatrehelp.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)
@@ -118,8 +117,7 @@
 /obj/machinery/vending/suitdispenser,
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/noslip{
 	icon = 'icons/turf/shuttle/floors.dmi';
@@ -148,11 +146,6 @@
 "I" = (
 /turf/simulated/wall/shuttle{
 	dir = 3
-	},
-/area/shuttle/transport)
-"J" = (
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall2"
 	},
 /area/shuttle/transport)
 "M" = (
@@ -198,8 +191,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/noslip{
 	icon = 'icons/turf/shuttle/floors.dmi';
@@ -298,7 +290,7 @@ r
 r
 I
 G
-J
+r
 r
 "}
 (8,1,1) = {"

--- a/_maps/map_files/shuttles/ferry_ussp.dmm
+++ b/_maps/map_files/shuttles/ferry_ussp.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)

--- a/_maps/map_files/shuttles/ferry_vip.dmm
+++ b/_maps/map_files/shuttles/ferry_vip.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)
@@ -16,8 +15,7 @@
 	name = "bedsheet"
 	},
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/transport)
@@ -44,8 +42,7 @@
 "k" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -65,11 +62,6 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/carpet/royalblack,
-/area/shuttle/transport)
-"o" = (
-/turf/simulated/wall/shuttle{
-	tag = "icon-swall2"
-	},
 /area/shuttle/transport)
 "q" = (
 /obj/item/paper_bin,
@@ -114,8 +106,7 @@
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/table/reinforced,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/machinery/recharger,
 /turf/simulated/floor/noslip{
@@ -131,8 +122,7 @@
 /obj/effect/decal/warning_stripes/south,
 /obj/structure/table/reinforced,
 /obj/machinery/light/spot{
-	dir = 8;
-	tag = "icon-tube1 (WEST)"
+	dir = 8
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 28
@@ -267,7 +257,7 @@ h
 h
 l
 u
-o
+h
 h
 "}
 (7,1,1) = {"

--- a/_maps/map_files/shuttles/ferry_zoo.dmm
+++ b/_maps/map_files/shuttles/ferry_zoo.dmm
@@ -1,8 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/transport)
@@ -200,8 +199,7 @@
 /obj/item/reagent_containers/food/snacks/meat,
 /obj/item/reagent_containers/food/snacks/meat,
 /obj/machinery/light/spot{
-	dir = 1;
-	tag = "icon-tube1 (NORTH)"
+	dir = 1
 	},
 /obj/structure/window/reinforced/survival_pod/unhittable{
 	dir = 8;

--- a/_maps/map_files/templates/medium_shuttle1.dmm
+++ b/_maps/map_files/templates/medium_shuttle1.dmm
@@ -4,19 +4,16 @@
 /area/space)
 "b" = (
 /obj/structure/shuttle/engine/propulsion/burst/left{
-	dir = 8;
-	tag = "icon-burst_l (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/ruin/powered/shuttle)
 "c" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 8;
-	tag = "icon-heater (WEST)"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/ruin/powered/shuttle)
@@ -35,31 +32,27 @@
 /area/ruin/powered/shuttle)
 "j" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "k" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "l" = (
 /obj/structure/computerframe,
 /obj/item/circuitboard/teleporter,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "m" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/ruin/powered/shuttle)
 "n" = (
@@ -67,8 +60,7 @@
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/suit/space/eva,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "o" = (
@@ -80,21 +72,18 @@
 /area/ruin/powered/shuttle)
 "q" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/ruin/powered/shuttle)
 "r" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "s" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "t" = (
@@ -105,8 +94,7 @@
 /obj/machinery/teleport/hub,
 /obj/item/hand_tele,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "w" = (
@@ -114,14 +102,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "z" = (
 /obj/structure/shuttle/engine/propulsion/burst/right{
-	dir = 8;
-	tag = "icon-burst_r (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/ruin/powered/shuttle)
@@ -131,51 +117,44 @@
 	},
 /obj/machinery/teleport/station,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "D" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "E" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "F" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "H" = (
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/ruin/powered/shuttle)
 "I" = (
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "J" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "K" = (
@@ -184,8 +163,7 @@
 	},
 /obj/machinery/vending/engivend,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "L" = (
@@ -193,15 +171,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "M" = (
 /obj/machinery/computer,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "N" = (
@@ -209,8 +185,7 @@
 /obj/item/storage/toolbox/electrical,
 /obj/item/clothing/gloves/color/yellow,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "O" = (
@@ -227,22 +202,19 @@
 /obj/structure/table,
 /obj/item/storage/belt/utility/full/multitool,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "R" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "S" = (
 /obj/item/beacon,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "U" = (
@@ -250,8 +222,7 @@
 /obj/machinery/recharger,
 /obj/item/gun/energy/laser/retro,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 

--- a/_maps/map_files/templates/medium_shuttle2.dmm
+++ b/_maps/map_files/templates/medium_shuttle2.dmm
@@ -4,26 +4,22 @@
 /area/space)
 "b" = (
 /obj/structure/shuttle/engine/propulsion/burst/left{
-	dir = 8;
-	tag = "icon-burst_l (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/ruin/powered/shuttle)
 "c" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 8;
-	tag = "icon-heater (WEST)"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	tag = "icon-rwindow (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/ruin/powered/shuttle)
 "f" = (
 /obj/structure/shuttle/engine/propulsion/burst/right{
-	dir = 8;
-	tag = "icon-burst_r (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/ruin/powered/shuttle)
@@ -38,15 +34,13 @@
 /area/ruin/powered/shuttle)
 "k" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "l" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "m" = (
@@ -55,8 +49,7 @@
 "n" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "o" = (
@@ -65,8 +58,7 @@
 /area/ruin/powered/shuttle)
 "p" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/ruin/powered/shuttle)
 "q" = (
@@ -75,8 +67,7 @@
 /area/ruin/powered/shuttle)
 "r" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "t" = (
@@ -87,26 +78,22 @@
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/ruin/powered/shuttle)
 "v" = (
 /obj/machinery/sleeper{
 	dir = 1;
-	icon_state = "sleeper";
-	tag = "icon-sleeper (NORTH)"
+	icon_state = "sleeper"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/ruin/powered/shuttle)
 "w" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "x" = (
@@ -131,38 +118,33 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "D" = (
 /obj/structure/computerframe,
 /obj/item/circuitboard/teleporter,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "E" = (
 /obj/machinery/teleport/hub,
 /obj/item/hand_tele,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "G" = (
 /obj/item/beacon,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "H" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "J" = (
@@ -171,38 +153,33 @@
 	},
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "K" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "M" = (
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "N" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "O" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility/full/multitool,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "P" = (
@@ -210,8 +187,7 @@
 /obj/item/storage/toolbox/electrical,
 /obj/item/clothing/gloves/color/yellow,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "S" = (
@@ -219,8 +195,7 @@
 /obj/machinery/recharger,
 /obj/item/gun/energy/laser/retro,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "T" = (
@@ -228,15 +203,13 @@
 /obj/item/clothing/head/helmet/space/eva,
 /obj/item/clothing/suit/space/eva,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "U" = (
 /obj/machinery/teleport/station,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "V" = (
@@ -250,8 +223,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/ruin/powered/shuttle)
 "X" = (
@@ -259,22 +231,19 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "Y" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "Z" = (
 /obj/machinery/computer,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 

--- a/_maps/map_files/templates/medium_shuttle3.dmm
+++ b/_maps/map_files/templates/medium_shuttle3.dmm
@@ -4,15 +4,13 @@
 /area/space)
 "b" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	tag = "icon-propulsion (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/ruin/powered/shuttle)
 "d" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	tag = "icon-heater (NORTH)"
+	dir = 1
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/ruin/powered/shuttle)
@@ -35,15 +33,13 @@
 /area/ruin/powered/shuttle)
 "n" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	tag = "icon-propulsion (EAST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/ruin/powered/shuttle)
 "o" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 8;
-	tag = "icon-heater (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/ruin/powered/shuttle)
@@ -53,15 +49,13 @@
 /area/ruin/powered/shuttle)
 "q" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 4;
-	tag = "icon-heater (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/ruin/powered/shuttle)
 "r" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 4;
-	tag = "icon-propulsion (WEST)"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/ruin/powered/shuttle)
@@ -72,14 +66,12 @@
 "v" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "w" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "x" = (
@@ -87,21 +79,18 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whiteyellowfull";
-	tag = "icon-whiteyellowfull"
+	icon_state = "whiteyellowfull"
 	},
 /area/ruin/powered/shuttle)
 "z" = (
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/ruin/powered/shuttle)
 "A" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "dark";
-	tag = "icon-dark"
+	icon_state = "dark"
 	},
 /area/ruin/powered/shuttle)
 "C" = (
@@ -110,16 +99,14 @@
 /area/ruin/powered/shuttle)
 "D" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/ruin/powered/shuttle)
 "E" = (
 /obj/structure/table,
 /obj/item/storage/firstaid,
 /turf/simulated/floor/plasteel{
-	icon_state = "bluefull";
-	tag = "icon-bluefull"
+	icon_state = "bluefull"
 	},
 /area/ruin/powered/shuttle)
 "F" = (

--- a/_maps/map_files/templates/piratbase.dmm
+++ b/_maps/map_files/templates/piratbase.dmm
@@ -29,8 +29,7 @@
 /obj/item/reagent_containers/food/snacks/bun,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "af" = (
@@ -454,8 +453,7 @@
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/ruin/space/pirate_base/atmos)
 "bC" = (
@@ -675,8 +673,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "ci" = (
@@ -1082,8 +1079,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "dm" = (
@@ -1442,8 +1438,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "ee" = (
@@ -2559,8 +2554,7 @@
 "hq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/ruin/space/pirate_base/atmos)
 "hr" = (
@@ -2729,8 +2723,7 @@
 /obj/effect/decal/remains/mouse,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "hN" = (
@@ -2929,8 +2922,7 @@
 /obj/structure/table_frame/wood,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "iq" = (
@@ -3052,8 +3044,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "iR" = (
@@ -3412,8 +3403,7 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "jW" = (
@@ -3748,8 +3738,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "kU" = (
@@ -4498,8 +4487,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "nl" = (
@@ -4688,8 +4676,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "nN" = (
@@ -4847,8 +4834,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "om" = (
@@ -5056,8 +5042,7 @@
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "oL" = (
@@ -5855,8 +5840,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "rh" = (
@@ -6316,8 +6300,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "sN" = (
@@ -6577,8 +6560,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "tB" = (
@@ -6635,8 +6617,7 @@
 /obj/structure/closet/walllocker/emerglocker/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "tH" = (
@@ -6769,8 +6750,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "ua" = (
@@ -7255,8 +7235,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "vi" = (
@@ -7267,8 +7246,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "vj" = (
@@ -7701,8 +7679,7 @@
 "wi" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "wj" = (
@@ -7872,8 +7849,7 @@
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/ruin/space/pirate_base/atmos)
 "wL" = (
@@ -8010,8 +7986,7 @@
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "xn" = (
@@ -8182,8 +8157,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "xM" = (
@@ -8401,8 +8375,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "yo" = (
@@ -8558,8 +8531,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "yS" = (
@@ -10800,8 +10772,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "FU" = (
@@ -11513,8 +11484,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "HT" = (
@@ -11936,8 +11906,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "Jh" = (
@@ -12054,8 +12023,7 @@
 /area/ruin/space/pirate_base/mining)
 "Jy" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/blue,
 /obj/effect/decal/warning_stripes/northwest,
@@ -12491,8 +12459,7 @@
 /area/ruin/space/pirate_base/lab_solar)
 "KI" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/blue,
 /obj/effect/decal/warning_stripes/southwest,
@@ -12596,8 +12563,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "KV" = (
@@ -13052,8 +13018,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "Mm" = (
@@ -13157,8 +13122,7 @@
 /mob/living/simple_animal/hostile/zombie/whiteship,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "MG" = (
@@ -13535,8 +13499,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "NF" = (
@@ -14300,8 +14263,7 @@
 /obj/item/kitchen/utensil/spoon,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "PS" = (
@@ -14743,8 +14705,7 @@
 /obj/machinery/vending/chinese,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "Rk" = (
@@ -15547,8 +15508,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "TO" = (
@@ -16133,8 +16093,7 @@
 /obj/item/storage/backpack/satchel_tox,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "Vx" = (
@@ -16947,8 +16906,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "Yc" = (
@@ -17553,8 +17511,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "Zy" = (

--- a/_maps/map_files/templates/piratbase_ruin.dmm
+++ b/_maps/map_files/templates/piratbase_ruin.dmm
@@ -37,8 +37,7 @@
 /obj/item/reagent_containers/food/snacks/bun,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "af" = (
@@ -529,8 +528,7 @@
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken5";
-	tag = "icon-wood-broken5"
+	icon_state = "wood-broken5"
 	},
 /area/ruin/space/pirate_base/atmos)
 "bC" = (
@@ -742,8 +740,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "cg" = (
@@ -1195,8 +1192,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "dm" = (
@@ -1518,8 +1514,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "ee" = (
@@ -1762,8 +1757,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "eS" = (
@@ -2596,8 +2590,7 @@
 "hq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken6";
-	tag = "icon-wood-broken6"
+	icon_state = "wood-broken6"
 	},
 /area/ruin/space/pirate_base/atmos)
 "hr" = (
@@ -2763,8 +2756,7 @@
 /obj/effect/decal/remains/mouse,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "hN" = (
@@ -2930,8 +2922,7 @@
 /obj/structure/table_frame/wood,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "io" = (
@@ -2952,8 +2943,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "ir" = (
@@ -3084,8 +3074,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "iR" = (
@@ -3432,8 +3421,7 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "jW" = (
@@ -3758,8 +3746,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "kV" = (
@@ -4905,8 +4892,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "om" = (
@@ -5101,8 +5087,7 @@
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "oL" = (
@@ -5557,8 +5542,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "qh" = (
@@ -6398,8 +6382,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "sN" = (
@@ -6708,8 +6691,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "tB" = (
@@ -7384,8 +7366,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "whitepurple"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "vi" = (
@@ -7396,8 +7377,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "vl" = (
@@ -7753,8 +7733,7 @@
 "wi" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "wj" = (
@@ -7918,8 +7897,7 @@
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood{
-	icon_state = "wood-broken";
-	tag = "icon-wood-broken"
+	icon_state = "wood-broken"
 	},
 /area/ruin/space/pirate_base/atmos)
 "wL" = (
@@ -8114,8 +8092,7 @@
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitepurple";
-	tag = "icon-whitepurple (NORTH)"
+	icon_state = "whitepurple"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "xn" = (
@@ -8285,8 +8262,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "xL" = (
@@ -9835,8 +9811,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "Cn" = (
@@ -10576,8 +10551,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "ES" = (
@@ -10968,8 +10942,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "FU" = (
@@ -11678,8 +11651,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "HT" = (
@@ -12072,8 +12044,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "Jh" = (
@@ -12196,8 +12167,7 @@
 /area/ruin/space/pirate_base/mining)
 "Jy" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/blue,
 /obj/effect/decal/warning_stripes/northwest,
@@ -12622,8 +12592,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "KF" = (
@@ -12642,8 +12611,7 @@
 /area/ruin/space/pirate_base/lab_solar)
 "KI" = (
 /obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/blue,
 /obj/effect/decal/warning_stripes/southwest,
@@ -12787,8 +12755,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "KV" = (
@@ -12857,8 +12824,7 @@
 /obj/machinery/vending/chinese,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "Li" = (
@@ -13221,8 +13187,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "Mm" = (
@@ -13330,8 +13295,7 @@
 /mob/living/simple_animal/hostile/zombie/whiteship,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "MG" = (
@@ -13730,8 +13694,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "NF" = (
@@ -14478,8 +14441,7 @@
 /obj/item/kitchen/utensil/spoon,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "PS" = (
@@ -14649,8 +14611,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon_state = "cafeteria"
 	},
 /area/ruin/space/pirate_base/lab_hall)
 "Qz" = (
@@ -16023,8 +15984,7 @@
 /obj/structure/closet/walllocker/emerglocker/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "Ut" = (
@@ -16393,8 +16353,7 @@
 /obj/item/storage/backpack/satchel_tox,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "Vx" = (
@@ -17278,8 +17237,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "Yc" = (
@@ -17875,8 +17833,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "whitepurplecorner";
-	tag = "icon-whitepurplecorner (EAST)"
+	icon_state = "whitepurplecorner"
 	},
 /area/ruin/space/pirate_base/laboratory)
 "Zy" = (

--- a/_maps/map_files/templates/shelter_1.dmm
+++ b/_maps/map_files/templates/shelter_1.dmm
@@ -43,8 +43,7 @@
 /area/survivalpod)
 "j" = (
 /obj/structure/sign/mining/survival{
-	dir = 4;
-	tag = "icon-survival (EAST)"
+	dir = 4
 	},
 /turf/simulated/wall/mineral/titanium/survival,
 /area/survivalpod)

--- a/_maps/map_files/templates/shelter_2.dmm
+++ b/_maps/map_files/templates/shelter_2.dmm
@@ -140,8 +140,7 @@
 /area/survivalpod)
 "x" = (
 /obj/structure/sign/mining/survival{
-	dir = 4;
-	tag = "icon-survival (EAST)"
+	dir = 4
 	},
 /turf/simulated/wall/mineral/titanium/survival,
 /area/survivalpod)

--- a/_maps/map_files/templates/shelter_3.dmm
+++ b/_maps/map_files/templates/shelter_3.dmm
@@ -29,8 +29,7 @@
 /area/survivalpod)
 "f" = (
 /obj/structure/sign/mining/survival{
-	dir = 4;
-	tag = "icon-survival (EAST)"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -39,8 +38,7 @@
 /area/survivalpod)
 "g" = (
 /obj/structure/sign/mining/survival{
-	dir = 4;
-	tag = "icon-survival (EAST)"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -123,8 +121,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+	dir = 4
 	},
 /turf/simulated/floor/pod,
 /area/survivalpod)
@@ -134,8 +131,7 @@
 /area/survivalpod)
 "y" = (
 /obj/structure/sign/mining/survival{
-	dir = 4;
-	tag = "icon-survival (EAST)"
+	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -221,8 +217,7 @@
 /area/survivalpod)
 "W" = (
 /obj/structure/sign/mining/survival{
-	dir = 4;
-	tag = "icon-survival (EAST)"
+	dir = 4
 	},
 /turf/simulated/wall/mineral/titanium/survival,
 /area/survivalpod)

--- a/_maps/map_files/templates/small_shuttle_1.dmm
+++ b/_maps/map_files/templates/small_shuttle_1.dmm
@@ -1,7 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/simulated/wall/shuttle{
-	tag = "icon-swall_f6";
 	icon_state = "swall_f6"
 	},
 /area/ruin/powered)
@@ -10,7 +9,6 @@
 /area/ruin/powered)
 "c" = (
 /turf/simulated/wall/shuttle{
-	tag = "icon-swall3";
 	icon_state = "swall3"
 	},
 /area/ruin/powered)
@@ -20,13 +18,11 @@
 /area/ruin/powered)
 "e" = (
 /turf/simulated/wall/shuttle{
-	tag = "icon-swall_f5";
 	icon_state = "swall_f5"
 	},
 /area/ruin/powered)
 "f" = (
 /turf/simulated/wall/shuttle{
-	tag = "icon-swall8";
 	icon_state = "swall8"
 	},
 /area/ruin/powered)
@@ -52,7 +48,6 @@
 /area/ruin/powered)
 "l" = (
 /turf/simulated/wall/shuttle{
-	tag = "icon-swall13";
 	icon_state = "swall13"
 	},
 /area/ruin/powered)
@@ -76,7 +71,6 @@
 /area/ruin/powered)
 "p" = (
 /turf/simulated/wall/shuttle{
-	tag = "icon-swall4";
 	icon_state = "swall4"
 	},
 /area/ruin/powered)
@@ -92,13 +86,11 @@
 /area/ruin/powered)
 "s" = (
 /turf/simulated/wall/shuttle{
-	tag = "icon-swall_f10";
 	icon_state = "swall_f10"
 	},
 /area/ruin/powered)
 "t" = (
 /turf/simulated/wall/shuttle{
-	tag = "icon-swall_f9";
 	icon_state = "swall_f9"
 	},
 /area/ruin/powered)

--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -65,7 +65,6 @@ GLOBAL_LIST_EMPTY(armor_cache)
 /datum/armor/Destroy(force)
 	GLOB.armor_cache -= tag
 	GLOB.armor_by_type -= type
-	tag = null
 	return ..()
 
 


### PR DESCRIPTION
Использованы реджексы отсюда https://github.com/ParadiseSS13/Paradise/pull/15438
## Список изменений
:cl:
map: Убрано использование переменной tag со всех карт.
map: Убраны pixel_x/y равные нулю со всех карт.
/:cl:
