### PR TITLE
Оптимизация кровотечений

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -28,6 +28,7 @@
 	GLOB.human_list += src
 
 /mob/living/carbon/human/Destroy()
+	bleeding_bodyparts.Cut()
 	QDEL_NULL(physiology)
 	QDEL_LIST(bodyparts)
 	SSmobs.cubemonkeys -= src

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -109,3 +109,6 @@
 	var/emp_damage_multiplier_internal = 1
 	/// EMP damage multiplier for external organs
 	var/emp_damage_multiplier_external = 1
+
+	/// Bleeding bodyparts (optimisation)
+	var/list/bleeding_bodyparts = list()

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -102,8 +102,6 @@
 	var/total_health = 100
 	/// Maximum stamina of this species, MUST be lower than MAX_STAMINA_LOSS
 	var/total_stamina = BASE_MAX_STAMINA
-	/// What type of damage does this species take if it's low on blood?
-	var/blood_damage_type = OXY
 	/// Species default genes
 	var/list/default_genes
 	/// Species movement speed. Positive numbers make it move slower, negative numbers make it move faster

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -45,6 +45,7 @@
 		chat_message_type = MESSAGE_TYPE_COMBAT
 	)
 	affected.open = ORGAN_ORGANIC_ENCASED_OPEN
+	affected.owner.add_bleeding_bodypart(affected)
 	affected.fracture(silent = TRUE)
 	return SURGERY_STEP_CONTINUE
 
@@ -97,6 +98,7 @@
 	)
 
 	affected.open = ORGAN_ORGANIC_ENCASED_OPEN
+	affected.owner.add_bleeding_bodypart(affected)
 
 	return SURGERY_STEP_CONTINUE
 
@@ -197,5 +199,6 @@
 
 	affected.mend_fracture()
 	affected.open = ORGAN_ORGANIC_OPEN
+	affected.owner.add_bleeding_bodypart(affected)
 
 	return SURGERY_STEP_CONTINUE

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -42,6 +42,7 @@
 		chat_message_type = MESSAGE_TYPE_COMBAT
 	)
 	affected.open = ORGAN_ORGANIC_OPEN
+	affected.owner.add_bleeding_bodypart(affected)
 	return SURGERY_STEP_CONTINUE
 
 /datum/surgery_step/generic/cut_open/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -189,6 +190,7 @@
 		self_msg = "Вы раздвигаете органы в брюшной полости [target], используя [tool.declent_ru(ACCUSATIVE)]."
 	user.visible_message(span_notice(msg), span_notice(self_msg), chat_message_type = MESSAGE_TYPE_COMBAT)
 	affected.open = ORGAN_ORGANIC_ENCASED_OPEN
+	affected.owner.add_bleeding_bodypart(affected)
 	return SURGERY_STEP_CONTINUE
 
 /datum/surgery_step/generic/retract_skin/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -132,6 +132,9 @@
 		if(-INFINITY to BLOOD_VOLUME_SURVIVE)
 			death()
 
+/mob/living/carbon/human/proc/add_bleeding_bodypart(obj/item/organ/external/bodypart)
+	bleeding_bodyparts |= bodypart
+
 /mob/living/carbon/human/proc/calculate_current_bleeding()
 	//not calculate bleeding for fake dath
 	if(HAS_TRAIT(src, TRAIT_FAKEDEATH))
@@ -141,8 +144,10 @@
 	var/internal_bleeding_rate = 0
 	var/has_arterial_bleed = FALSE
 	// calculate total bleeding from bodyparts
-	for(var/obj/item/organ/external/bodypart as anything in bodyparts)
+	var/list/bleeding_bodyparts_cache = bleeding_bodyparts
+	for(var/obj/item/organ/external/bodypart as anything in bleeding_bodyparts_cache)
 		if(bodypart.is_robotic())
+			bleeding_bodyparts_cache -= bodypart
 			continue
 
 		if(bodypart.tourniquet) //all bloodloss suppressed
@@ -177,6 +182,9 @@
 
 		if(bodypart.open)
 			current_bleed += OPEN_BODYPART_BLEEDING
+
+		if(bodypart.bleeding_amount <= 0 && !bodypart.has_internal_bleeding() && !embedded_length && !bodypart.open)
+			bleeding_bodyparts_cache -= bodypart
 
 	// calculate bleed rate with regenretion and current bleed
 	var/prev_bleed_rate = bleed_rate

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -95,10 +95,10 @@
 /mob/living/carbon/human/proc/apply_current_blood_level_effect()
 	switch(blood_volume)
 		if(BLOOD_VOLUME_PALE to BLOOD_VOLUME_SAFE)
-			apply_damage(BLOOD_PALE_DAMAGE, dna.species.blood_damage_type, spread_damage = TRUE, forced = TRUE)
+			adjust_blood_loss_damage(BLOOD_PALE_DAMAGE)
 
 		if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_PALE)
-			apply_damage(BLOOD_OKAY_DAMAGE, dna.species.blood_damage_type, spread_damage = TRUE, forced = TRUE)
+			adjust_blood_loss_damage(BLOOD_OKAY_DAMAGE)
 			if(prob(5))
 				Confused(2 SECONDS)
 				var/symptom = pick("слабость",
@@ -107,7 +107,7 @@
 				to_chat(src, span_warning("Вы чувствуете [symptom]."))
 
 		if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
-			apply_damage(BLOOD_BAD_DAMAGE, dna.species.blood_damage_type, spread_damage = TRUE, forced = TRUE)
+			adjust_blood_loss_damage(BLOOD_BAD_DAMAGE)
 			if(prob(5))
 				EyeBlurry(12 SECONDS)
 				Confused(12 SECONDS)
@@ -118,7 +118,7 @@
 				to_chat(src, span_warning("Вы чувствуете [symptom]."))
 
 		if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_BAD)
-			apply_damage(BLOOD_SURVIVE_DAMAGE, dna.species.blood_damage_type, spread_damage = TRUE, forced = TRUE)
+			adjust_blood_loss_damage(BLOOD_SURVIVE_DAMAGE)
 			if(prob(15))
 				Confused(10 SECONDS)
 				Slowed(15 SECONDS)
@@ -131,6 +131,9 @@
 
 		if(-INFINITY to BLOOD_VOLUME_SURVIVE)
 			death()
+
+/mob/living/carbon/human/proc/adjust_blood_loss_damage(amount) //if you want override damage type
+	adjustOxyLoss(amount)
 
 /mob/living/carbon/human/proc/add_bleeding_bodypart(obj/item/organ/external/bodypart)
 	bleeding_bodyparts |= bodypart

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -173,6 +173,7 @@
 	if(owner)
 		owner.bodyparts_by_name[limb_zone] = null
 		LAZYREMOVE(owner.splinted_limbs, src)
+		owner.bleeding_bodyparts -= src
 
 	QDEL_LIST(embedded_objects)
 	QDEL_NULL(hidden)
@@ -207,6 +208,8 @@
 
 	owner.bodyparts_by_name[limb_zone] = src
 	owner.bodyparts |= src
+	if(bleeding_amount > 0 || has_internal_bleeding() || LAZYLEN(embedded_objects) || open)
+		owner.bleeding_bodyparts |= src
 
 	for(var/atom/movable/thing in src)
 		thing.attempt_become_organ(src, owner, special)
@@ -225,6 +228,7 @@
 	remove_splint(silent = TRUE)
 	remove_all_embedded_objects()
 	remove_tourniquet()
+	owner.bleeding_bodyparts -= src
 
 	. = ..()
 
@@ -466,7 +470,7 @@
 
 			bleeding_amount += round(bleeding, BLEEDING_PRECISION)
 			bleeding_amount = min(bleeding_amount, max_bleeding_amount)
-			owner.add_bleeding_bodypart(src)
+			owner?.add_bleeding_bodypart(src)
 
 /obj/item/organ/external/proc/heal_damage(brute, burn, internal = FALSE, robo_repair = FALSE, updating_health = TRUE)
 	if(is_robotic() && !robo_repair)
@@ -1337,7 +1341,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 /obj/item/organ/external/proc/add_embedded_object(obj/item/thing, throw_alert = TRUE)
 	LAZYOR(embedded_objects, thing)
-	owner.add_bleeding_bodypart(src)
+	owner?.add_bleeding_bodypart(src)
 	thing.forceMove(src)
 	if(throw_alert)
 		owner?.throw_alert(ALERT_EMBEDDED, /atom/movable/screen/alert/embeddedobject)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -466,6 +466,7 @@
 
 			bleeding_amount += round(bleeding, BLEEDING_PRECISION)
 			bleeding_amount = min(bleeding_amount, max_bleeding_amount)
+			owner.add_bleeding_bodypart(src)
 
 /obj/item/organ/external/proc/heal_damage(brute, burn, internal = FALSE, robo_repair = FALSE, updating_health = TRUE)
 	if(is_robotic() && !robo_repair)
@@ -848,6 +849,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		)
 
 	open = ORGAN_ORGANIC_OPEN
+	owner.add_bleeding_bodypart(src)
 	return TRUE
 
 /obj/item/organ/external/chest/droplimb(clean = FALSE, disintegrate = DROPLIMB_SHARP, ignore_children = FALSE, nodamage = FALSE, silent = FALSE)
@@ -976,6 +978,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return FALSE
 
 	status |= ORGAN_INT_BLEED
+	owner.add_bleeding_bodypart(src)
 	INVOKE_ASYNC(owner, TYPE_PROC_REF(/mob, emote), "scream")
 
 	if(owner && !silent)
@@ -1009,6 +1012,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return FALSE
 
 	bleeding_amount = LIMB_ARTERIAL_BLEEDING_SIZE
+	owner.add_bleeding_bodypart(src)
 	INVOKE_ASYNC(owner, TYPE_PROC_REF(/mob, emote), "scream")
 
 	if(owner && !silent)
@@ -1333,6 +1337,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 /obj/item/organ/external/proc/add_embedded_object(obj/item/thing, throw_alert = TRUE)
 	LAZYOR(embedded_objects, thing)
+	owner.add_bleeding_bodypart(src)
 	thing.forceMove(src)
 	if(throw_alert)
 		owner?.throw_alert(ALERT_EMBEDDED, /atom/movable/screen/alert/embeddedobject)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -941,10 +941,12 @@
 		msg = "[user] вставля[PLUR_ET_YUT(user)] кости грудной клетки [target] обратно, используя [tool.declent_ru(ACCUSATIVE)]."
 		self_msg = "Вы вставляете кости грудной клетки [target] обратно, используя [tool.declent_ru(ACCUSATIVE)]."
 		affected.open = ORGAN_ORGANIC_ENCASED_OPEN
+		affected.owner.add_bleeding_bodypart(affected)
 	if(target_zone == BODY_ZONE_HEAD)
 		msg = "[user] вставля[PLUR_ET_YUT(user)] кости черепа [target] обратно, используя [tool.declent_ru(ACCUSATIVE)]."
 		self_msg = "Вы вставляете кости черепа [target] обратно, используя [tool.declent_ru(ACCUSATIVE)]."
 		affected.open = ORGAN_ORGANIC_ENCASED_OPEN
+		affected.owner.add_bleeding_bodypart(affected)
 	else
 		msg = "[user] закрыва[PLUR_ET_YUT(user)] края раны на [affected.declent_ru(PREPOSITIONAL)] [target], используя [tool.declent_ru(ACCUSATIVE)]."
 		self_msg = "Вы закрываете края раны на [affected.declent_ru(PREPOSITIONAL)] [target], используя [tool.declent_ru(ACCUSATIVE)]."

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -274,6 +274,7 @@
 		chat_message_type = MESSAGE_TYPE_COMBAT
 	)
 	affected.open = ORGAN_ORGANIC_OPEN
+	affected.owner.add_bleeding_bodypart(affected)
 
 	return SURGERY_STEP_CONTINUE
 


### PR DESCRIPTION

## Что этот ПР делает
Добавляет список частей тела с кровотечением, чтобы не прогонять по циклу каждый раз все части тела.

## Почему это хорошо для игры
Оптимизация.

## Список изменений
:cl:
refactor: оптимизация кровотечений
/:cl:
