### PR TITLE
Небольшие улучшения медбея часть два

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -27076,8 +27076,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/closet/secure_closet/paramedic,
-/obj/item/defibrillator/loaded,
-/obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -40938,7 +40936,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "eMN" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whiteblue"
@@ -68860,10 +68858,10 @@
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis,
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/nitrogenis,
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/nitrogenis,
-/obj/item/tank/internals/emergency_oxygen/engi/empty,
-/obj/item/tank/internals/emergency_oxygen/engi/empty,
 /obj/machinery/iv_drip,
 /obj/structure/closet/crate/secure/blood/mixed,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/simulated/floor/plasteel{
 	dir = 0;
 	icon_state = "whitered"
@@ -76230,8 +76228,8 @@
 	},
 /area/maintenance/fpmaint)
 "mVw" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -126635,14 +126633,14 @@
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "xYy" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/machinery/light,
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
 /area/medical/cmostore)
 "xYM" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue"

--- a/_maps/map_files/RandomRuins/SpaceRuins/USSP_gorky17.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/USSP_gorky17.dmm
@@ -2950,7 +2950,7 @@
 	name = "Hardsuit storage";
 	req_access = list(125)
 	},
-/obj/machinery/suit_storage_unit/cmo/sec_storage{
+/obj/machinery/suit_storage_unit/medical{
 	name = "Gorky17 medical suit storage unit";
 	req_access = list(122,123,124,125,126)
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/USSP_gorky17_collapsed.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/USSP_gorky17_collapsed.dmm
@@ -3614,7 +3614,7 @@
 	name = "Hardsuit storage";
 	req_access = list(122)
 	},
-/obj/machinery/suit_storage_unit/cmo/sec_storage{
+/obj/machinery/suit_storage_unit/medical{
 	name = "Gorky17 medical suit storage unit";
 	req_access = list(122,123,124,125,126)
 	},

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -24823,8 +24823,6 @@
 	name = "east fire alarm";
 	pixel_x = 24
 	},
-/obj/item/defibrillator/loaded,
-/obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitebluecorner"
@@ -76438,13 +76436,13 @@
 	},
 /area/medical/cryo)
 "qYs" = (
-/obj/item/tank/internals/emergency_oxygen/engi/empty,
-/obj/item/tank/internals/emergency_oxygen/engi/empty,
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/nitrogenis,
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/nitrogenis,
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis,
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis,
 /obj/structure/closet/crate/secure/blood/mixed,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue"

--- a/_maps/map_files/de_kerberos_2/de_kerberos_2.dmm
+++ b/_maps/map_files/de_kerberos_2/de_kerberos_2.dmm
@@ -42304,7 +42304,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "eMN" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whiteblue"
@@ -128707,14 +128707,14 @@
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "xYy" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/machinery/light,
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
 /area/medical/cmostore)
 "xYM" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue"
@@ -129977,8 +129977,8 @@
 	},
 /area/security/visiting_room)
 "ykM" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},

--- a/_maps/map_files/nova/nova.dmm
+++ b/_maps/map_files/nova/nova.dmm
@@ -20700,8 +20700,8 @@
 	},
 /area/tcommsat/chamber)
 "dbW" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -24980,11 +24980,11 @@
 	},
 /area/storage/primary)
 "dKP" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -69702,8 +69702,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/item/tank/internals/emergency_oxygen/engi/empty,
-/obj/item/tank/internals/emergency_oxygen/engi/empty,
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/nitrogenis,
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/nitrogenis,
 /obj/item/reagent_containers/iv_bag/bloodsynthetic/oxygenis,
@@ -69712,6 +69710,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/closet/crate/secure/blood/mixed,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -92546,9 +92546,6 @@
 /area/maintenance/secpost)
 "nYG" = (
 /obj/structure/closet/secure_closet/paramedic,
-/obj/item/defibrillator/loaded,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/storage/belt/medical,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whiteblue"
@@ -138378,11 +138375,11 @@
 /turf/simulated/floor/carpet,
 /area/maintenance/casino)
 "uJD" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -140376,9 +140373,9 @@
 	},
 /area/toxins/mixing)
 "uZu" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light,
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -155275,7 +155272,6 @@
 	},
 /area/crew_quarters/sleep/secondary)
 "xmb" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/machinery/firealarm{
 	pixel_y = 25
 	},
@@ -155283,6 +155279,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},

--- a/_maps/map_files/shuttles/admin_hospital.dmm
+++ b/_maps/map_files/shuttles/admin_hospital.dmm
@@ -41,7 +41,7 @@
 	},
 /area/shuttle/administration)
 "av" = (
-/obj/machinery/suit_storage_unit/cmo/sec_storage,
+/obj/machinery/suit_storage_unit/medical,
 /turf/simulated/floor/shuttle{
 	icon = 'icons/turf/floors.dmi';
 	icon_state = "titanium_blue"

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -314,7 +314,6 @@
 	uniform = /obj/item/clothing/under/rank/medical/paramedic
 	head = /obj/item/clothing/head/soft/paramedic
 	belt = /obj/item/storage/belt/medical/filled
-	mask = /obj/item/clothing/mask/cigarette
 	l_ear = /obj/item/radio/headset/headset_med
 	id = /obj/item/card/id/medical
 	l_hand = /obj/item/storage/firstaid/paramed

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -140,22 +140,23 @@
 	req_access = list(ACCESS_MEDICAL)
 
 /obj/machinery/suit_storage_unit/cmo
-	suit_type    = /obj/item/mod/control/pre_equipped/medical
+	name = "CMO suit storage unit"
+	suit_type = /obj/item/mod/control/pre_equipped/rescue
 	storage_type = /obj/item/tank/internals/oxygen
-	mask_type    = /obj/item/clothing/mask/breath
+	mask_type = /obj/item/clothing/mask/breath
 	req_access = list(ACCESS_CMO)
 
 /obj/machinery/suit_storage_unit/qm
 	name = "quartermaster suit storage unit"
-	suit_type    = /obj/item/mod/control/pre_equipped/loader
+	suit_type = /obj/item/mod/control/pre_equipped/loader
 	mask_type    = /obj/item/clothing/mask/breath
 	req_access = list(ACCESS_QM)
 
-//version of the SSU for medbay secondary storage. Includes magboots.
-/obj/machinery/suit_storage_unit/cmo/sec_storage
+/obj/machinery/suit_storage_unit/medical
 	name = "medical suit storage unit"
-	storage_type = null
-	mask_type = /obj/item/clothing/mask/gas
+	suit_type = /obj/item/mod/control/pre_equipped/medical
+	mask_type = /obj/item/clothing/mask/breath
+	req_access = list(ACCESS_MEDICAL)
 
 /obj/machinery/suit_storage_unit/clown
 	name = "clown suit storage unit"

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -293,10 +293,9 @@
 	new /obj/item/reagent_containers/hypospray/autoinjector/salbutamol(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/charcoal(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/traneksam(src)
-	new /obj/item/reagent_containers/food/pill/patch/styptic(src)
-	new	/obj/item/reagent_containers/food/pill/patch/silver_sulf(src)
-	new /obj/item/stack/medical/bruise_pack(src)
-	new /obj/item/stack/medical/ointment(src)
+	new /obj/item/stack/medical/bruise_pack/synthflesh_kit(src)
+	new /obj/item/stack/medical/bruise_pack/synthflesh_kit(src)
+	new /obj/item/stack/medical/suture/advanced(src)
 
 /obj/item/storage/firstaid/paramed/empty/populate_contents()
 	return

--- a/code/game/objects/items/weapons/storage/garment_bag.dm
+++ b/code/game/objects/items/weapons/storage/garment_bag.dm
@@ -283,3 +283,13 @@
 	new /obj/item/clothing/gloves/color/latex/nitrile(src)
 	new /obj/item/clothing/shoes/color/white(src)
 	new /obj/item/clothing/shoes/sandal/white(src)
+
+/obj/item/storage/garmentbag/paramedic/populate_contents()
+	new /obj/item/clothing/head/soft/paramedic(src)
+	new /obj/item/clothing/under/rank/medical/paramedic(src)
+	new /obj/item/clothing/under/rank/medical/paramedic/skirt(src)
+	new /obj/item/clothing/suit/storage/paramedic(src)
+	new	/obj/item/clothing/suit/storage/paramedic_jacket(src)
+	new /obj/item/clothing/gloves/color/latex/nitrile(src)
+	new /obj/item/clothing/shoes/color/black(src)
+	new /obj/item/clothing/mask/surgical(src)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -136,24 +136,14 @@
 	icon_state = "paramed"
 
 /obj/structure/closet/paramedic/populate_contents()
-	new /obj/item/clothing/under/rank/medical/paramedic(src)
-	new /obj/item/clothing/under/rank/medical/paramedic(src)
-	new /obj/item/clothing/under/rank/medical/paramedic/skirt(src)
-	new /obj/item/clothing/under/rank/medical/paramedic/skirt(src)
+	new /obj/item/storage/garmentbag/paramedic(src)
+	new /obj/item/storage/garmentbag/paramedic(src)
 	new /obj/item/radio/headset/headset_med(src)
 	new /obj/item/radio/headset/headset_med(src)
-	new /obj/item/clothing/gloves/color/latex(src)
-	new /obj/item/clothing/gloves/color/latex(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/head/soft/paramedic(src)
-	new /obj/item/clothing/head/soft/paramedic(src)
-	new /obj/item/clothing/suit/storage/paramedic(src)
-	new /obj/item/clothing/suit/storage/paramedic(src)
-	new	/obj/item/clothing/suit/storage/paramedic_jacket(src)
-	new	/obj/item/clothing/suit/storage/paramedic_jacket(src)
 	new /obj/item/tank/internals/emergency_oxygen/engi(src)
 	new /obj/item/tank/internals/emergency_oxygen/engi(src)
+	new /obj/item/clothing/glasses/hud/health(src)
+	new /obj/item/clothing/glasses/hud/health(src)
 
 /obj/structure/closet/librarian
 	name = "librarian wardrobe"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -210,10 +210,13 @@
 	new /obj/item/mod/control/pre_equipped/rescue(src)
 	new /obj/item/mod/control/pre_equipped/rescue(src)
 	new /obj/item/sensor_device(src)
-	new /obj/item/key/ambulance(src)
+	new /obj/item/sensor_device(src)
+	new /obj/item/pinpointer/crew(src)
 	new /obj/item/pinpointer/crew(src)
 	new /obj/item/handheld_defibrillator(src)
-	new /obj/item/tank/jetpack/carbondioxide(src)
+	new /obj/item/handheld_defibrillator(src)
+	new /obj/item/defibrillator/loaded(src)
+	new /obj/item/key/ambulance(src)
 
 /obj/structure/closet/secure_closet/reagents
 	name = "chemical storage closet"


### PR DESCRIPTION

## Что этот ПР делает
Я почистил ящики парамедика, добавил туда что нужно, убрал лишнее. Одежду парамедика сгруппировал в мешок одежды.
Сделал нормальное хранилище мэков для меда, а не наследование от СМОшного. Заменил на картах.
Поменял пустые балоны на полные у бригмедика на всех картах.
Немного улучшил содержимое раундстарт аптечки у парамедика
<img width="504" height="72" alt="image" src="https://github.com/user-attachments/assets/e7665bb5-a257-4c81-84f5-2414e8888678" />
## Почему это хорошо для игры
Небольшие изменения для удобства
## Список изменений
:cl:
add: Добавлен мешок с одеждой парамедика
tweak: Пустые балоны у бригмедика заменены на полные
tweak: МОД СМО теперь rescue, а не простой medical
tweak: Небольшое изменение содержимого аптечки парамедика
map: Удален лишний мусор из парамедской
/:cl:
