### PR TITLE
Удаление стерелизина, замена на космоцилин где использовался

### DIFF
--- a/code/modules/economy/quests/reagents_quests.dm
+++ b/code/modules/economy/quests/reagents_quests.dm
@@ -17,7 +17,7 @@
 			"synthflesh" = list("volume" = 30, "reward" = 80),
 			"facid" = list("volume" = 15, "reward" = 100),
 			"minttoxin" = list("volume" = 15, "reward" = 100),
-			"sterilizine" = list("volume" = 30, "reward" = 100),
+			"antihol" = list("volume" = 30, "reward" = 100),
 			"fomepizole" = list("volume" = 20, "reward" = 125),
 			"mitocholide" = list("volume" = 30, "reward" = 150),
 			"pen_acid" = list("volume" = 30, "reward" = 175),

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -63,7 +63,7 @@
 /obj/item/seeds/kudzu/on_chem_reaction(datum/reagents/S)
 	var/list/temp_mut_list = list()
 
-	if(S.has_reagent("sterilizine", 5))
+	if(S.has_reagent("spaceacillin", 5))
 		for(var/datum/spacevine_mutation/SM in mutations)
 			if(SM.quality == NEGATIVE)
 				temp_mut_list += SM

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -28,25 +28,6 @@
 	var/update_flags = STATUS_UPDATE_HEALTH
 	return ..() | update_flags
 
-/datum/reagent/medicine/sterilizine
-	name = "Стерилизин"
-	id = "sterilizine"
-	description = "Стерилизует раны для подготовки к операции."
-	reagent_state = LIQUID
-	color = "#C8A5DC" // rgb: 200, 165, 220
-	taste_description = "антисептика"
-
-	//makes you squeaky clean
-/datum/reagent/medicine/sterilizine/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume)
-	if(method == REAGENT_TOUCH)
-		M.germ_level -= min(volume*20, M.germ_level)
-
-/datum/reagent/medicine/sterilizine/reaction_obj(obj/O, volume)
-	O.germ_level -= min(volume*20, O.germ_level)
-
-/datum/reagent/medicine/sterilizine/reaction_turf(turf/T, volume)
-	T.germ_level -= min(volume*20, T.germ_level)
-
 /datum/reagent/medicine/synaptizine
 	name = "Синаптизин"
 	id = "synaptizine"

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -36,13 +36,6 @@
 	required_reagents = list("carpotoxin" = 1, "spaceacillin" = 1, "copper" = 1)
 	result_amount = 3
 
-/datum/chemical_reaction/sterilizine
-	name = "Sterilizine"
-	id = "sterilizine"
-	result = "sterilizine"
-	required_reagents = list("antihol" = 2, "chlorine" = 1)
-	result_amount = 3
-
 /datum/chemical_reaction/charcoal
 	name = "Charcoal"
 	id = "charcoal"
@@ -116,7 +109,7 @@
 	name = "Нейроматин"
 	id = "neuromatin"
 	result = "neuromatin"
-	required_reagents = list("sterilizine" = 3, "mannitol" = 5, "mitocholide" = 1, "atropine" = 1)
+	required_reagents = list("spaceacillin" = 3, "mannitol" = 5, "mitocholide" = 1, "atropine" = 1)
 	result_amount = 10
 	min_temp = 350 //K
 
@@ -323,7 +316,7 @@
 	name = "Degreaser"
 	id = "degreaser"
 	result = "degreaser"
-	required_reagents = list("oil" = 1, "sterilizine" = 1)
+	required_reagents = list("oil" = 1, "spaceacillin" = 1)
 	result_amount = 2
 
 /datum/chemical_reaction/liquid_solder


### PR DESCRIPTION

## Что этот ПР делает
Удаляет стерелизин, заменяет там где он использовался на космоцилин
## Почему это хорошо для игры
Стерелизин бесполезен. Он нигде кроме крафтов не используется. В медицинских целях он во всем проигрывает космоцилину
## Список изменений
:cl:
del: Удаление стерелизина
tweak: Крафты со стерелизином заменены на космоцилин
/:cl:
