### PR TITLE
Фикс рантайма с голомапой

### DIFF
--- a/code/modules/holomaps/machinery.dm
+++ b/code/modules/holomaps/machinery.dm
@@ -149,6 +149,9 @@
 	return TRUE
 
 /obj/machinery/station_map/proc/redraw_map(mob/user)
+	if(!user  || !user.client || !user.client.images)
+		close_map()
+		return
 	user.client.images -= holomap_datum.base_map
 	var/turf/current_turf = get_turf(src)
 	holomap_datum.initialize_holomap(current_turf, current_z_level, reinit_base_map = TRUE, extra_overlays = handle_overlays())


### PR DESCRIPTION

## Что этот ПР делает
Добавление доп проверки на клиента в голомапу при перерисовке.

## Почему это хорошо для игры
Удаляем рантаймы.

## Список изменений
:cl:
bugfix: исправлен рантайм голомапы хоса.
/:cl:
