### PR TITLE
Рефактор спич контроллера и очистка Input от мусора

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -25,43 +25,24 @@ VERB_MANAGER_SUBSYSTEM_DEF(input)
 
 /datum/controller/subsystem/verb_manager/input/Initialize()
 	setup_default_macro_sets()
+
 	initialized = TRUE
+
 	refresh_client_macro_sets()
+
 	return SS_INIT_SUCCESS
 
-// This is for when macro sets are eventualy datumized
+// This is for when macro sets are eventually datumized
 /datum/controller/subsystem/verb_manager/input/proc/setup_default_macro_sets()
 	macro_set = list(
-		"default" = list(
-			"Any" = "\"KeyDown \[\[*\]\]\"", // Passes any key down to the rebindable input system
-			"Any+UP" = "\"KeyUp \[\[*\]\]\"", // Passes any key up to the rebindable input system
-			"Tab" = "\".winset \\\"mainwindow.macro=legacy input.focus=true input.border=sunken\\\"\"", // Swaps us to legacy mode, forces input to the input bar, sets the input bar colour to salmon pink
-			"Back" = "\".winset \\\"input.focus=true ? input.text=\\\"\"", // This makes it so backspace can remove default inputs
-			"Escape" = "Open-Escape-Menu",
-		),
-		"legacy" = list(
-			"Tab" = "\".winset \\\"mainwindow.macro=default map.focus=true input.border=line\\\"\"", // Swaps us to rebind mode, moves input away from input bar, sets input bar to white
-			"Back" = "\".winset \\\"input.focus=true ? input.text=\\\"\"", // This makes it so backspace can remove default inputs
-		),
+		"Any" = "\"KeyDown \[\[*\]\]\"",
+		"Any+UP" = "\"KeyUp \[\[*\]\]\"",
+		"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
+		"Tab" = "\".winset \\\"input.focus=true?map.focus=true:input.focus=true\\\"\"",
+		"Escape" = "Open-Escape-Menu",
 	)
 
-	var/list/legacy_default = macro_set["legacy"]
-
-	/// This list defines the keys in legacy mode that get passed on to the rebindable input system
-	/// It cannot be bigger since, while typing, the keys would be passed to whatever they are set in the rebind input system
-	var/static/list/legacy_keys = list(
-		"North", "East", "South", "West",
-		"Northeast", "Southeast", "Northwest", "Southwest",
-		"Insert", "Delete",
-		"F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
-	)
-
-	// We use the static list to make only the keys in it passed to legacy mode
-	for(var/i in 1 to length(legacy_keys))
-		var/key = legacy_keys[i]
-		legacy_default[key] = "\"KeyDown [key]\""
-		legacy_default["[key]+UP"] = "\"KeyUp [key]\""
-
+// Badmins just wanna have fun ♪
 /datum/controller/subsystem/verb_manager/input/proc/refresh_client_macro_sets()
 	var/list/clients = GLOB.clients
 	for(var/i in 1 to length(clients))
@@ -95,7 +76,7 @@ VERB_MANAGER_SUBSYSTEM_DEF(input)
 	movements_per_second = MC_AVG_SECONDS(movements_per_second, moves_this_run, wait TICKS)
 
 /datum/controller/subsystem/verb_manager/input/run_verb_queue()
-	var/deferred_clicks_this_run = 0 //acts like current_clicks but doesnt count clicks that dont get processed by SSinput
+	var/deferred_clicks_this_run = 0 //acts like current_clicks but doesn't count clicks that don't get processed by SSinput
 
 	for(var/datum/callback/verb_callback/queued_click as anything in verb_queue)
 		if(!istype(queued_click))
@@ -119,4 +100,3 @@ VERB_MANAGER_SUBSYSTEM_DEF(input)
 
 /datum/controller/subsystem/verb_manager/input/get_stat_details()
 	return "M/S:[round(movements_per_second,0.01)] | C/S:[round(clicks_per_second,0.01)] ([round(delayed_clicks_per_second,0.01)] | CD: [round(average_click_delay / (1 SECONDS),0.01)])"
-

--- a/code/controllers/subsystem/speech_controller.dm
+++ b/code/controllers/subsystem/speech_controller.dm
@@ -1,54 +1,7 @@
-SUBSYSTEM_DEF(speech_controller)
+/// verb_manager subsystem just for handling say's
+VERB_MANAGER_SUBSYSTEM_DEF(speech_controller)
 	name = "Speech Controller"
 	wait = 1
-	flags = SS_TICKER | SS_NO_INIT
 	priority = FIRE_PRIORITY_SPEECH_CONTROLLER//has to be high priority, second in priority ONLY to SSinput
 	init_order = INIT_ORDER_SPEECH_CONTROLLER
-	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 	ss_id = "speech_controller"
-	///used so that an admin can force all speech verbs to execute immediately instead of queueing
-	var/FOR_ADMINS_IF_BROKE_immediately_execute_all_speech = FALSE
-
-	///list of the form: list(client mob, message that mob is queued to say, other say arguments (if any)).
-	///this is our process queue, processed every tick.
-	var/list/queued_says_to_execute = list()
-
-///queues mob_to_queue into our process list so they say(message) near the start of the next tick
-/datum/controller/subsystem/speech_controller/proc/queue_say_for_mob(mob/mob_to_queue, message, message_type)
-
-	if(!TICK_CHECK || FOR_ADMINS_IF_BROKE_immediately_execute_all_speech)
-		process_single_say(mob_to_queue, message, message_type)
-		return TRUE
-
-	queued_says_to_execute += list(list(mob_to_queue, message, message_type))
-
-	return TRUE
-
-/datum/controller/subsystem/speech_controller/fire(resumed)
-
-	///	cache for sanic speed (lists are references anyways)
-	var/list/says_to_process = queued_says_to_execute.Copy()
-	queued_says_to_execute.Cut()//we should be going through the entire list every single iteration
-
-	for(var/list/say_to_process as anything in says_to_process)
-
-		var/mob/mob_to_speak = say_to_process[MOB_INDEX]//index 1 is the mob, 2 is the message, 3 is the message category
-		var/message = say_to_process[MESSAGE_INDEX]
-		var/message_category = say_to_process[CATEGORY_INDEX]
-
-		process_single_say(mob_to_speak, message, message_category)
-
-///used in fire() to process a single mobs message through the relevant proc.
-///only exists so that sleeps in the message pipeline dont cause the whole queue to wait
-/datum/controller/subsystem/speech_controller/proc/process_single_say(mob/mob_to_speak, message, message_category)
-	set waitfor = FALSE
-
-	switch(message_category)
-		if(SPEECH_CONTROLLER_QUEUE_SAY_VERB)
-			mob_to_speak.say(message)
-
-		if(SPEECH_CONTROLLER_QUEUE_WHISPER_VERB)
-			mob_to_speak.whisper_say(message)
-
-		if(SPEECH_CONTROLLER_QUEUE_EMOTE_VERB)
-			mob_to_speak.emote("me",1,message,TRUE)

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -15,7 +15,7 @@
 	set waitfor = FALSE
 
 	//Reset the buffer
-	reset_held_keys()
+	client_reset_held_keys()
 
 	erase_all_macros()
 

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -15,22 +15,15 @@
 	set waitfor = FALSE
 
 	//Reset the buffer
-	client_reset_held_keys()
+	reset_held_keys()
 
 	erase_all_macros()
 
-	var/list/macro_sets = SSinput.macro_set
-	for(var/i in 1 to length(macro_sets))
-		var/setname = macro_sets[i]
-		if(setname != "default")
-			winclone(src, "default", setname)
-		var/list/macro_set = macro_sets[setname]
-		for(var/k in 1 to length(macro_set))
-			var/key = macro_set[k]
-			var/command = macro_set[key]
-			winset(src, "[setname]-[key]", "parent=[setname];name=[key];command=[command]")
-
-	winset(src, null, "input.border=line") //screw you, we start in hotkey mode now
+	var/list/macro_set = SSinput.macro_set
+	for(var/k in 1 to length(macro_set))
+		var/key = macro_set[k]
+		var/command = macro_set[key]
+		winset(src, "default-[key]", "parent=default;name=[key];command=[command]")
 
 	calculate_move_dir()
 

--- a/code/modules/mob/living/carbon/brain/brain_say.dm
+++ b/code/modules/mob/living/carbon/brain/brain_say.dm
@@ -13,7 +13,7 @@
 
 	..(message)
 
-/mob/living/carbon/brain/whisper(message as text)
+/mob/living/carbon/brain/whisper(message)
 	if(!can_speak(warning = TRUE))
 		return
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -423,7 +423,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 				else
 					O.hear_talk(M, message_pieces, verbage)
 
-/mob/living/whisper(message as text)
+/mob/living/whisper(message)
 	message = trim_strip_html_properly(message, 512)
 
 	if(!message)
@@ -441,13 +441,13 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 		return TRUE
 	// Log it here since it skips the default way say handles it
 	create_log(SAY_LOG, "(whisper) '[message]'")
-	SSspeech_controller.queue_say_for_mob(src, message_pieces, SPEECH_CONTROLLER_QUEUE_WHISPER_VERB)
+	whisper_say(message_pieces)
 
 // for weird circumstances where you're inside an atom that is also you, like pai's
 /mob/living/proc/get_whisper_loc()
 	return src
 
-/mob/living/whisper_say(list/message_pieces, verb = "шепч%(ет,ут)%")
+/mob/living/proc/whisper_say(list/message_pieces, verb = "шепч%(ет,ут)%")
 	if(client && check_mute(client.ckey, MUTE_IC))
 		to_chat(src, span_boldwarning("Вы не можете отправлять IC сообщения (мут)."))
 		return

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -3,8 +3,8 @@
 		return emote(copytext(message, 2), intentional = TRUE)
 	return ..()
 
-/mob/living/silicon/robot/drone/whisper_say(list/message_pieces)
-	say(multilingual_to_message(message_pieces)) //drones do not get to whisper, only speak normally
+/mob/living/silicon/robot/drone/whisper(message)
+	say(message) //drones do not get to whisper, only speak normally
 	return TRUE
 
 /mob/living/silicon/robot/drone/get_default_language()

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -5,37 +5,31 @@
 /mob/proc/say(message, verb = "говор%(ит,ят)%", sanitize = TRUE, ignore_speech_problems = FALSE, ignore_atmospherics = FALSE, ignore_languages = FALSE)
 	return
 
-/mob/verb/whisper(message as text)
+/mob/verb/whisper_verb(message as text)
 	set name = "Шептать"
 	set category = VERB_CATEGORY_IC
-	return
+	set instant = TRUE
 
-/mob/proc/whisper_say(list/message_pieces, verb = "whispers")
+	if(!message)
+		return
+
+	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, whisper), message), SSspeech_controller)
+
+/mob/proc/whisper(message)
 	return
 
 /mob/verb/say_verb(message as text)
 	set name = "Сказать"
 	set category = VERB_CATEGORY_IC
+	set instant = TRUE
 
-	//Let's try to make users fix their errors - we try to detect single, out-of-place letters and 'unintended' words
-	/*
-	var/first_letter = copytext(message,1,2)
-	if((copytext(message,2,3) == " " && first_letter != "I" && first_letter != "A" && first_letter != ";") || cmptext(copytext(message,1,5), "say ") || cmptext(copytext(message,1,4), "me ") || cmptext(copytext(message,1,6), "looc ") || cmptext(copytext(message,1,5), "ooc ") || cmptext(copytext(message,2,6), "say "))
-		var/response = alert(usr, "Do you really want to say this using the *say* verb?\n\n[message]\n", "Confirm your message", "Yes", "Edit message", "No")
-		if(response == "Edit message")
-			message = tgui_input_text(usr, "Please edit your message carefully:", "Edit message", message)
-			if(!message)
-				return
-		else if(response == "No")
-			return
-	*/
 	message = replace_characters(message, ILLEGAL_CHARACTERS_LIST)
 	set_typing_indicator(FALSE)
 
 	if(!message)
 		return
 
-	SSspeech_controller.queue_say_for_mob(usr, message, SPEECH_CONTROLLER_QUEUE_SAY_VERB)
+	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, say), message), SSspeech_controller)
 
 /mob/verb/me_verb(message as text)
 	set name = "Эмоция"
@@ -49,9 +43,9 @@
 		return
 
 	if(use_me)
-		custom_emote(usr.emote_type, message, intentional = TRUE)
+		QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, custom_emote), usr.emote_type, message, TRUE), SSspeech_controller)
 	else
-		SSspeech_controller.queue_say_for_mob(usr, message, SPEECH_CONTROLLER_QUEUE_EMOTE_VERB)
+		QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "me", 1, message, TRUE), SSspeech_controller)
 
 /mob/proc/say_dead(message)
 	message = handleDiscordEmojis(say_emphasis(message))


### PR DESCRIPTION

## Что этот ПР делает
Когда-то давно спич контроллер портировали, верб менеджер портировали, а подружить их забыли. Но это уже офы недоработали. Этот ПР это исправляет.
Так же почистил Input от каких-то непонятных легаси наборов вербов. 
## Список изменений
:cl:
refactor: Очистка Input от мусора .
refactor: Рефактор спич контроллера
/:cl:
