### PR TITLE
Функционал правой кнопки мыши для униформы и хранилищ

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -832,11 +832,8 @@
 
 /obj/item/storage/attackby_secondary(obj/item/weapon, mob/user, list/modifiers, list/attack_modifiers)
 	. = ..()
-	if(ATTACK_CHAIN_CANCEL_CHECK(.))
-		return .
-
 	open(user)
-	return .|ATTACK_CHAIN_BLOCKED_ALL
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/storage/attack_hand(mob/user)
 	if(ishuman(user))

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -174,7 +174,7 @@
 
 /obj/item/storage/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
-	if(!(. & SECONDARY_ATTACK_CALL_NORMAL))
+	if(. && !(. & SECONDARY_ATTACK_CALL_NORMAL))
 		return
 	click_alt(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -176,8 +176,13 @@
 	. = ..()
 	if(. && !(. & SECONDARY_ATTACK_CALL_NORMAL))
 		return
+
 	click_alt(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/storage/attack_self_secondary(mob/user, list/modifiers)
+	open(user)
+	return TRUE
 
 /obj/item/storage/proc/return_inv()
 	var/list/L = list()
@@ -823,6 +828,14 @@
 		return .
 
 	handle_item_insertion(I)
+	return .|ATTACK_CHAIN_BLOCKED_ALL
+
+/obj/item/storage/attackby_secondary(obj/item/weapon, mob/user, list/modifiers, list/attack_modifiers)
+	. = ..()
+	if(ATTACK_CHAIN_CANCEL_CHECK(.))
+		return .
+
+	open(user)
 	return .|ATTACK_CHAIN_BLOCKED_ALL
 
 /obj/item/storage/attack_hand(mob/user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -172,6 +172,13 @@
 	open(user)
 	return CLICK_ACTION_SUCCESS
 
+/obj/item/storage/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(!(. & SECONDARY_ATTACK_CALL_NORMAL))
+		return
+	click_alt(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/item/storage/proc/return_inv()
 	var/list/L = list()
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -91,6 +91,11 @@
 
 	orient2hud()
 
+
+/obj/item/storage/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/contextual_screentip_bare_hands, rmb_text = "Открыть")
+
 /obj/item/storage/Destroy()
 	for(var/obj/O in contents)
 		O.mouse_opacity = initial(O.mouse_opacity)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1170,6 +1170,11 @@
 	if(random_sensor)
 		sensor_mode = pick(SENSOR_OFF, SENSOR_LIVING, SENSOR_VITALS, SENSOR_COORDS)
 
+
+/obj/item/clothing/under/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/contextual_screentip_bare_hands, rmb_text = "Настроить датчики")
+
 /obj/item/clothing/under/Destroy()
 	QDEL_LIST(accessories)
 	return ..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1250,6 +1250,9 @@
 	return ..()
 
 /obj/item/clothing/under/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(!(. & SECONDARY_ATTACK_CALL_NORMAL))
+		return
 	set_sensors(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1251,7 +1251,7 @@
 
 /obj/item/clothing/under/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
-	if(!(. & SECONDARY_ATTACK_CALL_NORMAL))
+	if(. && !(. & SECONDARY_ATTACK_CALL_NORMAL))
 		return
 	set_sensors(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1253,8 +1253,13 @@
 	. = ..()
 	if(. && !(. & SECONDARY_ATTACK_CALL_NORMAL))
 		return
+
 	set_sensors(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/clothing/under/attack_self_secondary(mob/user, list/modifiers)
+	set_sensors(user)
+	return TRUE
 
 /obj/item/clothing/under/proc/attach_accessory(obj/item/clothing/accessory/accessory, mob/user, unequip = FALSE)
 	if(!can_attach_accessory(accessory, user))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1249,6 +1249,10 @@
 
 	return ..()
 
+/obj/item/clothing/under/attack_hand_secondary(mob/user, list/modifiers)
+	set_sensors(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/item/clothing/under/proc/attach_accessory(obj/item/clothing/accessory/accessory, mob/user, unequip = FALSE)
 	if(!can_attach_accessory(accessory, user))
 		if(user)


### PR DESCRIPTION

## Что этот ПР делает
1. При клике правой кнопкой мыши на униформу будет открываться выбор переключения датчиков.
2. При клике правой кнопкой мыши (с пустой рукой) на любое хранилище игрок больше не подбирает его а открывает для просмотра (как альт клик).

## Почему это хорошо для игры
QoL для хранилищ и фикс не очень приятной реализации правой кнопки на униформу (_сейчас можно случайно раздеться вместо датчиков_)

## Список изменений
:cl:
qol: Правая кнопка мыши на униформу переключает датчики.
qol: Правая кнопка мыши на любое хранилище открывает его для просмотра.
/:cl:
