### PR TITLE
Донат тир 1 админам

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -28,7 +28,7 @@
 
 /client/can_vv_get(var_name)
 	var/static/list/protected_vars = list(
-		"address", "chatOutput", "computer_id", "connection", "jbh", "pm_tracker", "related_accounts_cid", "related_accounts_ip", "watchlisted"
+		"address", "chatOutput", "computer_id", "connection", "jbh", "pm_tracker", "related_accounts_cid", "related_accounts_ip", "watchlisted", "donator_level"
 	)
 	if(!check_rights(R_ADMIN, FALSE, usr) && (var_name in protected_vars))
 		return FALSE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -577,11 +577,6 @@
 	if(!SSdbcore.IsConnected())
 		return
 
-	if(check_rights(R_ADMIN, FALSE, mob)) // Yes, the mob is required, regardless of other examples in this file, it won't work otherwise
-		donator_level = DONATOR_LEVEL_MAX
-		donor_loadout_points()
-		return
-
 	//Donator stuff.
 	var/datum/db_query/query_donor_select = SSdbcore.NewQuery({"
 		SELECT CAST(SUM(amount) as UNSIGNED INTEGER) FROM [CONFIG_GET(string/utility_database)].[format_table_name("budget")]

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -577,11 +577,6 @@
 	if(!SSdbcore.IsConnected())
 		return
 
-	if(check_rights(R_ADMIN, FALSE, mob)) // Yes, the mob is required, regardless of other examples in this file, it won't work otherwise
-		donator_level = DONATOR_TIER_I
-		donor_loadout_points()
-		return
-
 	//Donator stuff.
 	var/datum/db_query/query_donor_select = SSdbcore.NewQuery({"
 		SELECT CAST(SUM(amount) as UNSIGNED INTEGER) FROM [CONFIG_GET(string/utility_database)].[format_table_name("budget")]
@@ -599,15 +594,20 @@
 	if(query_donor_select.NextRow())
 		var/total = query_donor_select.item[1]
 		if(total >= 100)
-			donator_level = 1
+			donator_level = DONATOR_TIER_I
 		if(total >= 300)
-			donator_level = 2
+			donator_level = DONATOR_TIER_II
 		if(total >= 500)
-			donator_level = 3
+			donator_level = DONATOR_TIER_III
 		if(total >= 1000)
 			donator_level = DONATOR_LEVEL_MAX
 		donor_loadout_points()
 	qdel(query_donor_select)
+
+	if(check_rights(R_ADMIN, FALSE, mob) && donator_level < DONATOR_TIER_I) // Yes, the mob is required, regardless of other examples in this file, it won't work otherwise
+		donator_level = DONATOR_TIER_I
+		donor_loadout_points()
+		return
 
 /client/proc/donor_loadout_points()
 	if(donator_level > 0 && prefs)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -577,6 +577,11 @@
 	if(!SSdbcore.IsConnected())
 		return
 
+	if(check_rights(R_ADMIN, FALSE, mob)) // Yes, the mob is required, regardless of other examples in this file, it won't work otherwise
+		donator_level = DONATOR_TIER_I
+		donor_loadout_points()
+		return
+
 	//Donator stuff.
 	var/datum/db_query/query_donor_select = SSdbcore.NewQuery({"
 		SELECT CAST(SUM(amount) as UNSIGNED INTEGER) FROM [CONFIG_GET(string/utility_database)].[format_table_name("budget")]


### PR DESCRIPTION

## Что этот ПР делает
Выдает админам донат тир 1 вместо 4 тира.
По необходимости админы сами могут задонатить на 4 тир.

## Почему это хорошо для игры
Поддержим проект донатами!

## Список изменений
:cl:
tweak: донат тир 1 админам вместо 4.
/:cl:
