### PR TITLE
disable looc runechat emoji

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -164,6 +164,7 @@ GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 				message_admins("[key_name_admin(src)] has attempted to advertise in OOC: [msg]")
 				return
 
+	var/msg_runechat = msg
 	msg = handleDiscordEmojis(msg)
 
 	add_ooc_logs(src, msg, TRUE)
@@ -210,7 +211,7 @@ GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 
 				if(target.mob && target.prefs.toggles3 & PREFTOGGLE_3_RUNECHAT_LOOC)
 					var/mob/source_mob = mob.get_looc_source()
-					target.mob.create_chat_message(source_mob, "<b>LOOC:</b> [msg]", list("looc"), null)
+					target.mob.create_chat_message(source_mob, "<b>LOOC:</b> [msg_runechat]", list("looc"), null)
 
 /mob/proc/get_looc_source()
 	return src


### PR DESCRIPTION
## Что этот ПР делает
Отключает отображение emoji в runechat

## Почему это хорошо для игры
<img width="276" height="194" alt="image" src="https://github.com/user-attachments/assets/4faadb61-19e3-4455-90c8-eead1dac3ac2" />

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
<img width="129" height="119" alt="image" src="https://github.com/user-attachments/assets/5ea18215-b1da-461b-b9ef-54385efb3efb" />
<img width="344" height="35" alt="image" src="https://github.com/user-attachments/assets/aa8d32e0-90f9-4dc0-ba65-db8a61d9862d" />

</p>
</details>

## Список изменений

:cl:
bugfix: Фикс emoji в runechat
/:cl:
