### PR TITLE
Deleting tcomms from malta

### DIFF
--- a/_maps/map_files/event/Station/coldcolony.dmm
+++ b/_maps/map_files/event/Station/coldcolony.dmm
@@ -623,7 +623,12 @@
 /turf/simulated/floor/wood/fancy/birch,
 /area/coldcolony/malta/bridge/vip)
 "alA" = (
-/obj/machinery/tcomms/core/station,
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/stack/cable_coil/cyan{
+	amount = 2
+	},
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
## Что этот ПР делает

С Мальты удалено ядро телекоммуникаций.

## Почему это хорошо для игры

Для улучшения атмосферы c Мальты удалена раундстарт связь, но ее крайне легко восстановить, если то требуется.

## Демонстрация изменений

<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений

:cl:
map: С Мальты удалено ядро телекоммуникаций. 
/:cl:
