### PR TITLE
Баланс апгрейда сидушки боргов

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1417,7 +1417,7 @@
 	id = "borg_upgrade_mounted_seat"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/mounted_seat
-	req_tech = list(RESEARCH_TREE_ENGINEERING = 4, RESEARCH_TREE_MATERIALS = 4)
+	req_tech = list(RESEARCH_TREE_ENGINEERING = 7, RESEARCH_TREE_MATERIALS = 6, RESEARCH_TREE_MAGNETS = 6)
 	materials = list(MAT_METAL = 80000)
 	construction_time = 12 SECONDS
 	category = list(MECH_FAB_CATEGORY_CYBORG_EQUIPMENT)


### PR DESCRIPTION

## Что этот ПР делает
Увеличивает техи для модуля сидушки боргам.

## Почему это хорошо для игры
Меньше злоупотребления лрп механом в раундах со стороны синтов.

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

Меньше вот такого:
<img width="461" height="628" alt="image" src="https://github.com/user-attachments/assets/3e478448-4e3c-4606-830e-d025d999f246" />


</p>
</details>

## Список изменений
:cl:
balance: увеличены техи для апгрейда сидушки на борги.
/:cl:
