### PR TITLE
При рандоме у куклы всегда возраст 30+

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -294,8 +294,8 @@
 	return length(result) > 1 ? result : result[tags[1]]
 
 /proc/get_rand_age(datum/species/species)
-	var/age_limits = get_age_limits(species, list(SPECIES_AGE_MIN, SPECIES_AGE_MAX))
-	return rand(30, age_limits[SPECIES_AGE_MAX])
+	var/age_limits = get_age_limits(species, list(JOB_MIN_AGE_COMMAND, SPECIES_AGE_MAX))
+	return rand(age_limits[JOB_MIN_AGE_COMMAND], age_limits[SPECIES_AGE_MAX])
 
 /**
  * Handles creation of mob organs.

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -295,7 +295,7 @@
 
 /proc/get_rand_age(datum/species/species)
 	var/age_limits = get_age_limits(species, list(SPECIES_AGE_MIN, SPECIES_AGE_MAX))
-	return rand(age_limits[SPECIES_AGE_MIN], age_limits[SPECIES_AGE_MAX])
+	return rand(30, age_limits[SPECIES_AGE_MAX])
 
 /**
  * Handles creation of mob organs.


### PR DESCRIPTION

## Что этот ПР делает
Теперь при создании новой куклы, у нее возраст будет 30+. Это только при создании рандома. Вы все еще можете стать 18 летней школьницей на космической станции...

## Почему это хорошо для игры
Как разработчика, тестирование в основном происходит в локалке за капитана, у него возраст ограничен 30+. Очень раздражает, что каждый раз приходится поднимать возраст кукле. 

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
config: в проке рандома теперь минимум 30 лет возраста
qol: для разработчиков не придется поднимать кукле возраст
/:cl:
