### PR TITLE
Использование правой кнопки мыши на экшн кнопках для альтернативного действия

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -66,7 +66,7 @@
 		our_hud.position_action(src, SCRN_OBJ_DEFAULT)
 		return TRUE
 	var/trigger_flags
-	if(LAZYACCESS(modifiers, CTRL_CLICK))
+	if(LAZYACCESS(modifiers, CTRL_CLICK) || LAZYACCESS(modifiers, RIGHT_CLICK))
 		trigger_flags |= TRIGGER_SECONDARY_ACTION
 		linked_action.AltTrigger(usr, trigger_flags = trigger_flags)
 		linked_action.UpdateButtonIcon()


### PR DESCRIPTION

## Что этот ПР делает
При нажатии правой кнопкой мыши по экшн-кнопке (_кто не шарит - это те кнопки которые слева-сверху_), вызывается AltTrigger (_второстепенное действие_).

Пока что такой функционал имеет только экшн кнопка для заклинании глаза вотчера (_меняет режимы стрельбы_). В будущем надо переделать экшны на использование альтернативного триггера.

## Почему это хорошо для игры
QoL

## Список изменений
:cl:
qol: Использование правой кнопки мыши на экшн кнопках для альтернативного действия.
/:cl:
