### PR TITLE
Rotates every chair

### DIFF
--- a/_maps/map_files/Delta/Lavaland.dmm
+++ b/_maps/map_files/Delta/Lavaland.dmm
@@ -3251,10 +3251,6 @@
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
-"mU" = (
-/obj/structure/bed/dogbed,
-/turf/simulated/wall/r_wall,
-/area/mine/production)
 "mV" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/window/reinforced/clockwork{
@@ -6030,7 +6026,9 @@
 	},
 /area/mine/living_quarters)
 "FK" = (
-/obj/structure/chair/stool/holostool,
+/obj/structure/chair/stool/holostool{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
 "FN" = (
@@ -7122,6 +7120,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"
@@ -7980,7 +7981,9 @@
 /turf/simulated/floor/plasteel,
 /area/mine/production)
 "Sv" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -9145,6 +9148,10 @@
 "ZA" = (
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -25
 	},
 /turf/simulated/floor/bluegrid,
 /area/mine/maintenance)
@@ -26385,7 +26392,7 @@ fw
 lh
 vS
 IZ
-mU
+aR
 dd
 TV
 dA

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -1784,7 +1784,9 @@
 /area/engineering/mechanic_workshop/expedition)
 "aqj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -4431,6 +4433,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
 /turf/simulated/floor/wood{
 	icon_state = "fancy-wood-cherry"
 	},
@@ -5937,6 +5943,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "aUr" = (
@@ -7004,6 +7014,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -25
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "bbR" = (
@@ -7195,7 +7209,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bde" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -10308,6 +10324,10 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/clothing/mask/cigarette/syndicate,
 /obj/item/trash/tastybread,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/maintenance/banya)
 "bwc" = (
@@ -21133,6 +21153,9 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -22051,6 +22074,10 @@
 "cFR" = (
 /obj/structure/table,
 /obj/item/rcs,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "brown"
@@ -24944,6 +24971,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/mrchangs)
 "cTR" = (
@@ -27423,7 +27454,9 @@
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "dfI" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/suit/storage/fr_jacket,
 /turf/simulated/floor/plasteel{
@@ -28545,7 +28578,6 @@
 /area/toxins/xenobiology)
 "dku" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/holostool,
 /obj/item/ammo_casing{
 	pixel_x = 3;
 	pixel_y = 9
@@ -28555,6 +28587,9 @@
 	pixel_y = 4
 	},
 /obj/effect/spawner/random_spawners/blood_20,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/royalblack,
 /area/maintenance/asmaint3)
 "dkv" = (
@@ -32212,7 +32247,7 @@
 /area/medical/morgue)
 "dCj" = (
 /obj/structure/chair/stool{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -33140,6 +33175,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -33412,7 +33451,7 @@
 /area/hallway/secondary/exit)
 "dHO" = (
 /obj/structure/chair/stool{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -34402,7 +34441,9 @@
 	},
 /area/maintenance/kitchen)
 "dMr" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "dMu" = (
@@ -35008,6 +35049,13 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
+"dPs" = (
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "dPt" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -39106,10 +39154,6 @@
 	c_tag = "Cargo Office"
 	},
 /obj/item/storage/firstaid/regular,
-/obj/machinery/status_display/supply_display{
-	layer = 3.25;
-	pixel_y = 32
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -39460,6 +39504,9 @@
 "ewQ" = (
 /obj/random/tool,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkyellow"
@@ -39916,6 +39963,10 @@
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
@@ -48602,7 +48653,9 @@
 	},
 /area/security/securearmory)
 "gET" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -49102,7 +49155,9 @@
 /area/atmos)
 "gJJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/wooden,
+/obj/structure/chair/stool/wooden{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -52831,6 +52886,16 @@
 /obj/effect/spawner/lootdrop/maintenance/double,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
+"hzW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/maintenance/tourist)
 "hzX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/warning_stripes/north,
@@ -53198,6 +53263,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "purple"
@@ -54794,6 +54862,16 @@
 	icon_state = "darkred"
 	},
 /area/security/evidence)
+"hXz" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/storage)
 "hXD" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -59055,6 +59133,9 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/warning_stripes/northwest,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "iYg" = (
@@ -60805,7 +60886,9 @@
 /area/atmos)
 "jrU" = (
 /obj/effect/decal/warning_stripes/north,
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/effect/landmark/start/chemist,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -64562,6 +64645,15 @@
 	icon_state = "whitehall"
 	},
 /area/toxins/xenobiology)
+"kmQ" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/maintenance/library)
 "kmU" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -64861,6 +64953,14 @@
 	icon_state = "redfull"
 	},
 /area/security/checkpoint/south)
+"kqz" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/crew_quarters/locker)
 "kqC" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel{
@@ -65316,7 +65416,9 @@
 	},
 /area/medical/biostorage)
 "kwG" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "kwN" = (
@@ -65922,6 +66024,16 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
+"kDC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkblue"
+	},
+/area/crew_quarters/theatre)
 "kDH" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -67608,6 +67720,10 @@
 "lay" = (
 /obj/structure/holosign/barrier/engineering,
 /obj/effect/mapping_helpers/turfs/damage,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -76111,6 +76227,14 @@
 	icon_state = "white"
 	},
 /area/toxins/launch)
+"mWJ" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "mWP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -76985,6 +77109,10 @@
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/warning_stripes/northwest,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "nhF" = (
@@ -77526,6 +77654,14 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
+"nod" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/crew_quarters/locker)
 "nof" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/writing,
@@ -79462,7 +79598,9 @@
 	},
 /area/security/evidence)
 "nJv" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
@@ -83453,7 +83591,9 @@
 	},
 /area/hallway/primary/central/south)
 "oFL" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/arcade,
 /area/maintenance/starboard)
@@ -86149,6 +86289,9 @@
 /obj/item/twohanded/required/kirbyplants{
 	pixel_y = 12
 	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -86570,7 +86713,9 @@
 	},
 /area/engineering/hardsuitstorage)
 "prR" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/starboard)
@@ -86601,7 +86746,9 @@
 /area/engineering/supermatter)
 "psd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/wooden,
+/obj/structure/chair/stool/wooden{
+	dir = 1
+	},
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -88509,6 +88656,12 @@
 /obj/structure/closet/walllocker/emerglocker/directional/south,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
+"pMv" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "pMx" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -89617,6 +89770,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
+"qaa" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutral"
+	},
+/area/crew_quarters/fitness)
 "qac" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
@@ -94237,7 +94399,9 @@
 	pixel_y = 26
 	},
 /obj/effect/decal/warning_stripes/north,
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "qYR" = (
@@ -95004,6 +95168,10 @@
 /obj/item/stack/sheet/glass{
 	amount = 10
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/simulated/floor/plating,
 /area/teleporter/abandoned)
 "rgY" = (
@@ -95163,6 +95331,10 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -25
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
@@ -95649,6 +95821,16 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/east)
+"ron" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/security/nuke_storage)
 "roo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -98377,7 +98559,9 @@
 /turf/simulated/floor/carpet/purple,
 /area/hallway/secondary/exit)
 "rUr" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "rUu" = (
@@ -101478,6 +101662,9 @@
 /area/security/execution)
 "sDg" = (
 /obj/machinery/vending/autodrobe,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -103574,6 +103761,14 @@
 	icon_state = "neutral"
 	},
 /area/toxins/mixing)
+"tdW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/simulated/floor/plating,
+/area/hallway/secondary/exit/maint)
 "tdX" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -105022,7 +105217,7 @@
 /area/maintenance/asmaint2)
 "tvR" = (
 /obj/structure/chair/stool{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/prisoner,
@@ -107140,7 +107335,9 @@
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
 "tQL" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/plating,
@@ -108737,7 +108934,9 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "uit" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "caution"
@@ -110938,7 +111137,9 @@
 /turf/simulated/floor/plating,
 /area/security/warden)
 "uIy" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/effect/decal/remains/human{
 	layer = 3.5;
 	pixel_y = 8
@@ -116468,7 +116669,9 @@
 	},
 /area/medical/medbay)
 "vTW" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -121787,7 +121990,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/electrical)
@@ -123312,6 +123517,10 @@
 /obj/item/firelock_electronics,
 /obj/item/firealarm_electronics,
 /obj/item/airalarm_electronics,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "xvG" = (
@@ -123896,6 +124105,15 @@
 	icon_state = "neutral"
 	},
 /area/crew_quarters/fitness)
+"xBk" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "yellowcorner"
+	},
+/area/hallway/primary/port)
 "xBo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -124362,7 +124580,9 @@
 	},
 /area/medical/medbay)
 "xFW" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken3"
 	},
@@ -126887,6 +127107,9 @@
 /area/crew_quarters/courtroom)
 "ydT" = (
 /obj/machinery/vending/autodrobe,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "tranquillite"
@@ -145884,7 +146107,7 @@ mac
 tZC
 oEY
 cTi
-twh
+hzW
 hKl
 deL
 ouO
@@ -147698,7 +147921,7 @@ vAN
 dDI
 ghg
 uJd
-dYv
+kDC
 deL
 deL
 deL
@@ -156129,7 +156352,7 @@ kFO
 bxh
 tTD
 vfh
-wtR
+xBk
 bYj
 wNw
 vGf
@@ -156460,7 +156683,7 @@ rUu
 pWT
 iFi
 qqV
-pWT
+kmQ
 bTQ
 dFg
 rNX
@@ -158755,7 +158978,7 @@ vHG
 xut
 aaq
 xwq
-gzR
+hXz
 dxh
 dyq
 dzA
@@ -171791,7 +172014,7 @@ btL
 btL
 gCA
 bOL
-hPQ
+ron
 btL
 btL
 coE
@@ -173177,7 +173400,7 @@ bgy
 hoB
 hIP
 vyk
-ceu
+tdW
 ceu
 lHk
 ucM
@@ -174394,7 +174617,7 @@ evQ
 pwU
 vSD
 vSD
-fcN
+nod
 xDf
 vSD
 jrh
@@ -174650,7 +174873,7 @@ chD
 sod
 ffi
 vSD
-fcN
+kqz
 nSA
 vTW
 vSD
@@ -176212,7 +176435,7 @@ hzS
 yfp
 xZu
 tQL
-nJv
+dPs
 pCL
 yfp
 xWh
@@ -179297,7 +179520,7 @@ xBc
 fgz
 qEC
 hUP
-rUr
+pMv
 rOm
 rOm
 xZu
@@ -180322,7 +180545,7 @@ tzt
 cQh
 mCf
 msG
-wkE
+qaa
 qEC
 oip
 yfp
@@ -182819,7 +183042,7 @@ qbW
 aru
 djZ
 dXG
-dCj
+mWJ
 tvR
 fgv
 jwd

--- a/_maps/map_files/Delta/submaps/clown_mime_gambit.dmm
+++ b/_maps/map_files/Delta/submaps/clown_mime_gambit.dmm
@@ -394,6 +394,9 @@
 /area/mimeoffice)
 "R" = (
 /obj/machinery/vending/autodrobe,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "tranquillite"
@@ -423,6 +426,9 @@
 /area/template_noop)
 "X" = (
 /obj/machinery/vending/autodrobe,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},

--- a/_maps/map_files/Delta/submaps/dorm_maints_near_toilet.dmm
+++ b/_maps/map_files/Delta/submaps/dorm_maints_near_toilet.dmm
@@ -666,6 +666,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},

--- a/_maps/map_files/Delta/submaps/old_sm_room.dmm
+++ b/_maps/map_files/Delta/submaps/old_sm_room.dmm
@@ -34,6 +34,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/template_noop)
+"aA" = (
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/plating,
+/area/template_noop)
 "aM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing,
@@ -462,6 +468,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase/random/fiction,
 /turf/simulated/floor/wood/dark,
+/area/template_noop)
+"kf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/template_noop)
 "kl" = (
 /obj/structure/table/wood,
@@ -1007,6 +1023,10 @@
 	pixel_y = 9
 	},
 /obj/effect/spawner/random_spawners/blood_5,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/simulated/floor/wood,
 /area/template_noop)
 "vU" = (
@@ -2324,7 +2344,7 @@ tB
 tB
 tB
 kt
-Qc
+aA
 MU
 pp
 OJ
@@ -3275,7 +3295,7 @@ iv
 cI
 iR
 ZT
-pg
+kf
 kt
 tB
 tB

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -209,7 +209,9 @@
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "acr" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/trading)
 "acu" = (
@@ -3107,7 +3109,9 @@
 	},
 /area/security/main)
 "anP" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "anT" = (
@@ -4896,8 +4900,10 @@
 	},
 /area/security/securearmory)
 "att" = (
-/obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "atu" = (
@@ -5412,7 +5418,9 @@
 	},
 /area/security/permabrig)
 "auZ" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "ava" = (
@@ -6440,7 +6448,9 @@
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "aya" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -7248,6 +7258,10 @@
 /area/magistrateoffice)
 "aAJ" = (
 /obj/structure/chair/comfy/red,
+/obj/machinery/firealarm{
+	name = "north fire alarm";
+	pixel_y = 24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "escape"
@@ -7530,7 +7544,9 @@
 	},
 /area/security/permabrig)
 "aBP" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -8481,7 +8497,9 @@
 	},
 /area/security/medbay)
 "aFw" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -9239,7 +9257,9 @@
 	},
 /area/security/hos)
 "aIn" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -11605,9 +11625,11 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
 "aSe" = (
-/obj/structure/chair/stool,
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/chair/stool{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -11912,7 +11934,9 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/dorms)
 "aTF" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
@@ -12132,7 +12156,9 @@
 /turf/simulated/wall,
 /area/crew_quarters/toilet)
 "aUT" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -12265,7 +12291,9 @@
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "aVI" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/landmark/start/chemist,
 /turf/simulated/floor/plasteel,
@@ -12406,6 +12434,11 @@
 	pixel_y = -8
 	},
 /obj/structure/closet/crate/vault,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east fire alarm";
+	pixel_x = 26
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "vault"
@@ -12516,7 +12549,9 @@
 	},
 /area/medical/morgue)
 "aWJ" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "caution"
@@ -13662,9 +13697,11 @@
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "bbt" = (
-/obj/structure/chair/stool,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/chair/stool{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -16141,7 +16178,9 @@
 	},
 /area/security/prison/cell_block/A)
 "bke" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "bkh" = (
@@ -17626,7 +17665,9 @@
 	},
 /area/chapel/main)
 "bqd" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "chapel"
@@ -17785,7 +17826,9 @@
 	},
 /area/hallway/primary/central/nw)
 "bqL" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "bqM" = (
@@ -17952,7 +17995,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "brB" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "chapel"
 	},
@@ -18659,7 +18704,9 @@
 	},
 /area/security/detectives_office)
 "buA" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "chapel"
@@ -19678,7 +19725,9 @@
 	},
 /area/hallway/secondary/exit)
 "bzo" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "bzp" = (
@@ -21031,7 +21080,9 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/port)
 "bFN" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -21041,7 +21092,9 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "bFP" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/start/civilian,
 /turf/simulated/floor/carpet/arcade,
@@ -22371,7 +22424,9 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "bKT" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -27186,7 +27241,9 @@
 /turf/simulated/floor/glass/reinforced,
 /area/crew_quarters/hor)
 "cbq" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -27314,7 +27371,9 @@
 	},
 /area/crew_quarters/dorms)
 "cbU" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -28954,7 +29013,9 @@
 	},
 /area/medical/cmo)
 "chs" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -29144,7 +29205,9 @@
 	},
 /area/crew_quarters/hor)
 "chR" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -29865,7 +29928,9 @@
 	},
 /area/medical/medbay2)
 "ckB" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/effect/landmark/start/doctor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -29933,6 +29998,10 @@
 /obj/item/storage/box/mousetraps,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -31316,12 +31385,11 @@
 	},
 /area/hallway/primary/aft)
 "cqY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/chair/stool{
+	dir = 8
 	},
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/dorms)
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "cra" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
@@ -33747,7 +33815,9 @@
 /area/maintenance/server)
 "cAe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
@@ -35730,7 +35800,9 @@
 	},
 /area/chapel/office)
 "cIr" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/item/toy/figure/chemist,
 /turf/simulated/floor/plating,
 /area/maintenance/genetics)
@@ -38587,7 +38659,9 @@
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "cSN" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cSP" = (
@@ -38793,6 +38867,11 @@
 /area/toxins/xenobiology)
 "cTN" = (
 /obj/machinery/papershredder,
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south fire alarm";
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood/dark,
 /area/crew_quarters/chief)
 "cTO" = (
@@ -39012,10 +39091,6 @@
 	},
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/green,
@@ -47171,7 +47246,9 @@
 /area/maintenance/xenozoo)
 "ehb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -48054,6 +48131,19 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
+"eAH" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitegreencorner"
+	},
+/area/crew_quarters/sleep)
 "eAQ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -48891,7 +48981,9 @@
 "eSv" = (
 /obj/effect/decal/cleanable/dust,
 /obj/item/trash/spacetwinkie,
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -50159,7 +50251,9 @@
 	},
 /area/toxins/mixing)
 "fwz" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -50863,7 +50957,9 @@
 	},
 /area/maintenance/electrical)
 "fMP" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/effect/landmark/start/detective,
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -53451,7 +53547,9 @@
 /turf/simulated/floor/plating,
 /area/security/processing)
 "gTk" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -55502,6 +55600,13 @@
 	icon_state = "green"
 	},
 /area/hallway/secondary/garden)
+"hQO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "hQZ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -55700,6 +55805,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "hUq" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south fire alarm";
+	pixel_y = -24
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "hUt" = (
@@ -55825,7 +55935,9 @@
 /area/civilian/vacantoffice)
 "hYr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/trading)
 "hYx" = (
@@ -57559,6 +57671,10 @@
 /obj/item/poster/random_contraband,
 /obj/structure/sign/poster/random{
 	pixel_y = 32
+	},
+/obj/machinery/firealarm{
+	name = "north fire alarm";
+	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
@@ -60020,6 +60136,11 @@
 "jSu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/port_gen/pacman,
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west fire alarm";
+	pixel_x = -24
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "jSz" = (
@@ -60261,6 +60382,11 @@
 "jXL" = (
 /obj/vehicle/ridden/janicart,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west fire alarm";
+	pixel_x = -24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -60513,6 +60639,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
+"kdG" = (
+/obj/effect/spawner/random_spawners/fungus_30,
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west fire alarm";
+	pixel_x = -24
+	},
+/turf/simulated/wall,
+/area/maintenance/engineering)
 "key" = (
 /obj/item/storage/box/large{
 	pixel_x = 9;
@@ -62857,6 +62992,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
+"ldn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "ldz" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
@@ -63569,7 +63711,9 @@
 	},
 /area/quartermaster/office)
 "ltz" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -65993,7 +66137,9 @@
 	},
 /area/crew_quarters/chief)
 "muw" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken3"
 	},
@@ -66625,7 +66771,9 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "mJw" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/effect/landmark/start/botanist,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -68413,6 +68561,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"nAP" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west fire alarm";
+	pixel_x = -24
+	},
+/turf/simulated/wall,
+/area/maintenance/engineering)
 "nBc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -73111,7 +73267,9 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "pGN" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -77375,7 +77533,9 @@
 /turf/simulated/floor/plasteel/airless/indestructible,
 /area/toxins/test_area)
 "rwz" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/landmark/start/chemist,
 /turf/simulated/floor/plasteel,
@@ -78307,7 +78467,9 @@
 /turf/simulated/floor/grass,
 /area/hallway/primary/port)
 "rRj" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
@@ -79278,7 +79440,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "sqH" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/item/shard{
 	icon_state = "medium";
 	pixel_x = -7;
@@ -79639,7 +79803,9 @@
 /turf/space,
 /area/solar/port)
 "szV" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "chapel"
@@ -81249,7 +81415,9 @@
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "thz" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -81749,10 +81917,6 @@
 "trW" = (
 /obj/machinery/computer/atmos_alert,
 /obj/machinery/light,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/simulated/floor/wood/dark,
 /area/crew_quarters/chief)
 "trZ" = (
@@ -82015,7 +82179,9 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
 "twj" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -82988,6 +83154,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west fire alarm";
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -86366,7 +86537,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -89994,6 +90167,11 @@
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
 /obj/structure/table,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east fire alarm";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "wPy" = (
@@ -90937,6 +91115,11 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south fire alarm";
+	pixel_y = -24
+	},
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "xkV" = (
@@ -91814,6 +91997,11 @@
 "xEV" = (
 /obj/effect/decal/warning_stripes/southeast,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east fire alarm";
+	pixel_x = 24
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/xenozoo)
 "xEX" = (
@@ -116703,8 +116891,8 @@ uTI
 uTI
 cLi
 ttt
-tcn
-cLi
+kdG
+nAP
 wFK
 cOc
 cLi
@@ -122534,7 +122722,7 @@ aHT
 aMj
 aLP
 aNc
-aNc
+eAH
 caZ
 aNT
 aQS
@@ -128450,7 +128638,7 @@ cbT
 lYa
 aWP
 aZA
-cqY
+bbt
 cwT
 aOI
 aGY
@@ -130229,7 +130417,7 @@ aCh
 atr
 ava
 awD
-att
+hQO
 awl
 lkw
 lkw
@@ -130485,7 +130673,7 @@ aCh
 awl
 bbd
 auZ
-att
+ldn
 aye
 awl
 sHt
@@ -130588,7 +130776,7 @@ csL
 lkI
 gPr
 gbG
-cIl
+cqY
 dgT
 ssX
 vhY

--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -741,6 +741,12 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/zone3)
+"amT" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/turf/simulated/floor/indestructible/snow,
+/area/ninja/outside)
 "amV" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/indestructible/vox{
@@ -1346,6 +1352,15 @@
 /obj/structure/shuttle/engine/huge,
 /turf/space,
 /area/space)
+"aDx" = (
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/turf/simulated/floor/beach/sand{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "asteroid"
+	},
+/area/centcom/evac)
 "aDQ" = (
 /obj/effect/turf_decal{
 	dir = 8;
@@ -4112,7 +4127,9 @@
 	},
 /area/centcom/jail)
 "bYb" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /turf/simulated/floor/indestructible/snow,
 /area/ninja/outside)
 "bYi" = (
@@ -4654,18 +4671,22 @@
 /area/syndicate_mothership/jail)
 "ckt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /turf/simulated/floor/wood{
 	icon_state = "fancy-wood-oak"
 	},
 /area/syndicate_mothership)
 "ckC" = (
-/obj/structure/chair/stool,
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
 	},
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
+	},
+/obj/structure/chair/stool{
+	dir = 4
 	},
 /turf/simulated/floor/indestructible/asteroid,
 /area/ninja/outside)
@@ -6900,12 +6921,14 @@
 	},
 /area/centcom/specops)
 "dov" = (
-/obj/structure/chair/stool,
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
 	},
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
+	},
+/obj/structure/chair/stool{
+	dir = 1
 	},
 /turf/simulated/floor/indestructible/asteroid,
 /area/ninja/outside)
@@ -7248,7 +7271,9 @@
 	},
 /area/syndicate_mothership/infteam)
 "dwJ" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /turf/simulated/floor/grass,
 /area/centcom/evac)
 "dxk" = (
@@ -7611,6 +7636,13 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"dDW" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/obj/effect/landmark/spawner/syndie,
+/turf/simulated/floor/carpet/black,
+/area/syndicate_mothership)
 "dDZ" = (
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_x = -32
@@ -14841,6 +14873,12 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/trade/sol)
+"hfk" = (
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/centcom/evac)
 "hfl" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -15133,6 +15171,12 @@
 	icon_state = "darkredaltstrip"
 	},
 /area/centcom/jail)
+"hpI" = (
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/centcom/zone1)
 "hqm" = (
 /obj/effect/turf_decal/tile{
 	alpha = 128;
@@ -16042,7 +16086,9 @@
 	},
 /area/centcom/specops)
 "hOr" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /turf/simulated/floor/beach/sand{
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "asteroid"
@@ -19850,7 +19896,9 @@
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
 "jEu" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/centcom/zone1)
 "jEv" = (
@@ -21354,6 +21402,12 @@
 /obj/effect/turf_decal/stripes/gold,
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership)
+"klF" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/syndicate_mothership/elite_squad)
 "kms" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/flashlight/lamp/green,
@@ -23470,7 +23524,9 @@
 /turf/simulated/floor/beach/sand,
 /area/centcom/evac)
 "ljs" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -23733,14 +23789,8 @@
 	},
 /area/shuttle/ninja)
 "lrP" = (
-/obj/structure/chair/stool/bar{
-	icon = 'icons/obj/lighting.dmi';
-	icon_state = "lantern-on";
-	light_color = "#FFBF00";
-	light_range = 6;
-	name = "lantern"
-	},
 /obj/structure/flora/ausbushes/sparsegrass,
+/obj/item/flashlight/lantern,
 /turf/simulated/floor/grass,
 /area/centcom/evac)
 "lsd" = (
@@ -24412,13 +24462,7 @@
 "lEY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/genericbush,
-/obj/structure/chair/stool/bar{
-	icon = 'icons/obj/lighting.dmi';
-	icon_state = "lantern-on";
-	light_color = "#FFBF00";
-	light_range = 6;
-	name = "lantern"
-	},
+/obj/item/flashlight/lantern,
 /turf/simulated/floor/grass,
 /area/centcom/evac)
 "lFm" = (
@@ -25036,7 +25080,9 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/bridge)
 "lWc" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/effect/landmark/spawner/syndie,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -30
@@ -25527,7 +25573,9 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/nt_droppod)
 "mgd" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/elite_squad)
 "mgC" = (
@@ -25705,7 +25753,9 @@
 	},
 /area/wizard_station)
 "mle" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -25721,13 +25771,7 @@
 	},
 /area/centcom/evac)
 "mlk" = (
-/obj/structure/chair/stool/bar{
-	icon = 'icons/obj/lighting.dmi';
-	icon_state = "lantern-on";
-	light_color = "#FFBF00";
-	light_range = 6;
-	name = "lantern"
-	},
+/obj/item/flashlight/lantern,
 /turf/simulated/floor/grass,
 /area/centcom/evac)
 "mll" = (
@@ -29985,6 +30029,15 @@
 	icon_state = "fancy-wood-oak"
 	},
 /area/ninja/outpost)
+"nYp" = (
+/obj/effect/landmark/spawner/prisonsecuritywarp,
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/centcom/jail)
 "nYu" = (
 /obj/item/flag/syndi,
 /obj/structure/sign/poster/contraband/syndicate_recruitment{
@@ -32863,7 +32916,9 @@
 	},
 /area/centcom/zone3)
 "psE" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /turf/simulated/floor/wood{
 	icon_state = "fancy-wood-oak"
 	},
@@ -33128,11 +33183,13 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/bridge)
 "pxs" = (
-/obj/structure/chair/stool,
 /obj/structure/sign/poster/contraband/punch_shit{
 	pixel_y = 32
 	},
 /obj/effect/landmark/spawner/prisonsecuritywarp,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -33259,7 +33316,9 @@
 "pAV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /turf/simulated/floor/wood{
 	icon_state = "fancy-wood-oak"
 	},
@@ -33635,8 +33694,10 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
 "pMI" = (
-/obj/structure/chair/stool/bar,
 /obj/structure/window/reinforced,
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/centcom/zone1)
 "pMN" = (
@@ -35013,7 +35074,9 @@
 	},
 /area/centcom/specops)
 "qso" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/infteam)
 "qst" = (
@@ -35206,7 +35269,9 @@
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo14"
 	},
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/infteam)
 "qwd" = (
@@ -35291,9 +35356,11 @@
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo15"
 	},
-/obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/black{
 	dir = 4
+	},
+/obj/structure/chair/stool{
+	dir = 1
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/infteam)
@@ -35675,16 +35742,11 @@
 	},
 /area/centcom/specops)
 "qFF" = (
-/obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/chair/stool/bar{
-	icon = 'icons/obj/lighting.dmi';
-	icon_state = "lantern-on";
-	light_color = "#FFBF00";
-	light_range = 6;
-	name = "lantern"
+	dir = 4
 	},
-/turf/simulated/floor/grass,
-/area/centcom/evac)
+/turf/simulated/floor/carpet,
+/area/centcom/zone1)
 "qFV" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -37533,6 +37595,12 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/control)
+"ruT" = (
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/centcom/zone1)
 "rvc" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/decal/warning_stripes/yellow,
@@ -38014,18 +38082,10 @@
 	pixel_x = -4;
 	pixel_y = 5
 	},
-/obj/structure/chair/stool/bar{
-	icon = 'icons/obj/lighting.dmi';
-	icon_state = "lantern-on";
-	light_color = "#FFBF00";
-	light_range = 6;
-	name = "lantern";
-	pixel_x = 4;
-	pixel_y = 6
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
+/obj/item/flashlight/lantern,
 /turf/simulated/floor/carpet/red,
 /area/syndicate_mothership/control)
 "rHo" = (
@@ -39810,7 +39870,9 @@
 	},
 /area/centcom/specops)
 "sAg" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
 /turf/simulated/floor/wood{
 	icon_state = "fancy-wood-oak"
 	},
@@ -40257,6 +40319,12 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/elite_squad)
+"sJr" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/indestructible/snow,
+/area/ninja/outside)
 "sJw" = (
 /obj/machinery/door_control/secure{
 	id = "CC_Armory_Grenade";
@@ -40321,13 +40389,7 @@
 "sKR" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/chair/stool/bar{
-	icon = 'icons/obj/lighting.dmi';
-	icon_state = "lantern-on";
-	light_color = "#FFBF00";
-	light_range = 6;
-	name = "lantern"
-	},
+/obj/item/flashlight/lantern,
 /turf/simulated/floor/grass,
 /area/centcom/evac)
 "sLt" = (
@@ -43301,9 +43363,11 @@
 /turf/simulated/floor/wood,
 /area/centcom/zone1)
 "tWu" = (
-/obj/structure/chair/stool/bar,
 /obj/structure/curtain/open/shower/security{
 	pixel_x = -32
+	},
+/obj/structure/chair/stool/bar{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/centcom/zone1)
@@ -45738,8 +45802,10 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/centcom/specops)
 "vdf" = (
-/obj/structure/chair/stool,
 /obj/effect/landmark/spawner/prisonsecuritywarp,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -64704,7 +64770,7 @@ keo
 wUZ
 xBV
 wWV
-xBV
+dDW
 aHS
 keo
 aae
@@ -64961,7 +65027,7 @@ keo
 wNz
 xBV
 qHC
-xBV
+dDW
 nIK
 keo
 aaf
@@ -76494,9 +76560,9 @@ vPe
 jWb
 kLM
 lDs
-mgd
-mgd
-mgd
+klF
+klF
+klF
 lDs
 kKP
 ofX
@@ -90234,7 +90300,7 @@ ycO
 tdj
 ckC
 ykS
-bYb
+sJr
 ykS
 ykS
 cxG
@@ -90749,7 +90815,7 @@ buy
 cli
 cHT
 cUD
-bYb
+amT
 ykS
 kjK
 dGF
@@ -96604,8 +96670,8 @@ hjL
 tJJ
 pqb
 pxs
-vdf
-vdf
+nYp
+nYp
 hwc
 xmb
 fXZ
@@ -99887,7 +99953,7 @@ onc
 pzx
 sAi
 tWd
-jEu
+ruT
 ihM
 mJH
 hLa
@@ -100144,7 +100210,7 @@ onc
 cVM
 sAi
 gmC
-jEu
+ruT
 ihM
 xAJ
 lQY
@@ -100401,7 +100467,7 @@ onc
 pFP
 sAi
 sRv
-jEu
+ruT
 ihM
 meZ
 aVH
@@ -100915,7 +100981,7 @@ onc
 nBT
 sAi
 gmC
-jEu
+ruT
 ihM
 kAE
 dsj
@@ -101172,7 +101238,7 @@ onc
 uBh
 sAi
 tWd
-jEu
+ruT
 ihM
 hxR
 dsj
@@ -101429,7 +101495,7 @@ onc
 xTi
 sAi
 eCI
-jEu
+ruT
 ihM
 ffO
 aVH
@@ -101686,7 +101752,7 @@ onc
 byB
 sAi
 tWd
-jEu
+ruT
 ihM
 xAJ
 lQY
@@ -101943,7 +102009,7 @@ onc
 cte
 wUF
 gmC
-jEu
+ruT
 ihM
 xYe
 arb
@@ -102185,7 +102251,7 @@ dwJ
 dwJ
 dZA
 fkh
-qFF
+lrP
 dZA
 phM
 skw
@@ -102200,7 +102266,7 @@ onc
 onc
 xHc
 tWd
-jEu
+ruT
 pNo
 ihM
 ihM
@@ -102694,9 +102760,9 @@ gdL
 qwy
 fkh
 phM
-dwJ
-dwJ
-dwJ
+hfk
+hfk
+hfk
 dZA
 phM
 fkh
@@ -103470,7 +103536,7 @@ qsv
 qsv
 gYq
 gpF
-qFF
+lrP
 dZA
 dZA
 skw
@@ -103487,8 +103553,8 @@ onc
 kAE
 tak
 fPG
-saA
-saA
+qFF
+qFF
 kAE
 tak
 hWf
@@ -103719,7 +103785,7 @@ kiX
 fkh
 fkh
 fkh
-qFF
+lrP
 upv
 dZA
 kiX
@@ -103972,7 +104038,7 @@ mVX
 mVX
 wLM
 vgN
-qFF
+lrP
 fkh
 fkh
 vXo
@@ -104251,7 +104317,7 @@ pyu
 oga
 onc
 uNF
-jEu
+ruT
 wUF
 ycL
 aZv
@@ -104508,7 +104574,7 @@ pyu
 rpk
 onc
 tWd
-jEu
+ruT
 wUF
 kAE
 aTZ
@@ -104516,7 +104582,7 @@ bBI
 eNm
 fPG
 ljs
-saA
+hpI
 kAE
 tak
 xSv
@@ -105256,7 +105322,7 @@ mVX
 mVX
 wLM
 rUx
-hOr
+aDx
 fkh
 fkh
 fkh
@@ -105513,7 +105579,7 @@ mVX
 mVX
 wLM
 rUx
-hOr
+aDx
 pHc
 fkh
 fkh
@@ -105770,7 +105836,7 @@ mVX
 mVX
 wLM
 rUx
-hOr
+aDx
 hOr
 hOr
 fkh

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -6781,6 +6781,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"

--- a/_maps/map_files/nova/Lavaland.dmm
+++ b/_maps/map_files/nova/Lavaland.dmm
@@ -2268,6 +2268,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 27
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/mine/cafeteria)
 "nA" = (
@@ -7006,6 +7010,10 @@
 	pixel_y = 9
 	},
 /obj/machinery/vending/cola,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"

--- a/_maps/map_files/nova/nova.dmm
+++ b/_maps/map_files/nova/nova.dmm
@@ -2429,6 +2429,13 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/maintenance/backstage)
+"atW" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dust,
+/turf/simulated/floor/carpet,
+/area/maintenance/casino)
 "atX" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -14391,7 +14398,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "ceo" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -14981,6 +14990,11 @@
 "cjf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west fire alarm";
+	pixel_x = -24
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "cjj" = (
@@ -17099,6 +17113,13 @@
 	icon_state = "purple"
 	},
 /area/hallway/secondary/entry/lounge)
+"czP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "czS" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -22440,7 +22461,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "dqo" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/light_construct{
 	dir = 4
@@ -22582,7 +22605,9 @@
 	},
 /area/crew_quarters/chief)
 "drw" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -24801,6 +24826,12 @@
 	icon_state = "white"
 	},
 /area/medical/virology/lab)
+"dJj" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/casino)
 "dJk" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -26382,6 +26413,10 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /obj/item/reagent_containers/food/drinks/flask/detflask,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "dWp" = (
@@ -26411,6 +26446,11 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/effect/decal/warning_stripes/northeast,
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.25;
+	pixel_x = 24
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "dWz" = (
@@ -27701,6 +27741,14 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"egn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/banya)
 "ego" = (
 /obj/machinery/disposal,
 /obj/effect/decal/warning_stripes/red,
@@ -31452,6 +31500,10 @@
 "eIR" = (
 /obj/structure/railing/corner,
 /obj/item/twohanded/required/kirbyplants,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -33722,8 +33774,10 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "fbd" = (
-/obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "fbg" = (
@@ -34609,7 +34663,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "fhT" = (
@@ -39219,9 +39275,7 @@
 /turf/simulated/wall,
 /area/quartermaster/storage)
 "fSj" = (
-/obj/structure/chair/stool/bar/dark{
-	dir = 1
-	},
+/obj/structure/chair/stool/bar/dark,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -42501,6 +42555,11 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west fire alarm";
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/maintenance/starboardaux)
@@ -47231,9 +47290,7 @@
 	},
 /area/engineering/gravitygenerator)
 "hdm" = (
-/obj/structure/chair/stool/bar/dark{
-	dir = 1
-	},
+/obj/structure/chair/stool/bar/dark,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -49688,7 +49745,9 @@
 /area/security/processing)
 "hwL" = (
 /obj/effect/decal/warning_stripes/south,
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/effect/landmark/start/chemist,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52628,6 +52687,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "escape"
@@ -57690,7 +57753,9 @@
 /turf/simulated/floor/redgrid,
 /area/aisat/aihallway)
 "iJK" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
@@ -60747,7 +60812,9 @@
 /area/engineering/break_room)
 "jhA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -62820,6 +62887,11 @@
 "jwc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west fire alarm";
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -67653,7 +67725,9 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "kjs" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken6"
@@ -69830,7 +69904,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "kBH" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -70413,6 +70489,11 @@
 	pixel_y = 2
 	},
 /obj/item/stock_parts/cell,
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west fire alarm";
+	pixel_x = -24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whiteblue"
@@ -84423,6 +84504,13 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/maintenance/gambling_den)
+"mOp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "mOA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -97878,6 +97966,11 @@
 "oQD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.25;
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/xenozoo)
 "oQF" = (
@@ -98711,6 +98804,18 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
+"oWo" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/sleep/secondary)
 "oWr" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -101938,7 +102043,9 @@
 	},
 /area/crew_quarters/toilet)
 "pvx" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -105083,6 +105190,9 @@
 /obj/machinery/camera{
 	c_tag = "South-East Solars"
 	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "pSY" = (
@@ -107297,6 +107407,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"qii" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "floorgrime"
+	},
+/area/maintenance/fpmaint)
 "qit" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -109001,7 +109119,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/effect/landmark/start/civilian,
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
@@ -113274,7 +113394,9 @@
 /area/crew_quarters/bar/atrium)
 "rdT" = (
 /obj/effect/decal/warning_stripes/east,
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/effect/landmark/start/chemist,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -116445,7 +116567,9 @@
 	},
 /area/medical/medbay)
 "rAF" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /obj/effect/landmark/start/civilian,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -118950,6 +119074,10 @@
 	},
 /area/security/main)
 "rTe" = (
+/obj/machinery/firealarm{
+	name = "north fire alarm";
+	pixel_y = 24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -123295,7 +123423,9 @@
 /turf/simulated/floor/glass/reinforced,
 /area/maintenance/starboardaux)
 "sAp" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
 "sAt" = (
@@ -124388,6 +124518,9 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/warning_stripes/northwest,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "sIt" = (
@@ -137672,7 +137805,9 @@
 	dir = 8
 	},
 /obj/effect/spawner/random_spawners/blood_5,
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "uFu" = (
@@ -138014,7 +138149,9 @@
 	},
 /area/toxins/lab)
 "uIl" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -138611,7 +138748,9 @@
 	},
 /area/maintenance/trading)
 "uMA" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/atm{
 	pixel_y = 32
@@ -140216,9 +140355,7 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/structure/chair/stool{
-	dir = 1
-	},
+/obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -147848,8 +147985,10 @@
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat_interior)
 "whH" = (
-/obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -148853,7 +148992,9 @@
 /turf/simulated/wall,
 /area/medical/ward)
 "woh" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/maintenance/casino)
 "woj" = (
@@ -150251,7 +150392,9 @@
 /turf/simulated/floor/plating,
 /area/medical/virology/lab)
 "wyl" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -150698,7 +150841,9 @@
 	},
 /area/hallway/primary/fore)
 "wBK" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/green,
 /area/maintenance/casino)
 "wBO" = (
@@ -152624,7 +152769,9 @@
 /turf/simulated/floor/wood,
 /area/blueshield)
 "wRo" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -159901,9 +160048,7 @@
 	},
 /area/quartermaster/miningdock)
 "xWh" = (
-/obj/structure/chair/stool/bar/dark{
-	dir = 1
-	},
+/obj/structure/chair/stool/bar/dark,
 /turf/simulated/floor/carpet/black,
 /area/crew_quarters/bar/atrium)
 "xWl" = (
@@ -161423,6 +161568,13 @@
 	},
 /turf/simulated/floor/glass,
 /area/hallway/secondary/exit)
+"yfY" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/casino)
 "ygc" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -183614,7 +183766,7 @@ kTP
 fVK
 uCU
 ulX
-kAF
+egn
 cRo
 gCK
 ulX
@@ -188261,7 +188413,7 @@ cpz
 eWC
 bDc
 wLy
-kIr
+yfY
 hUD
 jLu
 wsu
@@ -188515,7 +188667,7 @@ qiO
 eiX
 toQ
 oMd
-qLl
+dJj
 bDc
 ecg
 iFo
@@ -248583,7 +248735,7 @@ gtU
 pve
 eOO
 pHL
-ceo
+qii
 dLa
 avu
 csW
@@ -248840,7 +248992,7 @@ wIv
 aTU
 mYa
 hHt
-fbd
+czP
 dZS
 eeg
 jEj
@@ -249096,7 +249248,7 @@ yev
 iaU
 pve
 ceo
-fbd
+mOp
 qfw
 dLa
 eeg
@@ -255589,7 +255741,7 @@ mze
 wsu
 wsu
 aRF
-pwp
+atW
 pwp
 eAR
 mRf
@@ -255846,7 +255998,7 @@ dJv
 oYT
 wsu
 rkO
-pwp
+atW
 xjn
 xzt
 qHF
@@ -256103,7 +256255,7 @@ dqk
 rHn
 wsu
 aXC
-qLl
+dJj
 ezd
 xzt
 qHF
@@ -268444,7 +268596,7 @@ fJm
 pCO
 ngz
 pTu
-dtS
+oWo
 dtS
 dtS
 dtS

--- a/_maps/map_files/nova/submaps/AbondonedChapel.dmm
+++ b/_maps/map_files/nova/submaps/AbondonedChapel.dmm
@@ -1060,6 +1060,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
+"KA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/rat,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east fire alarm";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/club)
 "La" = (
 /obj/item/storage/toolbox/electrical,
 /obj/item/stack/tape_roll{
@@ -2028,7 +2038,7 @@ rY
 am
 LI
 Bz
-aS
+KA
 Na
 kG
 gO

--- a/_maps/map_files/nova/submaps/AbondonedMed.dmm
+++ b/_maps/map_files/nova/submaps/AbondonedMed.dmm
@@ -253,9 +253,7 @@
 	},
 /area/maintenance/medroom)
 "cP" = (
-/obj/structure/chair/stool/bar{
-	dir = 4
-	},
+/obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -780,7 +778,9 @@
 /area/maintenance/apmaint)
 "hk" = (
 /obj/effect/decal/cleanable/vomit/green,
-/obj/structure/chair/stool/holostool,
+/obj/structure/chair/stool/holostool{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -2206,7 +2206,6 @@
 /turf/template_noop,
 /area/template_noop)
 "vn" = (
-/obj/item/radio/intercom/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_x = -32
@@ -3171,6 +3170,7 @@
 "Ei" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dust,
+/obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plating,
 /area/maintenance/abandonedhangar)
 "Ej" = (
@@ -3564,9 +3564,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "Io" = (
-/obj/structure/chair/stool/bar{
-	dir = 4
-	},
+/obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
@@ -3850,7 +3848,9 @@
 	},
 /area/maintenance/medroom)
 "Ki" = (
-/obj/structure/chair/stool/holostool,
+/obj/structure/chair/stool/holostool{
+	dir = 8
+	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -4992,9 +4992,7 @@
 	},
 /area/maintenance/kitchen)
 "WX" = (
-/obj/structure/chair/stool/bar{
-	dir = 4
-	},
+/obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"


### PR DESCRIPTION

## Что этот ПР делает

Переворачивает стулья, чтобы они смотрели на стол / были повёрнуты от стены.
Убирает фальшивые стулья с ЦК на замену нормальных ламп.
Добавляет air alarm на Нове уборщику.
Добавляет fire alarm во все комнаты, где была air alarm, но не стояло fire alarm.

## Почему это хорошо для игры

Теперь при посадки на стул, персонаж не смотрит в душу игрока.

## Демонстрация изменений

<details><summary>Изображения и видео</summary>
Пример стульев
<img width="1020" height="332" alt="Пример стульев" src="https://github.com/user-attachments/assets/dda2e6ae-843f-486c-8914-b9ee1f79a9ce" />
<p>

</p>
</details>

## Список изменений
:cl:
map: Убраны стулья, которые маскировались под лампы.
map: Изменено направление многих стульев, чтобы они более красиво выглядели.
map: Добавлены отсутствующие air alarm на Нове.
map: Добавлены отсутствующие fire alarm на Нове, Кибераиде, Дельте.
/:cl:
