### PR TITLE
Вендоры и хирургические мониторы больше не разговаривают

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -138,7 +138,7 @@
 	/// Used for changing icon states for different base sprites.
 	var/base_icon_state
 
-	var/tts_seed = "Arthas"
+	var/tts_seed = null
 	var/tts_atom_say_effect = SOUND_EFFECT_RADIO
 
 	///AI controller that controls this atom. type on init, then turned into an instance during runtime

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -138,7 +138,7 @@
 	/// Used for changing icon states for different base sprites.
 	var/base_icon_state
 
-	var/tts_seed = null
+	var/tts_seed = "Arthas"
 	var/tts_atom_say_effect = SOUND_EFFECT_RADIO
 
 	///AI controller that controls this atom. type on init, then turned into an instance during runtime

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -7,7 +7,6 @@
 	icon_screen = "crew"
 	circuit = /obj/item/circuitboard/operating
 	light_color = LIGHT_COLOR_BLUE
-	tts_seed = "Arthas"
 	var/obj/machinery/optable/table
 	var/verbose = TRUE //general speaker toggle
 	var/oxyAlarm = 30 //oxy damage at which the computer will beep

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -7,7 +7,7 @@
 	icon_screen = "crew"
 	circuit = /obj/item/circuitboard/operating
 	light_color = LIGHT_COLOR_BLUE
-	tts_seed = null
+	tts_seed = "Arthas"
 	var/obj/machinery/optable/table
 	var/verbose = TRUE //general speaker toggle
 	var/oxyAlarm = 30 //oxy damage at which the computer will beep
@@ -217,13 +217,13 @@
 		patientStatus = "без сознания"
 
 	if(isNewPatient)
-		atom_say("Обнаружен новый пациент, загрузка показаний.")
+		atom_say("Обнаружен новый пациент, загрузка показаний.", use_tts = FALSE)
 		var/blood_type_msg
 		if(ishuman(table.patient))
 			blood_type_msg = table.patient.dna.blood_type
 		else
 			blood_type_msg = "\[ОШИБКА: НЕИЗВЕСТНО\]"
-		atom_say("[table.patient], группа крови [blood_type_msg], [patientStatus].")
+		atom_say("[table.patient], группа крови [blood_type_msg], [patientStatus].", use_tts = FALSE)
 		SStgui.update_uis(src)
 		patientStatusHolder = table.patient.stat
 		currentPatient = table.patient
@@ -235,9 +235,9 @@
 		if(oxy && table.patient.getOxyLoss()>oxyAlarm)
 			playsound(src.loc, 'sound/machines/defib_saftyoff.ogg', 50, FALSE)
 		if(healthAnnounce && table.patient.health <= healthAlarm)
-			atom_say("Оценка здоровья пациента: [round(table.patient.health)] %.")
+			atom_say("Оценка здоровья пациента: [round(table.patient.health)] %.", use_tts = FALSE)
 		if(table.patient.stat != patientStatusHolder)
-			atom_say("Состояние пациента: [patientStatus].")
+			atom_say("Состояние пациента: [patientStatus].", use_tts = FALSE)
 			patientStatusHolder = table.patient.stat
 
 /obj/machinery/computer/operating/old_frame

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -7,6 +7,7 @@
 	icon_screen = "crew"
 	circuit = /obj/item/circuitboard/operating
 	light_color = LIGHT_COLOR_BLUE
+	tts_seed = null
 	var/obj/machinery/optable/table
 	var/verbose = TRUE //general speaker toggle
 	var/oxyAlarm = 30 //oxy damage at which the computer will beep

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -60,6 +60,7 @@
 	integrity_failure = 100
 	armor = list(MELEE = 20, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 50, ACID = 70)
 	abstract_type = /obj/machinery/vending
+	tts_seed = null
 
 	// All the overlay controlling variables
 	/// Overlay of vendor maintenance panel.

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -60,7 +60,6 @@
 	integrity_failure = 100
 	armor = list(MELEE = 20, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 50, ACID = 70)
 	abstract_type = /obj/machinery/vending
-	tts_seed = "Arthas"
 
 	// All the overlay controlling variables
 	/// Overlay of vendor maintenance panel.

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -60,7 +60,7 @@
 	integrity_failure = 100
 	armor = list(MELEE = 20, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 50, ACID = 70)
 	abstract_type = /obj/machinery/vending
-	tts_seed = null
+	tts_seed = "Arthas"
 
 	// All the overlay controlling variables
 	/// Overlay of vendor maintenance panel.
@@ -1328,7 +1328,7 @@
 	if(!message)
 		return
 
-	atom_say(message)
+	atom_say(message, use_tts = FALSE)
 
 /obj/machinery/vending/obj_break(damage_flag)
 	if(stat & BROKEN)


### PR DESCRIPTION

## Что этот ПР делает
То что написано в названии
## Почему это хорошо для игры
Я сойду с ума если услышу еще раз "Операционный компьютер заявляет, "Оценка здоровья пациента: -645 %."". Снижает нагрузку на ТТС, заставляя обрабатывать только фразы игроков
## Список изменений
:cl:
tweak: Вендоры и хирургические мониторы не имеют ТТСа
/:cl:
