### PR TITLE
tweak: Смещение спрайта при положении лежа

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -315,9 +315,9 @@
 #define IS_HORIZONTAL(x) (x.body_position == LYING_DOWN)
 
 ///How much a mob's sprite should be moved when they're lying down
-#define PIXEL_Y_OFFSET_LYING -6
+#define PIXEL_Y_OFFSET_LYING -3
 ///How much a mob's sprite should be moved when they're lying up (on the ceiling)
-#define PIXEL_Y_OFFSET_LYING_REVERSED 6
+#define PIXEL_Y_OFFSET_LYING_REVERSED 3
 
 // Slip flags, also known as lube flags
 /// The mob will not slip if they're walking intent

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -129,7 +129,7 @@
 	var/matrix/m180 = matrix(target.transform)
 	m180.Turn(180)
 	animate(target, transform = m180, time = 0.3 SECONDS)
-	if(istype(target, /mob/living/carbon/human/lesser))
+	if(istype(target, /mob/living/carbon/human/lesser) && ismonkey(target))
 		target.pixel_x = target.base_pixel_x
 		target.pixel_y = target.base_pixel_y + PIXEL_Y_OFFSET_LYING + 3
 	else

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -129,7 +129,7 @@
 	var/matrix/m180 = matrix(target.transform)
 	m180.Turn(180)
 	animate(target, transform = m180, time = 0.3 SECONDS)
-	if(istype(target, /mob/living/carbon/human/lesser) && ismonkey(target))
+	if(ismonkey(target))
 		target.pixel_x = target.base_pixel_x
 		target.pixel_y = target.base_pixel_y + PIXEL_Y_OFFSET_LYING + 3
 	else

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -129,7 +129,7 @@
 	var/matrix/m180 = matrix(target.transform)
 	m180.Turn(180)
 	animate(target, transform = m180, time = 0.3 SECONDS)
-	if (istype(target, /mob/living/carbon/human/lesser))
+	if(istype(target, /mob/living/carbon/human/lesser))
 		target.pixel_x = target.base_pixel_x
 		target.pixel_y = target.base_pixel_y + PIXEL_Y_OFFSET_LYING + 3
 	else

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -129,8 +129,12 @@
 	var/matrix/m180 = matrix(target.transform)
 	m180.Turn(180)
 	animate(target, transform = m180, time = 0.3 SECONDS)
-	target.pixel_x = target.base_pixel_x
-	target.pixel_y = target.base_pixel_y + PIXEL_Y_OFFSET_LYING
+	if (istype(target, /mob/living/carbon/human/lesser))
+		target.pixel_x = target.base_pixel_x
+		target.pixel_y = target.base_pixel_y + PIXEL_Y_OFFSET_LYING + 3
+	else
+		target.pixel_x = target.base_pixel_x
+		target.pixel_y = target.base_pixel_y + PIXEL_Y_OFFSET_LYING
 
 /obj/structure/kitchenspike/post_unbuckle_mob(mob/living/target)
 	target.adjustBruteLoss(30)


### PR DESCRIPTION

## Что этот ПР делает
Изменет положение спрайта при лежании
## Почему это хорошо для игры
Теперь лёжа на операционном столе кукла лежит как следует, а не свисает с края
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
Было: 
<img width="358" height="217" alt="image" src="https://github.com/user-attachments/assets/0012588f-4ca7-4bdf-a480-db1962c59994" />
</p>
<p>
Стало: 
<img width="216" height="143" alt="image" src="https://github.com/user-attachments/assets/bed23ea8-ee4f-4ee2-87e4-fec475cbdfee" />
</p>
</details>

## Список изменений
:cl:
tweak: Изменен оффсет пикселей с -6 на -3
/:cl:
