### PR TITLE
Хотфикс бага с выбором скина предметов лежащих на полу

### DIFF
--- a/code/datums/elements/item_skins.dm
+++ b/code/datums/elements/item_skins.dm
@@ -38,6 +38,8 @@
 		return
 	if(item.current_skin) //already exists skin, no reskin allowed
 		return
+	if(!user.is_in_hands(item)) // can not apply skin if item not in hands
+		return
 
 	var/list/skin_options = list()
 	for(var/datum/item_skin_data/skin as anything in item.skins)


### PR DESCRIPTION

## Что этот ПР делает
Предметам можно будет менять скин только если они в руке.

## Почему это хорошо для игры
Репорт: https://discord.com/channels/617003227182792704/1491175383674912950


## Список изменений
:cl:
tweak: Скины на предметы можно поставить только если предмет в руках.
/:cl:
