### PR TITLE
Old age req for HOS

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -22,6 +22,7 @@
 	exp_type = EXP_TYPE_SECURITY
 	disabilities_allowed_slightly = 0
 	outfit = /datum/outfit/job/hos
+	min_age_type = JOB_MIN_AGE_COMMAND
 
 /datum/outfit/job/hos
 	name = JOB_TITLE_RU_HOS


### PR DESCRIPTION

## Что этот ПР делает
Возвращает 30 лет или эквивалент в возрастные ограничения для ГСБ
## Почему это хорошо для игры
Никаких таяра 18 лет космодесантник не лысий на ГСБ, ето круто
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
tweak: Возваращена необходимость быть определенного возраста для ГСБ
/:cl:
