### PR TITLE
Удаление сонного газа и их труб из пермы

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -13492,7 +13492,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -40304,9 +40303,6 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "eHP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkred"
@@ -42441,7 +42437,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -42689,7 +42684,6 @@
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "fiU" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on,
 /obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -42773,7 +42767,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -43865,10 +43858,6 @@
 "fxR" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/table/reinforced,
-/obj/item/flash{
-	pixel_x = -4;
-	pixel_y = 2
-	},
 /obj/item/melee/baton,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -44204,13 +44193,6 @@
 /obj/item/taperecorder,
 /turf/simulated/floor/plasteel,
 /area/security/processing)
-"fCQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/security/permabrig)
 "fCT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49011,7 +48993,6 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "gIs" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on,
 /obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -49362,24 +49343,6 @@
 /obj/item/bedsheet/red,
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
-"gLR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/security/permabrig)
 "gLS" = (
 /obj/effect/landmark/spawner/carp,
 /obj/structure/lattice,
@@ -49647,31 +49610,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
 /obj/structure/punching_bag,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
-	},
-/area/security/permabrig)
-"gOj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
 	},
 /area/security/permabrig)
 "gOq" = (
@@ -55108,7 +55050,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "PermaLockdown";
 	name = "Perma Lockdown"
@@ -66734,13 +66675,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/bridge/vip)
-"kNh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
-	},
-/area/security/permabrig)
 "kNj" = (
 /obj/structure/rack,
 /obj/random/tool,
@@ -68662,17 +68596,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/kitchen)
-"lme" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/permabrig)
 "lmf" = (
 /turf/simulated/wall/r_wall/rust,
 /area/toxins/sm_test_chamber)
@@ -71208,19 +71131,6 @@
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
-"lUg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/permabrig)
 "lUn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -79771,7 +79681,7 @@
 /area/medical/research/nhallway)
 "nMG" = (
 /obj/effect/decal/warning_stripes/east,
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -103271,7 +103181,6 @@
 	},
 /area/maintenance/asmaint)
 "sZL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/weightmachine/weightlifter,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -113324,24 +113233,6 @@
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
 /area/medical/virology/lab)
-"vjr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
-	},
-/area/security/permabrig)
 "vjx" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -116537,7 +116428,6 @@
 	pixel_y = -3;
 	req_access = list(2)
 	},
-/obj/item/megaphone,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -117252,22 +117142,17 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "wbR" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	name = "Riot Control";
-	req_access = list(2)
-	},
-/obj/item/wrench,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/turf/simulated/floor/plating,
+/obj/structure/table/reinforced,
+/obj/item/flash{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/security/permabrig)
 "wbW" = (
 /obj/machinery/camera{
@@ -120259,7 +120144,6 @@
 /turf/simulated/floor/carpet/black,
 /area/crew_quarters/theatre)
 "wLc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/weightmachine/weightlifter,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -120536,12 +120420,11 @@
 	},
 /area/toxins/xenobiology)
 "wNO" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/megaphone,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
 /area/security/permabrig)
 "wNR" = (
 /obj/machinery/door/firedoor,
@@ -182687,8 +182570,8 @@ vGv
 eAN
 gIs
 sZL
-kNh
-vjr
+vGv
+mnQ
 vrZ
 aru
 xwO
@@ -182945,7 +182828,7 @@ ckl
 fhd
 rqS
 gKa
-gLR
+kaJ
 dRJ
 yeN
 fWz
@@ -183205,11 +183088,11 @@ fmb
 gOi
 ffK
 ibF
-lme
+chy
 fjL
-lme
+chy
 bMB
-lUg
+chy
 syC
 mFd
 chy
@@ -183459,7 +183342,7 @@ dqV
 hKy
 dqV
 nLY
-gLR
+kaJ
 dRJ
 ice
 eKe
@@ -183715,8 +183598,8 @@ uPb
 uoU
 fiU
 wLc
-fCQ
-gOj
+uPb
+xfr
 tCR
 aru
 xwO

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -586,12 +586,6 @@
 	icon_state = "white"
 	},
 /area/security/medbay)
-"adN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/security/permabrig)
 "adO" = (
 /turf/simulated/wall/r_wall,
 /area/security/medbay)
@@ -2847,7 +2841,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -2870,9 +2863,6 @@
 /area/security/hos)
 "anc" = (
 /obj/machinery/door/airlock/public/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "and" = (
@@ -3417,7 +3407,6 @@
 /obj/structure/chair/stool{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/outlet_injector/on,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood,
 /area/security/permabrig)
@@ -3919,7 +3908,6 @@
 /area/security/permabrig)
 "aqK" = (
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/wood,
 /area/security/permabrig)
 "aqL" = (
@@ -4640,9 +4628,6 @@
 "asG" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/utensil/pfork,
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 4
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8;
 	pixel_y = 1
@@ -4660,9 +4645,6 @@
 /area/security/permabrig)
 "asH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -4679,9 +4661,6 @@
 "asI" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Lounge"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4811,9 +4790,6 @@
 	},
 /area/security/prison/cell_block/A)
 "atc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "red"
@@ -4840,9 +4816,6 @@
 "atg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/security/permabrig)
@@ -4950,7 +4923,6 @@
 /area/security/customs)
 "atz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4965,7 +4937,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -5491,9 +5462,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -5509,9 +5477,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "avi" = (
@@ -5525,21 +5490,12 @@
 /turf/simulated/floor/grass,
 /area/security/permabrig)
 "avj" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Riot Control";
-	req_access = list(2)
-	},
-/turf/simulated/floor/plating,
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner/brig,
+/turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "avl" = (
 /obj/structure/table,
-/obj/item/wrench,
-/obj/item/screwdriver,
-/obj/item/reagent_containers/spray/cleaner/brig,
 /obj/machinery/light,
 /obj/machinery/camera/motion{
 	c_tag = "Prison Lobby";
@@ -5547,6 +5503,7 @@
 	network = list("Prison","SS13")
 	},
 /obj/machinery/light_switch/directional/south,
+/obj/item/melee/baton,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "avn" = (
@@ -6061,7 +6018,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -6600,9 +6556,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "ayx" = (
@@ -6618,7 +6571,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/wood,
 /area/security/permabrig)
 "ayy" = (
@@ -7985,9 +7937,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -7999,9 +7948,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -8018,9 +7964,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -8032,9 +7975,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -8043,7 +7983,6 @@
 "aDD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -10040,9 +9979,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "aKW" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 4
-	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -10051,9 +9987,6 @@
 /area/security/permabrig)
 "aKZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cmo"
@@ -10078,18 +10011,12 @@
 /obj/machinery/door/airlock{
 	name = "Prison Showers"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
 "aLi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -10128,7 +10055,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/machinery/camera{
 	c_tag = "Prison General South";
 	dir = 1;
@@ -11143,9 +11069,6 @@
 	},
 /area/hallway/primary/fore)
 "aPH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -11161,9 +11084,6 @@
 /area/security/permabrig)
 "aPJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11194,9 +11114,6 @@
 	},
 /area/crew_quarters/sleep)
 "aPR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -12071,17 +11988,6 @@
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
-"aTP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floorgrime"
-	},
-/area/security/permabrig)
 "aTR" = (
 /turf/simulated/floor/beach/water{
 	icon_state = "seadeep"
@@ -12118,9 +12024,6 @@
 "aUn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -12717,11 +12620,6 @@
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass,
 /area/security/permabrig)
-"aXc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plasteel,
-/area/security/permabrig)
 "aXd" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -12876,9 +12774,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aXY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -12889,12 +12784,6 @@
 	dir = 6
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "floorgrime"
-	},
-/area/security/permabrig)
-"aYa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -13770,9 +13659,6 @@
 	name = "Prison Lockdown Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "bbt" = (
@@ -13792,9 +13678,6 @@
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "bbw" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -13841,9 +13724,6 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bbB" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -14777,9 +14657,6 @@
 /area/security/permabrig)
 "beJ" = (
 /obj/machinery/smartfridge/drying_rack,
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Prison Forestry South";
 	dir = 1;
@@ -14812,9 +14689,6 @@
 "beV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -14823,9 +14697,6 @@
 	},
 /area/security/permabrig)
 "beW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -14833,9 +14704,6 @@
 "beY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -16019,9 +15887,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -28757,7 +28622,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -28937,9 +28801,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -28968,7 +28829,6 @@
 /area/crew_quarters/dorms)
 "cgY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -46611,7 +46471,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -47713,13 +47572,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/security/checkpoint/south)
-"epC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/security/permabrig)
 "epI" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
@@ -47738,9 +47590,6 @@
 "eqg" = (
 /obj/structure/chair{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -47798,9 +47647,6 @@
 "erf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -55476,9 +55322,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -55846,7 +55689,6 @@
 	name = "Prison Toilets"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -58175,7 +58017,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -60785,13 +60626,6 @@
 "khg" = (
 /turf/simulated/floor/carpet,
 /area/chapel/main)
-"khl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/security/permabrig)
 "khs" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -61277,9 +61111,6 @@
 /area/maintenance/fpmaint)
 "kpX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -61917,7 +61748,6 @@
 	},
 /area/crew_quarters/dorms)
 "kEY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -62277,14 +62107,9 @@
 /turf/simulated/floor/carpet,
 /area/civilian/vacantoffice)
 "kKP" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/turf/simulated/floor/plating,
+/obj/structure/table,
+/obj/item/screwdriver,
+/turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "kKR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -63565,7 +63390,6 @@
 	name = "Prison Toilets"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -63769,9 +63593,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
 /obj/structure/cable{
@@ -64881,9 +64702,6 @@
 	},
 /area/medical/research/restroom)
 "lTr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -66187,9 +66005,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -68314,17 +68129,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
-"nuL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "floorgrime"
-	},
-/area/security/permabrig)
 "nuO" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -72906,7 +72710,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "pwz" = (
@@ -75477,7 +75280,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "qzY" = (
@@ -77041,9 +76843,6 @@
 "riY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
 /turf/simulated/floor/wood,
@@ -84054,7 +83853,6 @@
 	pixel_x = -28
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/outlet_injector/on,
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -84483,9 +84281,6 @@
 "uys" = (
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1
 	},
 /obj/effect/landmark/spawner/late/prisoner,
 /turf/simulated/floor/plasteel{
@@ -85181,7 +84976,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -86585,7 +86379,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "vrr" = (
@@ -87760,7 +87553,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/unary/outlet_injector/on,
 /obj/effect/landmark/spawner/late/prisoner,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -87926,9 +87718,6 @@
 "vVk" = (
 /obj/structure/bed,
 /obj/item/radio/intercom/locked/prison/directional/north,
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -88993,7 +88782,6 @@
 	},
 /area/hallway/primary/aft)
 "wpn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
@@ -90295,7 +90083,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "wSx" = (
@@ -90541,9 +90328,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -91047,7 +90831,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "xjx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -91868,7 +91651,6 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
-/obj/machinery/atmospherics/unary/outlet_injector/on,
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -93200,7 +92982,6 @@
 "ydr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -110125,7 +109906,7 @@ olE
 olE
 atO
 sFB
-epC
+ppb
 nyd
 ppb
 iSC
@@ -110381,7 +110162,7 @@ agd
 jih
 uln
 hUa
-khl
+atc
 atc
 qmz
 tCQ
@@ -111944,7 +111725,7 @@ aXY
 cgY
 lTr
 xjx
-aXc
+ppb
 beJ
 abN
 uTI
@@ -112451,7 +112232,7 @@ ppb
 aLr
 owA
 aPR
-nuL
+beV
 atA
 atz
 ayw
@@ -112709,9 +112490,9 @@ aLt
 atO
 aPT
 ppb
-aTP
-aXc
-aYa
+bcm
+ppb
+beW
 kEY
 pwi
 awO
@@ -112966,7 +112747,7 @@ abN
 abN
 qfY
 sWT
-epC
+ppb
 aPC
 aYf
 mqK
@@ -113480,7 +113261,7 @@ uTI
 abN
 awU
 awU
-adN
+tCQ
 abN
 abN
 mAO

--- a/_maps/map_files/event/Station/coldcolony.dmm
+++ b/_maps/map_files/event/Station/coldcolony.dmm
@@ -480,14 +480,11 @@
 /turf/simulated/floor/plasteel,
 /area/coldcolony/malta/medical/virology)
 "ahY" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/melee/baton,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plating,
 /area/coldcolony/malta/security/permabrig)
 "aic" = (
 /obj/machinery/power/port_gen/pacman{
@@ -4404,14 +4401,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/coldcolony/malta/hallway/service/north)
-"bDc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/coldcolony/malta/security/permabrig)
 "bDK" = (
 /obj/machinery/door_control{
 	desiredstate = 1;
@@ -4938,8 +4927,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/coldcolony/malta/resid_serv/crew_quarters/fitness)
 "bOi" = (
-/obj/structure/table,
-/obj/item/wirecutters,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/coldcolony/malta/maintenance/perma)
 "bOn" = (
@@ -7964,14 +7952,14 @@
 	},
 /area/coldcolony/malta/engineering/engine)
 "cSn" = (
-/obj/structure/window/reinforced,
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+/obj/structure/table/reinforced,
+/obj/item/flash{
+	pixel_x = -4;
+	pixel_y = 2
 	},
-/obj/item/wrench,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/coldcolony/malta/security/permabrig)
 "cSx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8328,6 +8316,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -10377,9 +10368,6 @@
 	security_level = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -16676,9 +16664,6 @@
 /turf/simulated/floor/carpet/red,
 /area/coldcolony/malta/security/magistrateoffice)
 "ghN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -18909,9 +18894,6 @@
 /turf/simulated/floor/plating,
 /area/coldcolony/malta/resid_serv/crew_quarters/theatre)
 "gWt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -20781,15 +20763,6 @@
 	icon_state = "arrival"
 	},
 /area/shuttle/pirate_corvette)
-"hHg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/coldcolony/malta/security/permabrig)
 "hHi" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Reception";
@@ -21452,7 +21425,6 @@
 /area/coldcolony/malta/outer/roadblock)
 "hWc" = (
 /obj/effect/decal/warning_stripes/red,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -25949,9 +25921,11 @@
 /turf/simulated/floor/plasteel,
 /area/coldcolony/malta/maintenance/garden)
 "jCC" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plating,
+/obj/structure/table/reinforced,
+/obj/item/megaphone,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/coldcolony/malta/security/permabrig)
 "jCG" = (
 /obj/structure/table/wood,
@@ -26749,10 +26723,10 @@
 /area/coldcolony/malta/hallway/cargo_escape/port/west)
 "jUd" = (
 /obj/structure/table,
-/obj/item/wrench,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plating,
 /area/coldcolony/malta/maintenance/perma)
 "jUh" = (
@@ -29080,9 +29054,6 @@
 	},
 /area/coldcolony/malta/bridge/tcomm)
 "kKc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel{
@@ -32516,14 +32487,6 @@
 	icon_state = "light-fancy-wood-broken4"
 	},
 /area/coldcolony/malta/security/magistrateoffice)
-"mcj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/coldcolony/malta/security/permabrig)
 "mcu" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -33705,12 +33668,10 @@
 	},
 /area/coldcolony/malta/hallway/cargo_escape/north)
 "mBh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/coldcolony/malta/security/permabrig)
+/obj/item/storage/toolbox/mechanical/old,
+/turf/simulated/floor/plating,
+/area/coldcolony/malta/maintenance/perma)
 "mBn" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/shuttle/plating,
@@ -39934,15 +39895,6 @@
 	icon_state = "arrivalcorner"
 	},
 /area/shuttle/pirate_corvette)
-"oOd" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/coldcolony/malta/security/permabrig)
 "oOB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -43184,9 +43136,6 @@
 /turf/simulated/wall/rust,
 /area/coldcolony/malta/maintenance/science)
 "pZz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -49130,9 +49079,6 @@
 	id_tag = "Perma22"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -49174,14 +49120,6 @@
 	icon_state = "darkblue"
 	},
 /area/coldcolony/malta/bridge/vip)
-"sgn" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/coldcolony/malta/security/permabrig)
 "shF" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -63672,9 +63610,6 @@
 	},
 /area/coldcolony/malta/research/lab)
 "xzK" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -106340,7 +106275,7 @@ xOz
 rSb
 wYq
 lsc
-bDc
+rbF
 ahY
 jCC
 cSn
@@ -106854,7 +106789,7 @@ rSb
 rSb
 wYq
 kUv
-mcj
+rbF
 dcR
 lLL
 kUv
@@ -107621,11 +107556,11 @@ rSb
 rSb
 fTE
 xtJ
-vTM
+mBh
 qVE
 wYq
 lxG
-hHg
+oyD
 lJo
 eCV
 rLu
@@ -108396,10 +108331,10 @@ qVE
 vTM
 wYq
 cYT
-oOd
-mBh
+oyD
+oyD
 hWc
-mBh
+oyD
 ghN
 lLL
 kzc
@@ -108653,7 +108588,7 @@ jUd
 lQO
 wYq
 fEv
-sgn
+rbF
 daH
 bCc
 iRN

--- a/_maps/map_files/nova/nova.dmm
+++ b/_maps/map_files/nova/nova.dmm
@@ -618,7 +618,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "afG" = (
@@ -3077,16 +3076,9 @@
 	},
 /area/medical/virology/lab)
 "azz" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Riot Control";
-	req_access = list(2)
-	},
-/obj/item/wrench,
-/turf/simulated/floor/plating,
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner/brig,
+/turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "azB" = (
 /obj/machinery/computer/atmos_alert,
@@ -5963,7 +5955,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "aTu" = (
@@ -7490,16 +7481,6 @@
 	icon_state = "yellow"
 	},
 /area/engineering/engine/monitor)
-"bfS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plasteel,
-/area/security/permabrig)
 "bfZ" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -8075,7 +8056,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "bkc" = (
@@ -8225,7 +8205,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "bls" = (
@@ -8373,9 +8352,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
@@ -9609,12 +9585,9 @@
 /area/medical/morgue)
 "bvj" = (
 /obj/structure/table,
-/obj/item/screwdriver{
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/spray/cleaner/brig,
 /obj/machinery/light,
 /obj/machinery/light_switch/directional/south,
+/obj/item/melee/baton,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "bvl" = (
@@ -12020,10 +11993,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"bMk" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plasteel,
-/area/security/permabrig)
 "bMr" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -12158,9 +12127,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
 	},
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel,
@@ -15518,9 +15484,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -15545,7 +15508,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "cmZ" = (
@@ -17346,9 +17308,6 @@
 /area/bridge)
 "cBM" = (
 /obj/machinery/door/airlock/public/glass,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "cBO" = (
@@ -18567,17 +18526,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
-"cLT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/security/permabrig)
 "cLU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18794,9 +18742,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dust,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/security/permabrig)
 "cNo" = (
@@ -25759,9 +25704,6 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
-	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Prison Gate";
 	name = "Prison Lockdown Blast Doors"
@@ -26680,7 +26622,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "dYQ" = (
@@ -26891,9 +26832,6 @@
 /area/hallway/secondary/exit)
 "eam" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -28001,9 +27939,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "ehB" = (
@@ -28769,9 +28704,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/security/permabrig)
@@ -33495,13 +33427,6 @@
 	icon_state = "red"
 	},
 /area/security/checkpoint)
-"eYN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/security/permabrig)
 "eYO" = (
 /obj/effect/landmark/start/captain,
 /turf/simulated/floor/carpet/royalblue,
@@ -34162,14 +34087,11 @@
 /turf/simulated/floor/wood/dark,
 /area/crew_quarters/bar)
 "fdN" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table,
+/obj/item/screwdriver{
+	pixel_y = 13
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "fdS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34373,14 +34295,6 @@
 	icon_state = "purple"
 	},
 /area/hallway/secondary/entry/lounge)
-"ffV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plating,
-/area/security/permabrig)
 "ffW" = (
 /obj/effect/landmark/start/mime,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -35140,9 +35054,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -36245,9 +36156,6 @@
 "fuA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/locked/prison/directional/west,
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "fuE" = (
@@ -38302,9 +38210,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "fKD" = (
@@ -39910,9 +39815,6 @@
 "fWG" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "fWP" = (
@@ -40928,9 +40830,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -42442,9 +42341,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
@@ -48774,7 +48670,6 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/crew_quarters/toilet2)
 "hol" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
@@ -50207,10 +50102,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint6)
 "hAG" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/cleanable/cobweb{
 	layer = 4
 	},
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/simulated/floor/plating,
 /area/security/permahallway)
 "hAI" = (
@@ -51469,7 +51364,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "hNq" = (
@@ -54654,9 +54548,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "ikl" = (
@@ -55763,9 +55654,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -56013,7 +55901,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/outlet_injector/on,
 /turf/simulated/floor/plasteel{
 	dir = 5
 	},
@@ -56059,9 +55946,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/item/radio/intercom/locked/prison/directional/south,
@@ -58499,9 +58383,6 @@
 "iPV" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "iPW" = (
@@ -62472,9 +62353,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "jte" = (
@@ -63308,15 +63186,6 @@
 	icon_state = "neutralfull"
 	},
 /area/storage/primary)
-"jzz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/security/permabrig)
 "jzB" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
@@ -63424,9 +63293,6 @@
 	},
 /area/engineering/engine/monitor)
 "jAz" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -66617,7 +66483,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "jZN" = (
@@ -67763,9 +67628,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -73379,9 +73241,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "lcw" = (
@@ -76144,9 +76003,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "lAs" = (
@@ -76538,15 +76394,6 @@
 	icon_state = "darkblue"
 	},
 /area/chapel/massdriver)
-"lDe" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/security/permabrig)
 "lDk" = (
 /obj/machinery/dna_scannernew,
 /turf/simulated/floor/plasteel{
@@ -76615,9 +76462,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
 	},
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plasteel{
@@ -76926,9 +76770,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/ants,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_regular_floor = "yellowsiding";
@@ -77245,9 +77086,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -77547,7 +77385,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "lLO" = (
@@ -81828,7 +81665,6 @@
 /area/quartermaster/storage)
 "msJ" = (
 /obj/effect/decal/cleanable/dust,
-/obj/machinery/atmospherics/unary/outlet_injector/on,
 /turf/simulated/floor/wood,
 /area/security/permabrig)
 "msW" = (
@@ -86532,9 +86368,6 @@
 /area/toxins/mixing)
 "ncI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5
 	},
@@ -89776,9 +89609,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "nBv" = (
@@ -91603,7 +91433,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "nQh" = (
@@ -95926,15 +95755,6 @@
 	icon_state = "whitehall"
 	},
 /area/maintenance/fsmaint3)
-"oyV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/security/permabrig)
 "oyX" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	input_tag = "co2_in";
@@ -96729,9 +96549,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "oGj" = (
@@ -98837,9 +98654,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
 /turf/simulated/floor/plasteel{
 	dir = 5
 	},
@@ -100474,7 +100288,6 @@
 "pia" = (
 /obj/item/beach_ball/holoball,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "pib" = (
@@ -100773,9 +100586,6 @@
 "pkC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -101332,9 +101142,6 @@
 	},
 /obj/structure/railing/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -102376,9 +102183,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "pxh" = (
@@ -103229,9 +103033,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -103857,7 +103658,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "pHU" = (
@@ -107033,23 +106833,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint3)
-"qeS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/security/permabrig)
 "qfb" = (
 /obj/effect/turf_decal/arrows/white{
 	dir = 4
@@ -108959,7 +108742,6 @@
 	},
 /obj/effect/decal/cleanable/vomit,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -109518,9 +109300,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_regular_floor = "yellowsiding";
@@ -109716,13 +109495,6 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/theatre)
-"qzY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/security/permabrig)
 "qAg" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
@@ -111458,9 +111230,6 @@
 "qNQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/locked/prison/directional/south,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "qNS" = (
@@ -115686,7 +115455,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "rul" = (
@@ -119345,7 +119113,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "rUr" = (
@@ -121358,9 +121125,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -124965,7 +124729,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel{
 	dir = 5
 	},
@@ -125105,9 +124868,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -130791,10 +130551,6 @@
 	icon_state = "darkbluecornersalt"
 	},
 /area/hallway/primary/command)
-"tCy" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/turf/simulated/floor/plating,
-/area/security/permahallway)
 "tCz" = (
 /obj/structure/table/wood,
 /obj/structure/sign/bobross{
@@ -132328,7 +132084,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -134467,9 +134222,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
@@ -139152,9 +138904,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/security/permabrig)
 "uPv" = (
@@ -141104,7 +140853,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel{
 	dir = 5
 	},
@@ -145661,7 +145409,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "vOk" = (
@@ -146494,9 +146241,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -154564,9 +154308,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "xfx" = (
@@ -155956,9 +155697,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -160848,9 +160586,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_regular_floor = "yellowsiding";
@@ -160874,9 +160609,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
@@ -173313,7 +173045,7 @@ iNO
 wTy
 vLe
 lFS
-cLT
+iNO
 oAi
 xFS
 mlh
@@ -173569,7 +173301,7 @@ heo
 xFS
 iNO
 bQm
-qeS
+fYR
 xuG
 rLP
 qGB
@@ -173829,8 +173561,8 @@ pAr
 yaW
 jkV
 aEm
-oyV
-lDe
+tQA
+tQA
 rBd
 peZ
 gQQ
@@ -174086,7 +173818,7 @@ uYD
 qyy
 uYD
 uYD
-jzz
+tQA
 sbk
 scx
 dhP
@@ -175635,7 +175367,7 @@ uYD
 gGc
 bNn
 pia
-eYN
+rnQ
 gVg
 owH
 uYD
@@ -176899,7 +176631,7 @@ eIe
 uYD
 sEs
 xfn
-ffV
+fEI
 hNk
 cmW
 cmW
@@ -176910,14 +176642,14 @@ lLK
 aTt
 dYO
 afA
-bfS
+siH
 tNL
 siH
 vOg
-bfS
+siH
 vOg
 vOg
-bfS
+siH
 ike
 jdU
 paw
@@ -177161,7 +176893,7 @@ cWS
 aRa
 qGB
 rnQ
-qzY
+rnQ
 vKP
 rnQ
 fxS
@@ -177169,7 +176901,7 @@ udq
 lie
 rnQ
 hUV
-qzY
+rnQ
 qGB
 rnQ
 rhu
@@ -177675,7 +177407,7 @@ aus
 uYD
 kKu
 kKu
-qzY
+rnQ
 aXR
 uYD
 itp
@@ -177940,7 +177672,7 @@ sMz
 yiN
 uYD
 uYD
-qzY
+rnQ
 xGj
 rrr
 uYD
@@ -178194,7 +177926,7 @@ kNC
 dyz
 wrH
 jAz
-bMk
+dyz
 azz
 ebs
 oGf
@@ -181015,7 +180747,7 @@ pZF
 kAX
 fQu
 ocY
-tCy
+owx
 nRd
 wBe
 ocY


### PR DESCRIPTION

## Что этот ПР делает

Удаление всех труб для сонного газа из пермы и самого газа
## Почему это хорошо для игры

Добавлен иплант подавления БИ, теперь угроз в перме вообще нет, и сонный газ выглядит просто как душка и без того беззащитных зеков

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
del: Удаление сонного газа и их труб из пермы
map: На места газов были добавлены мелкие предметы, стандартизировано под все мапы

/:cl:
