### PR TITLE
Худ коллиматоры в вендор модулей

### DIFF
--- a/code/modules/projectiles/gun_modules/muzzle.dm
+++ b/code/modules/projectiles/gun_modules/muzzle.dm
@@ -12,6 +12,7 @@
 	overlay_state = "supp_o"
 	overlay_offset = list("x" = -1, "y" = 0)
 	class = GUN_MODULE_CLASS_PISTOL_MUZZLE | GUN_MODULE_CLASS_RIFLE_MUZZLE | GUN_MODULE_CLASS_SNIPER_MUZZLE
+	custom_price = 2 * PAYCHECK_LOWER
 	var/oldsound
 	var/initial_w_class
 
@@ -49,6 +50,7 @@
 	icon_state = "suppshotgun"
 	overlay_state = "suppshotgun_o"
 	class = GUN_MODULE_CLASS_SHOTGUN_MUZZLE
+	custom_price = 2 * PAYCHECK_LOWER
 
 /obj/item/gun_module/muzzle/suppressor/shotgun/get_ru_names()
 	return list(
@@ -66,6 +68,7 @@
 	icon_state = "suppheavy"
 	overlay_state = "suppheavy_o"
 	class = GUN_MODULE_CLASS_SNIPER_MUZZLE
+	custom_price = 3 * PAYCHECK_LOWER
 
 /obj/item/gun_module/muzzle/suppressor/heavy/get_ru_names()
 	return list(
@@ -143,6 +146,7 @@
 	var/initial_w_class
 	var/spread_decrease = 0
 	var/initial_recoil
+	custom_price = 2 * PAYCHECK_LOWER
 
 /obj/item/gun_module/muzzle/compensator/get_ru_names()
 	return list(

--- a/code/modules/projectiles/gun_modules/muzzle.dm
+++ b/code/modules/projectiles/gun_modules/muzzle.dm
@@ -50,7 +50,7 @@
 	icon_state = "suppshotgun"
 	overlay_state = "suppshotgun_o"
 	class = GUN_MODULE_CLASS_SHOTGUN_MUZZLE
-	custom_price = 2 * PAYCHECK_LOWER
+	custom_price = 2.5 * PAYCHECK_LOWER
 
 /obj/item/gun_module/muzzle/suppressor/shotgun/get_ru_names()
 	return list(

--- a/code/modules/projectiles/gun_modules/rail.dm
+++ b/code/modules/projectiles/gun_modules/rail.dm
@@ -67,7 +67,7 @@
 	bonus_accuracy = 10
 	spread_decrease_mod = 0.30
 	movespeed_slowdown = 1.3
-	custom_price = PAYCHECK_LOWER
+	custom_price = 1.5 * PAYCHECK_LOWER
 
 /obj/item/gun_module/rail/scope/collimator/get_ru_names()
 	return list(

--- a/code/modules/projectiles/gun_modules/rail.dm
+++ b/code/modules/projectiles/gun_modules/rail.dm
@@ -67,6 +67,7 @@
 	bonus_accuracy = 10
 	spread_decrease_mod = 0.30
 	movespeed_slowdown = 1.3
+	custom_price = PAYCHECK_LOWER
 
 /obj/item/gun_module/rail/scope/collimator/get_ru_names()
 	return list(
@@ -85,6 +86,7 @@
 	item_state = "coll_p"
 	overlay_state = "coll_p_o"
 	class = GUN_MODULE_CLASS_PISTOL_RAIL
+	custom_price = PAYCHECK_LOWER
 
 /obj/item/gun_module/rail/scope/collimator/pistol/get_ru_names()
 	return list(
@@ -112,6 +114,7 @@
 	bonus_accuracy = 10
 	spread_decrease_mod = 0.40
 	movespeed_slowdown = 1.6
+	custom_price = 3 * PAYCHECK_MAX
 
 /obj/item/gun_module/rail/scope/x4/get_ru_names()
 	return list(
@@ -134,6 +137,7 @@
 	zoom_amount = 7
 	bonus_accuracy = 30
 	movespeed_slowdown = 2
+	custom_price = 5 * PAYCHECK_MAX
 
 /obj/item/gun_module/rail/scope/x8/get_ru_names()
 	return list(
@@ -157,6 +161,7 @@
 	bonus_accuracy = 50
 	spread_decrease_mod = 0.75
 	movespeed_slowdown = 2.5
+	custom_price = 10 * PAYCHECK_MAX
 
 /obj/item/gun_module/rail/scope/x16/get_ru_names()
 	return list(
@@ -230,6 +235,7 @@
 	hud_type = DATA_HUD_MEDICAL_ADVANCED
 	class = GUN_MODULE_CLASS_PISTOL_RAIL | GUN_MODULE_CLASS_SHOTGUN_RAIL | GUN_MODULE_CLASS_RIFLE_RAIL | GUN_MODULE_CLASS_SNIPER_RAIL
 	origin_tech = "biotech=2;magnets=3;combat=1;programming=1"
+	custom_price = PAYCHECK_LOWER
 
 /obj/item/gun_module/rail/hud/medical/get_ru_names()
 	return list(
@@ -251,6 +257,7 @@
 	hud_type = DATA_HUD_SECURITY_ADVANCED
 	class = GUN_MODULE_CLASS_PISTOL_RAIL | GUN_MODULE_CLASS_SHOTGUN_RAIL | GUN_MODULE_CLASS_RIFLE_RAIL | GUN_MODULE_CLASS_SNIPER_RAIL
 	origin_tech = "combat=2;magnets=3;programming=1;materials=1"
+	custom_price = 1.5 * PAYCHECK_LOWER
 
 /obj/item/gun_module/rail/hud/security/get_ru_names()
 	return list(

--- a/code/modules/projectiles/gun_modules/underbarrel.dm
+++ b/code/modules/projectiles/gun_modules/underbarrel.dm
@@ -64,6 +64,7 @@
 	overlay_state = "light_o"
 	class = GUN_MODULE_CLASS_PISTOL_UNDER
 	overlay_offset = list("x" = 0, "y" = 0)
+	custom_price = PAYCHECK_LOWER
 
 /obj/item/gun_module/under/flashlight/pistol/get_ru_names()
 	return list(
@@ -83,6 +84,7 @@
 	overlay_state = "light_s_o"
 	class = GUN_MODULE_CLASS_SHOTGUN_UNDER | GUN_MODULE_CLASS_RIFLE_UNDER
 	overlay_offset = list("x" = 0, "y" = 0)
+	custom_price = 1.5 * PAYCHECK_LOWER
 
 /obj/item/gun_module/under/flashlight/rifle/get_ru_names()
 	return list(
@@ -126,6 +128,7 @@
 	overlay_offset = list("x" = 1, "y" = 0)
 	bonus_accuracy = 10
 	spread_reduction = 0.20
+	custom_price = 2 * PAYCHECK_LOWER
 
 /obj/item/gun_module/under/hand/simple/get_ru_names()
 	return list(
@@ -146,6 +149,7 @@
 	overlay_state = "hand_a_o"
 	class = GUN_MODULE_CLASS_SHOTGUN_UNDER | GUN_MODULE_CLASS_RIFLE_UNDER
 	overlay_offset = list("x" = 0, "y" = 0)
+	custom_price = 3 * PAYCHECK_LOWER
 
 /obj/item/gun_module/under/hand/angle/get_ru_names()
 	return list(
@@ -174,6 +178,7 @@
 	var/bonus_accuracy = 10
 	var/spread_decrease = 0
 	var/datum/component/laser_sight/component_type
+	custom_price = 2 * PAYCHECK_LOWER
 
 /obj/item/gun_module/under/laser/Destroy()
 	. = ..()

--- a/code/modules/vending/gun_mods.dm
+++ b/code/modules/vending/gun_mods.dm
@@ -29,10 +29,13 @@
 		/obj/item/gun_module/under/hand/simple = 5,
 		/obj/item/gun_module/under/hand/angle = 5,
 		/obj/item/ammo_box/magazine/enforcer/extended = 10,
+		/obj/item/gun_module/rail/hud/medical = 3,
+		/obj/item/gun_module/rail/hud/security = 3,
 	)
 	contraband = list(
 		/obj/item/gun_module/muzzle/suppressor = 3,
 		/obj/item/gun_module/muzzle/suppressor/shotgun = 2,
+		/obj/item/gun_module/rail/scope/x4 = 1,
 	)
 
 /obj/machinery/vending/gun_mods/get_ru_names()


### PR DESCRIPTION

## Что этот ПР делает
1. Добавляет мед и сб худ в вендор модулей.
2. Изменение цен модулей.
3. Добавление в контрабанд итемс прицела х4 в количестве 1 штуки.

## Почему это хорошо для игры
Возвращаем неиспользуемые модули в игру.
Баланс цен на который забили когда меняли цены всем предметам.

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

<img width="417" height="436" alt="image" src="https://github.com/user-attachments/assets/ee78dcfb-25c6-4e1e-a499-24f09b8cc93a" />


<img width="424" height="296" alt="image" src="https://github.com/user-attachments/assets/d3bc26ea-1f37-4e87-9664-edc18395ba16" />


</p>
</details>

## Список изменений
:cl:
qol: Модули худ-коллиматоров в вендор модулей.
balance: Ребаланс цен на оружейные модули.
/:cl:
