### PR TITLE
фикс куска крови после выстрела

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -298,7 +298,7 @@
 // Gun procs.
 
 /obj/item/gun/proc/on_autofire_start(mob/living/shooter)
-	if(semicd || shooter.incapacitated() || !can_trigger_gun(shooter))
+	if(fire_cd || shooter.incapacitated() || !can_trigger_gun(shooter))
 		return FALSE
 
 	if(!can_shoot(shooter))
@@ -320,7 +320,7 @@
 /obj/item/gun/proc/do_autofire(datum/source, atom/target, mob/living/shooter, allow_akimbo, params)
 	SIGNAL_HANDLER
 
-	if(semicd || shooter.incapacitated())
+	if(fire_cd || shooter.incapacitated())
 		return NONE
 
 	if(!can_shoot(shooter))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -106,7 +106,7 @@
 	if(!proj.nodamage && !QDELETED(src))
 		apply_damage(proj.damage, proj.damage_type, def_zone, armor)
 		if(proj.damage_type == BRUTE && (!armor || prob(30) || proj.damage - armor >= 25))
-			spray_blood(get_dir(proj.starting, src), rand(1, max(1, floor((proj.damage - armor) / 10))))
+			spray_blood(get_dir(proj.starting, src), min(rand(1, max(1, floor((proj.damage - armor) / 10))), 5))
 		if(proj.dismemberment)
 			check_projectile_dismemberment(proj, def_zone)
 	return proj.on_hit(src, armor, def_zone)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -31,7 +31,8 @@
 	var/burst_size = 1					//how large a burst is
 	var/fire_delay = 0					//rate of fire for burst firing and semi auto
 	var/firing_burst = 0				//Prevent the weapon from firing again while already firing
-	var/semicd = 0						//cooldown handler
+	/// Firing cooldown, true if this gun shouldn't be allowed to manually fire
+	var/fire_cd = 0
 	var/weapon_weight = WEAPON_LIGHT
 	var/list/restricted_species
 	var/ninja_weapon = FALSE			//Оружия со значением TRUE обходят ограничение ниндзя на использование пушек
@@ -386,7 +387,7 @@
 	if(chambered)
 		chambered.leave_residue(user)
 
-	if(semicd)
+	if(fire_cd)
 		return
 
 	if(user.buckled)
@@ -454,9 +455,9 @@
 			return
 		process_chamber()
 		update_icon()
-		semicd = 1
+		fire_cd = TRUE
 		spawn(fire_delay)
-			semicd = 0
+			fire_cd = FALSE
 
 	if(user)
 		user.update_held_items()
@@ -670,35 +671,49 @@
 	if(!ishuman(user) || !ishuman(target))
 		return
 
-	if(semicd)
+	if(fire_cd)
 		return
 
 	if(user == target)
-		target.visible_message(span_warning("[user] вставляет ствол [declent_ru(GENITIVE)] себе в рот, готовясь нажать на спуск..."), \
-							span_userdanger("Вы вставляеете ствол [declent_ru(GENITIVE)] себе в рот, готовясь нажать на спуск..."))
+		target.visible_message(
+			span_warning("[user] вставля[PLUR_ET_YUT(user)] ствол [declent_ru(GENITIVE)] себе в рот, готовясь нажать на спуск..."),
+			span_userdanger("Вы вставляеете ствол [declent_ru(GENITIVE)] себе в рот, готовясь нажать на спуск..."),
+		)
 	else
-		target.visible_message(span_warning("[user] направляет [declent_ru(ACCUSATIVE)] в голову [target], готовясь выстрелить..."), \
-							span_userdanger("[user] направляет [declent_ru(ACCUSATIVE)] вам в голову, готовясь выстрелить!"))
+		target.visible_message(
+			span_warning("[user] направля[PLUR_ET_YUT(user)] [declent_ru(ACCUSATIVE)] в голову [target], готовясь выстрелить..."),
+			span_userdanger("[user] направля[PLUR_ET_YUT(user)] [declent_ru(ACCUSATIVE)] вам в голову, готовясь выстрелить..."),
+		)
 
-	semicd = 1
+	fire_cd = TRUE
 
 	if(!do_after(user, 12 SECONDS, target, NONE) || user.zone_selected != BODY_ZONE_PRECISE_MOUTH)
 		if(user)
 			if(user == target)
-				user.visible_message(span_notice("[user] решает, что жить всё-таки хочется."))
+				user.visible_message(
+					span_notice("[user] реша[PLUR_ET_YUT(user)], что жить всё-таки хочется."),
+				)
 			else if(target && target.Adjacent(user))
-				target.visible_message(span_notice("[user] решает пощадить [target]."), span_notice("[user] решает оставить вас в живых!"))
-		semicd = 0
+				target.visible_message(
+					span_notice("[user] реша[PLUR_ET_YUT(user)] пощадить [target]."),
+					span_notice("[user] реша[PLUR_ET_YUT(user)] оставить вас в живых!"),
+				)
+		fire_cd = FALSE
 		return
 
-	semicd = 0
+	fire_cd = FALSE
 
-	target.visible_message(span_warning("[user] нажимает на спусковой крючок!"), span_userdanger("[user] нажимает на спусковой крючок!"))
+	target.visible_message(
+		span_warning("[user] нажима[PLUR_ET_YUT(user)] на спусковой крючок!"),
+		span_userdanger("[user] нажима[PLUR_ET_YUT(user)] на спусковой крючок!")
+	)
 
 	if(chambered?.BB)
 		chambered.BB.damage *= 15
 
-	process_fire(target, user, 1, params)
+	var/fired = process_fire(target, user, TRUE, params, BODY_ZONE_HEAD)
+	if(!fired && chambered?.BB)
+		chambered.BB.damage /= 5
 
 /////////////
 // ZOOMING //

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -677,7 +677,7 @@
 	if(user == target)
 		target.visible_message(
 			span_warning("[user] вставля[PLUR_ET_YUT(user)] ствол [declent_ru(GENITIVE)] себе в рот, готовясь нажать на спуск..."),
-			span_userdanger("Вы вставляеете ствол [declent_ru(GENITIVE)] себе в рот, готовясь нажать на спуск..."),
+			span_userdanger("Вы вставляете ствол [declent_ru(GENITIVE)] себе в рот, готовясь нажать на спуск..."),
 		)
 	else
 		target.visible_message(
@@ -713,7 +713,7 @@
 
 	var/fired = process_fire(target, user, TRUE, params, BODY_ZONE_HEAD)
 	if(!fired && chambered?.BB)
-		chambered.BB.damage /= 5
+		chambered.BB.damage /= 15
 
 /////////////
 // ZOOMING //

--- a/code/modules/projectiles/guns/special/_throw.dm
+++ b/code/modules/projectiles/guns/special/_throw.dm
@@ -74,7 +74,7 @@
 
 /obj/item/gun/throw/process_fire(atom/target, mob/living/user, message = TRUE, params, zone_override, bonus_spread = 0)
 	add_fingerprint(user)
-	if(semicd)
+	if(fire_cd)
 		return
 
 	var/obj/item/I = to_launch
@@ -86,6 +86,6 @@
 	add_attack_logs(user, target, "fired [I] from a [src]")
 	process_chamber()
 
-	semicd = 1
+	fire_cd = TRUE
 	spawn(fire_delay)
-		semicd = 0
+		fire_cd = FALSE


### PR DESCRIPTION

## Что этот ПР делает
Умноженное на 15 значение выстрела в рот, вызывало кусок крови, который по формуле летел овер дохуя, теперь летит чуть поменьше.

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

<img width="491" height="459" alt="image" src="https://github.com/user-attachments/assets/350d9695-ee79-4921-b957-7fe3e8202527" />


</p>
</details>

## Список изменений
:cl:
tweak: Теперь все куски крови при выстрели летят максимум на 5 тайлов.
/:cl:
