### PR TITLE
Возвращает молоко в раздатчик напитков

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -378,9 +378,9 @@
 	icon_state = "soda_dispenser"
 	beaker_overlay_name = "bar_beaker"
 	ui_title = "Фонтан Напитков 10000"
-	dispensable_reagents = list("water", "ice", "soymilk", "coffee", "tea", "hot_coco", "cola", "spacemountainwind", "dr_gibb", "space_up",
-	"tonic", "sodawater", "lemon_lime", "grapejuice", "sugar", "orangejuice", "lemonjuice", "limejuice", "tomatojuice", "banana",
-	"watermelonjuice", "carrotjuice", "potato", "berryjuice", "milk")
+	dispensable_reagents = list("banana", "berryjuice", "carrotjuice", "coffee", "cola", "dr_gibb", "grapejuice", "hot_coco", "ice", "lemon_lime",
+	"lemonjuice", "limejuice", "milk", "orangejuice", "potato", "sodawater", "soymilk", "space_up", "spacemountainwind", "sugar",
+	"tea", "tomatojuice", "tonic", "water", "watermelonjuice")
 	upgrade_reagents = list("bananahonk", "milkshake", "cafe_latte", "cafe_mocha", "triple_citrus", "icecoffe","icetea")
 	hacked_reagents = list("thirteenloko")
 	var/list/hackedupgrade_reagents = list("zaza") //I possess zaza

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -380,7 +380,7 @@
 	ui_title = "Фонтан Напитков 10000"
 	dispensable_reagents = list("water", "ice", "soymilk", "coffee", "tea", "hot_coco", "cola", "spacemountainwind", "dr_gibb", "space_up",
 	"tonic", "sodawater", "lemon_lime", "grapejuice", "sugar", "orangejuice", "lemonjuice", "limejuice", "tomatojuice", "banana",
-	"watermelonjuice", "carrotjuice", "potato", "berryjuice")
+	"watermelonjuice", "carrotjuice", "potato", "berryjuice", "milk")
 	upgrade_reagents = list("bananahonk", "milkshake", "cafe_latte", "cafe_mocha", "triple_citrus", "icecoffe","icetea")
 	hacked_reagents = list("thirteenloko")
 	var/list/hackedupgrade_reagents = list("zaza") //I possess zaza

--- a/code/modules/reagents/chemistry/recipes/food.dm
+++ b/code/modules/reagents/chemistry/recipes/food.dm
@@ -47,8 +47,7 @@
 	name = "Cheesewheel"
 	id = "cheesewheel"
 	result = null
-	required_reagents = list("milk" = 40)
-	required_catalysts = list("enzyme" = 5)
+	required_reagents = list("milk" = 90, "enzyme" = 5)
 	result_amount = 1
 
 /datum/chemical_reaction/cheesewheel/on_reaction(datum/reagents/holder, created_volume)


### PR DESCRIPTION

## Что этот ПР делает
Возвращает молоко в раздатчик напитков.
Повышает 40 молока для одного сыра до 90
Энзим теперь тратится
## Почему это хорошо для игры
В конечном итоге убор молока из раздатчика не повлиял ни на что хорошим образом. Кто хотел в рот ебать и не париться наделали себе миллион тофу, а множество рецептов, зависящих от сыра стали условно недоступны, ибо дрочить корову не хочется никому
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
<img width="447" height="262" alt="image" src="https://github.com/user-attachments/assets/cb23b7f8-68d6-4910-8098-ef3fb883141b" />
<img width="536" height="529" alt="image" src="https://github.com/user-attachments/assets/31ba121d-37c0-4a29-bda3-4569897cdb48" />

</p>
</details>

## Список изменений
:cl:
tweak: Возвращено молоко в раздатчик напитков
tweak: Чтобы сделать 1 головку сыра нужно 5 энзима и 90 молока. Энзим теперь тратится.
/:cl:
