### PR TITLE
Neuromatin in "injectors" category, not in "contraband"

### DIFF
--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -50,6 +50,7 @@
 				/obj/item/reagent_containers/syringe/calomel = 8,
 				/obj/item/reagent_containers/syringe/insulin = 8,
 				/obj/item/reagent_containers/syringe/heparin = 8,
+				/obj/item/reagent_containers/hypospray/autoinjector/neuromatin = 3,
 			),
 		),
 		list(
@@ -111,7 +112,6 @@
 	contraband = list(
 		/obj/item/reagent_containers/glass/bottle/sulfonal = 3,
 		/obj/item/reagent_containers/glass/bottle/pancuronium = 3,
-		/obj/item/reagent_containers/hypospray/autoinjector/neuromatin = 3,
 	)
 	armor = list(MELEE = 50, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 0, BIO = 0, FIRE = 100, ACID = 70)
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION

## Что этот ПР делает
Переносит нейроматин из категории "контрабанда" в категорию "инъекторы". Теперь не нужно взламывать вендор, чтобы пересадить человеку мозг.
## Почему это хорошо для игры
Пересадка кринж, но закрывать её за механом контрабанды это такое. Дефицит инъекторов (9 на станцию раундстарт в отличии от 30+ инъекторов эпипена) делает пересадку ненастолько выгодной, как ПОДНЯТЬ В ТАЙМИНГ или клонировать, этого достаточно, чтобы пересадку не абузили. 
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
tweak: Нейроматин теперь в категории "Инъекторы", не "Контрабанда"
/:cl:
