### PR TITLE
Защита от вандалов у вендора оружейных модулей

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -256,7 +256,7 @@
 	 * If this is et to TRUE, free buy process not drop products, but can tilt.
 	 * Otherwise, free buy works normally.
 	 */
-	var/free_buy_secure = FALSE
+	var/vandal_secure = FALSE
 
 /obj/machinery/vending/get_ru_names()
 	return list(
@@ -791,7 +791,7 @@
  * freebies - number of free items to vend
  */
 /obj/machinery/vending/proc/freebie(mob/user, num_freebies)
-	if(free_buy_secure)
+	if(vandal_secure)
 		return
 
 	visible_message(span_notice("[DECLENT_RU_CAP(src, NOMINATIVE)] товар[declension_ru(num_freebies, "", "ы", "ы")] из своего ассортимента[credits_contained > 0 ? " и купюры" : ""]!"))
@@ -1343,6 +1343,9 @@
 
 	stat |= BROKEN
 	update_icon(UPDATE_OVERLAYS)
+
+	if(vandal_secure)
+		return
 
 	var/dump_amount = 0
 	var/found_anything = TRUE

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -253,7 +253,7 @@
 	 */
 	var/all_products_free
 	/**
-	 * If this is et to TRUE, free buy process not drop products, but can tilt.
+	 * If this is set to TRUE, the free item distribution process will not drop products, but the machine can still tilt.
 	 * Otherwise, free buy works normally.
 	 */
 	var/vandal_secure = FALSE
@@ -792,6 +792,7 @@
  */
 /obj/machinery/vending/proc/freebie(mob/user, num_freebies)
 	if(vandal_secure)
+		visible_message(span_warning("[DECLENT_RU_CAP(src, NOMINATIVE)] дребезжит, но ничего не выдаёт!"))
 		return
 
 	visible_message(span_notice("[DECLENT_RU_CAP(src, NOMINATIVE)] товар[declension_ru(num_freebies, "", "ы", "ы")] из своего ассортимента[credits_contained > 0 ? " и купюры" : ""]!"))

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -252,6 +252,11 @@
 	 * Defaults to null, set it to TRUE or FALSE explicitly on a per-machine basis if you want to force it to be a certain value.
 	 */
 	var/all_products_free
+	/**
+	 * If this is et to TRUE, free buy process not drop products, but can tilt.
+	 * Otherwise, free buy works normally.
+	 */
+	var/free_buy_secure = FALSE
 
 /obj/machinery/vending/get_ru_names()
 	return list(
@@ -786,6 +791,9 @@
  * freebies - number of free items to vend
  */
 /obj/machinery/vending/proc/freebie(mob/user, num_freebies)
+	if(free_buy_secure)
+		return
+
 	visible_message(span_notice("[DECLENT_RU_CAP(src, NOMINATIVE)] товар[declension_ru(num_freebies, "", "ы", "ы")] из своего ассортимента[credits_contained > 0 ? " и купюры" : ""]!"))
 
 	for(var/i in 1 to num_freebies)

--- a/code/modules/vending/gun_mods.dm
+++ b/code/modules/vending/gun_mods.dm
@@ -18,7 +18,7 @@
 	refill_canister = /obj/item/vending_refill/gun_mods
 	default_price = PAYCHECK_CREW
 	default_premium_price = PAYCHECK_MAX
-	free_buy_secure = TRUE
+	vandal_secure = TRUE
 
 	products = list(
 		/obj/item/gun_module/muzzle/compensator = 8,

--- a/code/modules/vending/gun_mods.dm
+++ b/code/modules/vending/gun_mods.dm
@@ -18,6 +18,7 @@
 	refill_canister = /obj/item/vending_refill/gun_mods
 	default_price = PAYCHECK_CREW
 	default_premium_price = PAYCHECK_MAX
+	free_buy_secure = TRUE
 
 	products = list(
 		/obj/item/gun_module/muzzle/compensator = 8,


### PR DESCRIPTION

## Что этот ПР делает
Добавляет флаг для защиты от вандализма у торгового автомата. Если этот флаг включен, то автомат не будет выдавать товар при попытке вандализма.

Добавлен такой флаг для торгового автомата с оружейными модулями.
Для остальных торгоматов можете сами поставить этот флаг.

## Почему это хорошо для игры
Заебали халявщики.

## Демонстрация изменений

## Список изменений
:cl:
tweak: Добавлена защита от вандализма у торгового автомата с оружейными модулями.
/:cl:
