### PR TITLE
Bluespace, janitoral and tactical cleaner now have tactical advantage over poor people cleaners

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -1898,50 +1898,6 @@
 	)
 	category = CAT_MISC
 
-/datum/crafting_recipe/brig_cleaner
-	name = "Brig cleaner"
-	result = /obj/item/reagent_containers/spray/cleaner/brig/empty
-	reqs = list(
-		/obj/item/reagent_containers/spray = 1,
-	)
-	blacklist = list(/obj/item/reagent_containers/spray/cleaner/brig)
-	pathtools = list(/obj/item/toy/crayon/red = 1)
-	time = 1.5 SECONDS
-	category = CAT_MISC
-
-/datum/crafting_recipe/chemical_cleaner
-	name = "Chemical cleaner"
-	result = /obj/item/reagent_containers/spray/cleaner/chemical/empty
-	reqs = list(
-		/obj/item/reagent_containers/spray = 1,
-	)
-	blacklist = list(/obj/item/reagent_containers/spray/cleaner/chemical)
-	pathtools = list(/obj/item/toy/crayon/orange = 1)
-	time = 1.5 SECONDS
-	category = CAT_MISC
-
-/datum/crafting_recipe/janitor_cleaner
-	name = "Janitor cleaner"
-	result = /obj/item/reagent_containers/spray/cleaner/janitor/empty
-	reqs = list(
-		/obj/item/reagent_containers/spray = 1,
-	)
-	blacklist = list(/obj/item/reagent_containers/spray/cleaner/janitor)
-	pathtools = list(/obj/item/toy/crayon/purple = 1)
-	time = 1.5 SECONDS
-	category = CAT_MISC
-
-/datum/crafting_recipe/medical_cleaner
-	name = "Medical cleaner"
-	result = /obj/item/reagent_containers/spray/cleaner/medical/empty
-	reqs = list(
-		/obj/item/reagent_containers/spray = 1,
-	)
-	blacklist = list(/obj/item/reagent_containers/spray/cleaner/medical)
-	pathtools = list(/obj/item/toy/crayon/white = 1)
-	time = 1.5 SECONDS
-	category = CAT_MISC
-
 /datum/crafting_recipe/pathcloak
 	name = "Pathfinder Cloak"
 	result = /obj/item/clothing/suit/hooded/pathfinder

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -220,8 +220,8 @@
 	desc = "Распылитель с увеличенным объёмом, изготовленный с использованием блюспейс-технологий. Оно точно того стоило?"
 	icon_state = "cleaner_bluespace"
 	item_state = "cleaner_bs"
-	spray_maxrange = 3
-	spray_currentrange = 3
+	spray_maxrange = 4
+	spray_currentrange = 4
 	volume = 450
 
 /obj/item/reagent_containers/spray/blue_cleaner/get_ru_names()

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -162,6 +162,8 @@
 	desc = "Распылитель, заполненный непенящимся средством для очистки поверхностей. Стильный дизайн, специально для самого продуктивного работника станции!"
 	icon_state = "cleaner_janitor"
 	item_state = "cleaner_jan"
+	spray_maxrange = 6
+	spray_currentrange = 6
 
 /obj/item/reagent_containers/spray/cleaner/janitor/get_ru_names()
 	return list(
@@ -200,6 +202,8 @@
 	desc = "Бутылочка из прочнейшего тёмно-синего пластика, наверху которой прикреплён распылитель, оборудованный коллиматорным прицелом и глушителем. Разработано Уборочно-Силовыми Структурами \"Нанотрейзен\" для ЗАЧИСТКИ и контроля грязи в помещениях. Порадуйте своего внутреннего тактикульщика!"
 	icon_state = "cleaner_tactical"
 	item_state = "cleaner_tactical"
+	spray_maxrange = 5
+	spray_currentrange = 5
 
 /obj/item/reagent_containers/spray/cleaner/tactical/get_ru_names()
 	return list(
@@ -216,8 +220,8 @@
 	desc = "Распылитель с увеличенным объёмом, изготовленный с использованием блюспейс-технологий. Оно точно того стоило?"
 	icon_state = "cleaner_bluespace"
 	item_state = "cleaner_bs"
-	spray_maxrange = 4
-	spray_currentrange = 4
+	spray_maxrange = 3
+	spray_currentrange = 3
 	volume = 450
 
 /obj/item/reagent_containers/spray/blue_cleaner/get_ru_names()
@@ -338,7 +342,7 @@
 /obj/item/reagent_containers/spray/chemsprayer/spray(atom/A)
 	var/list/Sprays = new/list(3)
 	for(var/i in 1 to 3) // intialize sprays
-		if(reagents.total_volume < 1) 
+		if(reagents.total_volume < 1)
 			break
 		var/obj/effect/decal/chempuff/D = new/obj/effect/decal/chempuff(get_turf(src))
 		D.create_reagents(amount_per_transfer_from_this)
@@ -357,7 +361,7 @@
 	for(var/i in 1 to length(Sprays))
 		spawn()
 			var/obj/effect/decal/chempuff/D = Sprays[i]
-			if(!D) 
+			if(!D)
 				continue
 
 			// Spreads the sprays a little bit


### PR DESCRIPTION

## Что этот ПР делает
То что написано в описании
## Почему это хорошо для игры
Теперь клинеры брызгают на разную длину, не наказывая уборщика за то что он играет в игрушку и делает свою работу. Очередной бафф рнд и БЩ. Блюспейс клинер обладает высоким количеством реагента в себе, поэтому брызгает только на тайл дальше. Клинер уборщика должен быть самым лучшим в силу того, что это буквально его рабочий инструмент. Клинер БЩ сделан  чуть сильнее, чтобы убирать мостик и ради шутки в названии ПРа.
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
balance: Блюспейс клинер брызгает на 4 тайла, тактический клинер на 5 и клинер уборщика на 6.
/:cl:
