### PR TITLE
Добавление кд на выстрелы в упор

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -115,6 +115,9 @@
 
 	/// Responsible for the range of the throwing back when shooting at point blank range
 	var/pb_knockback = 0
+	/// Point blank shot cooldown
+	var/pb_cooldown_duration = 3 SECONDS
+	COOLDOWN_DECLARE(pb_cooldown)
 	/// Shots counter
 	var/shots_counter = 0
 
@@ -243,6 +246,9 @@
 	playsound(user, 'sound/weapons/empty.ogg', 100, TRUE)
 
 /obj/item/gun/proc/shoot_live_shot(mob/living/user, atom/target, pointblank = FALSE, message = TRUE)
+	if(pointblank && !COOLDOWN_FINISHED(src, pb_cooldown))
+		pointblank = FALSE
+
 	do_recoil(user, target)
 
 	if(!chambered)
@@ -262,6 +268,7 @@
 		if(message)
 			if(pointblank)
 				user.visible_message(span_danger("[user] стреля[PLUR_ET_YUT(user)] из [declent_ru(GENITIVE)] в упор в [target]!"), span_danger("Вы стреляете из [declent_ru(GENITIVE)] в упор в [target]!"), span_italics("Вы слышите [fire_sound_text]!"), projectile_message = TRUE)
+				COOLDOWN_START(src, pb_cooldown, pb_cooldown_duration)
 				if(pb_knockback > 0 && isliving(target))
 					var/mob/living/living_target = target
 					if(!(living_target.move_resist > MOVE_FORCE_NORMAL)) //no knockbacking prince of terror or somethin

--- a/code/modules/projectiles/guns/ballistic/_shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/_shotgun.dm
@@ -14,7 +14,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot
 	fire_sound = 'sound/weapons/gunshots/1shotgun_old.ogg'
 	weapon_weight = WEAPON_HEAVY
-	pb_knockback = 2
+	pb_knockback = 1
 	COOLDOWN_DECLARE(last_pump)	// to prevent spammage
 	accuracy = GUN_ACCURACY_SHOTGUN
 	recoil = GUN_RECOIL_HIGH


### PR DESCRIPTION

## Что этот ПР делает
1. Добавляет кд в 3 секунды для выстрелов в упор (_тут выстрел в упор - механ откидывания, не сам выстрел_)
2. Снижение откидывания с 2 тайлов до 1 тайла


## Почему это хорошо для игры
Баланс, долгожданный нерф имбы на сб. А откидывание просил гап (_он просил вообще убрать_)


## Список изменений
:cl:
balance: кд на выстрелы в упор в 3 секунды.
/:cl:
