### PR TITLE
Перенос экшн кнопок на клик правой кнопкой мыши для одежды

### DIFF
--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -216,7 +216,7 @@
 
 /datum/action/item_action/halt
 	name = "СТОЯТЬ!"
-	desc = "Левая кнопка - активировать.\nПравая кнопка - сменить фразу."
+	desc = "Левая кнопка — активировать.\nПравая кнопка — сменить фразу."
 
 /datum/action/item_action/selectphrase
 	name = "Сменить фразу"

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -38,7 +38,7 @@
 
 /datum/action/item_action/proc/call_effect_proc()
 	var/obj/item/item_target = target
-	item_target.ui_action_click(owner, src)
+	item_target.ui_action_click(owner, src, TRUE)
 
 
 /datum/action/item_action/AltTrigger(mob/clicker, trigger_flags)

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -41,6 +41,23 @@
 	item_target.ui_action_click(owner, src)
 
 
+/datum/action/item_action/AltTrigger(mob/clicker, trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	return do_alt_effect(trigger_flags)
+
+/datum/action/item_action/proc/do_alt_effect(trigger_flags)
+	if(!target)
+		return FALSE
+	call_alt_effect_proc()
+	UpdateButtonIcon()
+	return TRUE
+
+/datum/action/item_action/proc/call_alt_effect_proc()
+	var/obj/item/item_target = target
+	item_target.ui_action_click(owner, src, FALSE)
+
 // MARK: Actions
 
 /datum/action/item_action/toggle_light
@@ -199,6 +216,7 @@
 
 /datum/action/item_action/halt
 	name = "СТОЯТЬ!"
+	desc = "Левая кнопка - активировать.\nПравая кнопка - сменить фразу."
 
 /datum/action/item_action/selectphrase
 	name = "Сменить фразу"

--- a/code/datums/elements/right_click_mappers.dm
+++ b/code/datums/elements/right_click_mappers.dm
@@ -30,7 +30,7 @@
 /datum/element/right_click_mapper/ui_action_click
 
 /datum/element/right_click_mapper/ui_action_click/call_mapped_proc(obj/item/target_item, mob/user)
-	target_item.ui_action_click(user, src, TRUE)
+	target_item.ui_action_click(user, null, TRUE)
 
 /// Map right click to attack_self(mob/user)
 /datum/element/right_click_mapper/attack_self

--- a/code/datums/elements/right_click_mappers.dm
+++ b/code/datums/elements/right_click_mappers.dm
@@ -15,6 +15,7 @@
 
 /datum/element/right_click_mapper/Detach(datum/target)
 	UnregisterSignal(target, COMSIG_ATOM_ATTACK_HAND_SECONDARY)
+	target.RemoveElement(/datum/element/contextual_screentip_bare_hands)
 	. = ..()
 
 /datum/element/right_click_mapper/proc/on_attack_hand_secondary(var/obj/item/target_item, mob/user)

--- a/code/datums/elements/right_click_mappers.dm
+++ b/code/datums/elements/right_click_mappers.dm
@@ -1,0 +1,39 @@
+
+/**
+ * Element for call mapped proc when player click right button on item.
+ */
+/datum/element/right_click_mapper
+
+/datum/element/right_click_mapper/Attach(datum/target, screentip_text)
+	. = ..()
+
+	if(!isitem(target))
+		return COMPONENT_INCOMPATIBLE
+
+	RegisterSignal(target, COMSIG_ATOM_ATTACK_HAND_SECONDARY, PROC_REF(on_attack_hand_secondary))
+	target.AddElement(/datum/element/contextual_screentip_bare_hands, rmb_text = screentip_text)
+
+/datum/element/right_click_mapper/Detach(datum/target)
+	UnregisterSignal(target, COMSIG_ATOM_ATTACK_HAND_SECONDARY)
+	. = ..()
+
+/datum/element/right_click_mapper/proc/on_attack_hand_secondary(var/obj/item/target_item, mob/user)
+	SIGNAL_HANDLER
+
+	call_mapped_proc(target_item, user)
+	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+/datum/element/right_click_mapper/proc/call_mapped_proc(obj/item/target_item, mob/user)
+	return
+
+/// Map right click to ui_action_click(mob/user, datum/action/action, leftclick) (Warning: Do not use for items where used action arg!)
+/datum/element/right_click_mapper/ui_action_click
+
+/datum/element/right_click_mapper/ui_action_click/call_mapped_proc(obj/item/target_item, mob/user)
+	target_item.ui_action_click(user, src, TRUE)
+
+/// Map right click to attack_self(mob/user)
+/datum/element/right_click_mapper/attack_self
+
+/datum/element/right_click_mapper/attack_self/call_mapped_proc(obj/item/target_item, mob/user)
+	target_item.attack_self(user)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -953,7 +953,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
  * The default action is attack_self().
  * Checks before we get to here are: mob is alive, mob is not restrained, paralyzed, asleep, resting, laying, item is on the mob.
  */
-/obj/item/proc/ui_action_click(mob/user, datum/action/action, leftclick)
+/obj/item/proc/ui_action_click(mob/user, datum/action/action, leftclick = TRUE)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_UI_ACTION_CLICK, user, action, leftclick) & COMPONENT_ACTION_HANDLED)
 		return
 	attack_self(user)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -35,6 +35,11 @@
 		PREPOSITIONAL = "фонарике"
 	)
 
+
+/obj/item/flashlight/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить фонарик")
+
 /obj/item/flashlight/dummy
 	name = "Testing flashlight"
 	light_system = MOVABLE_LIGHT

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -38,7 +38,7 @@
 
 /obj/item/flashlight/ComponentInitialize()
 	. = ..()
-	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить фонарик")
+	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить свет")
 
 /obj/item/flashlight/dummy
 	name = "Testing flashlight"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -954,6 +954,9 @@
 			flavour = "[adjust_flavour]"
 		to_chat(user, "You [flavour] [src].")
 
+/obj/item/clothing/suit/attack_self(mob/user)
+	adjustsuit(user)
+
 /obj/item/clothing/suit/update_icon_state()
 	// Trims the '_open' off the end of the icon state, thus avoiding a case where jackets that start open will
 	// end up with a suffix of _open_open if adjusted twice, since their initial state is _open

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -667,6 +667,10 @@
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/eyes.dmi',
 	)
 
+/obj/item/clothing/glasses/welding/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить [declent_ru(ACCUSATIVE)]")
+
 /obj/item/clothing/glasses/welding/attack_self(mob/user)
 	weldingvisortoggle(user)
 

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -391,7 +391,6 @@ SECURITY
 	over_hat = TRUE
 	can_toggle = TRUE
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT | VISOR_DARKNESSVIEW | VISOR_FULL_HUD
-	actions_types = list(/datum/action/item_action/toggle)
 	visor_flags_cover = GLASSESCOVERSEYES
 	sprite_sheets = list(
 		SPECIES_VOX = 'icons/mob/clothing/species/vox/eyes.dmi',
@@ -403,6 +402,10 @@ SECURITY
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/eyes.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/eyes.dmi',
 	)
+
+/obj/item/clothing/glasses/hud/security/sunglasses/tacticool/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/glasses/hud/security/sunglasses/tacticool/attack_self(mob/user)
 	weldingvisortoggle(user)
@@ -671,6 +674,10 @@ SKILLS
 		INSTRUMENTAL = "много-режимными HUD-очками",
 		PREPOSITIONAL = "много-режимных HUD-очках",
 	)
+
+/obj/item/clothing/glasses/hud/blueshield/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/glasses/hud/blueshield/cap
 	name = "Gold multi-mod HUD glasses"

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -359,9 +359,6 @@
 /obj/item/clothing/gloves/color/latex/inugami/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/right_click_mapper/attack_self, "Включить/выключить встроенный дефибриллятор")
-
-/obj/item/clothing/gloves/color/latex/inugami/ComponentInitialize()
-	. = ..()
 	AddComponent(/datum/component/defib, ignore_hardsuits = TRUE, safe_by_default = TRUE, emp_proof = TRUE, emag_proof = TRUE)
 
 /obj/item/clothing/gloves/color/latex/inugami/attack_self(mob/living/carbon/human/user)

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -358,6 +358,10 @@
 
 /obj/item/clothing/gloves/color/latex/inugami/ComponentInitialize()
 	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Включить/выключить встроенный дефибриллятор")
+
+/obj/item/clothing/gloves/color/latex/inugami/ComponentInitialize()
+	. = ..()
 	AddComponent(/datum/component/defib, ignore_hardsuits = TRUE, safe_by_default = TRUE, emp_proof = TRUE, emag_proof = TRUE)
 
 /obj/item/clothing/gloves/color/latex/inugami/attack_self(mob/living/carbon/human/user)

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -10,7 +10,6 @@
 	light_system = MOVABLE_LIGHT_DIRECTIONAL
 	item_color = "yellow" //Determines used sprites: hardhat[on]_[color] and hardhat[on]_[color]2 (lying down sprite)
 	armor = list(MELEE = 15, BULLET = 5, LASER = 20, ENERGY = 10, BOMB = 20, BIO = 10, FIRE = 100, ACID = 50)
-	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	clothing_flags = parent_type::clothing_flags|STACKABLE_HELMET_EXEMPT
 	resistance_flags = FIRE_PROOF
 	dog_fashion = /datum/dog_fashion/head/hardhat
@@ -22,6 +21,10 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/head.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/head.dmi',
 	)
+
+/obj/item/clothing/head/hardhat/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить фонарик")
 
 /obj/item/clothing/head/hardhat/attack_self()
 	toggle_helmet_light()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -156,12 +156,15 @@
 	icon_state = "justice"
 	toggle_on_message = "You turn off the lights on"
 	toggle_off_message = "You turn on the lights on"
-	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	can_toggle = TRUE
 	toggle_cooldown = 20
 	active_sound = 'sound/items/weeoo1.ogg'
 	active_sound_volume = 50
 	dog_fashion = null
+
+/obj/item/clothing/head/helmet/justice/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить фонарь шлема")
 
 /obj/item/clothing/head/helmet/justice/escape
 	name = "alarm helmet"
@@ -243,11 +246,14 @@
 	flags_inv = parent_type::flags_inv|HIDEMASK|HIDEHAIR
 	toggle_on_message = "You attach the face shield to the"
 	toggle_off_message = "You remove the face shield from the"
-	actions_types = list(/datum/action/item_action/toggle_helmet_mode)
 	can_toggle = TRUE
 	toggle_cooldown = 20
 	toggle_sound = 'sound/items/zippoclose.ogg'
 	dog_fashion = null
+
+/obj/item/clothing/head/helmet/gladiator/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить режим костюма")
 
 /obj/item/clothing/head/helmet/redtaghelm
 	name = "red laser tag helmet"

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -239,7 +239,6 @@
 	icon_state = "fedora"
 	item_state = "fedora"
 	desc = "A great hat ruined by being within fifty yards of you."
-	actions_types = list(/datum/action/item_action/tip_fedora)
 
 	sprite_sheets = list(
 		SPECIES_VOX = 'icons/mob/clothing/species/vox/head.dmi',
@@ -249,6 +248,10 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/head.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/head.dmi',
 	)
+
+/obj/item/clothing/head/fedora/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Поправить федору")
 
 /obj/item/clothing/head/fedora/attack_self(mob/user)
 	tip_fedora(user)
@@ -492,6 +495,10 @@
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/head.dmi',
 	)
 	actions_types = list(/datum/action/item_action/caw)
+
+/obj/item/clothing/head/griffin/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Каркнуть")
 
 /obj/item/clothing/head/griffin/attack_self()
 	caw()

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -203,7 +203,7 @@
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/head.dmi',
 	)
 
-/obj/item/clothing/head/welding/ComponentInitialize()
+/obj/item/clothing/head/ushanka/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/right_click_mapper/attack_self, "Опустить/поднять уши")
 

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -50,6 +50,10 @@
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/head.dmi',
 	)
 
+/obj/item/clothing/head/welding/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить [declent_ru(ACCUSATIVE)]")
+
 /obj/item/clothing/head/welding/flamedecal
 	name = "flame decal welding helmet"
 	desc = "A welding helmet adorned with flame decals, and several cryptic slogans of varying degrees of legibility."
@@ -187,7 +191,6 @@
 	cold_protection = HEAD
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
 	dog_fashion = /datum/dog_fashion/head/ushanka
-	actions_types = list(/datum/action/item_action/toggle_helmet_mode)
 	can_toggle = TRUE
 	toggle_on_message = "You raise the ear flaps on"
 	toggle_off_message = "You lower the ear flaps on"
@@ -199,6 +202,10 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/head.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/head.dmi',
 	)
+
+/obj/item/clothing/head/welding/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Опустить/поднять уши")
 
 /obj/item/clothing/head/sovietsidecap
 	name = "Soviet side cap"

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -6,7 +6,6 @@
 	item_color = "cargo"
 	dying_key = DYE_REGISTRY_SOFTCAP
 	var/flipped = FALSE
-	actions_types = list(/datum/action/item_action/flip_cap)
 	dog_fashion = /datum/dog_fashion/head/cargo_tech
 	sprite_sheets = list(
 		SPECIES_VOX = 'icons/mob/clothing/species/vox/head.dmi',
@@ -16,6 +15,10 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/head.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/head.dmi',
 	)
+
+/obj/item/clothing/head/soft/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Развернуть кепку")
 
 /obj/item/clothing/head/soft/update_icon_state()
 	icon_state = flipped ? "[item_color]soft_flipped" : "[item_color]soft"

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -4,7 +4,6 @@
 	icon_state = "balaclava"
 	item_state = "balaclava"
 	can_toggle = TRUE
-	actions_types = list(/datum/action/item_action/adjust)
 	flags_inv = HIDENAME|HIDEFACIALHAIR|HIDEHEADHAIR
 	adjusted_slot_flags = ITEM_SLOT_HEAD
 	adjusted_flags_inv = HIDENAME|HIDEFACIALHAIR
@@ -26,6 +25,10 @@
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/mask.dmi',
 		SPECIES_WRYN = 'icons/mob/clothing/species/wryn/mask.dmi',
 	)
+
+/obj/item/clothing/mask/balaclava/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Поднять/Опустить [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/mask/balaclava/attack_self(mob/user)
 	adjustmask(user)

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -9,7 +9,6 @@
 	flags_cover = MASKCOVERSMOUTH
 	gas_transfer_coefficient = 0.10
 	permeability_coefficient = 0.50
-	actions_types = list(/datum/action/item_action/adjust)
 	resistance_flags = NONE
 	can_toggle = TRUE
 	sprite_sheets = list(
@@ -41,6 +40,10 @@
 		INSTRUMENTAL = "дыхательной маской",
 		PREPOSITIONAL = "дыхательной маске",
 	)
+
+/obj/item/clothing/mask/breath/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Поднять/Опустить [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/mask/breath/attack_self(mob/user)
 	adjustmask(user)
@@ -79,7 +82,6 @@
 	item_state = "voxmask"
 	permeability_coefficient = 0.01
 	species_restricted = list(SPECIES_VOX, SPECIES_VOX_ARMALIS) //These should fit the "Mega Vox" just fine.
-	actions_types = null
 
 /obj/item/clothing/mask/breath/vox/get_ru_names()
 	return list(

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -69,6 +69,10 @@
 		PREPOSITIONAL = "сварочном протовогазе",
 	)
 
+/obj/item/clothing/mask/gas/welding/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить [declent_ru(ACCUSATIVE)]")
+
 /obj/item/clothing/mask/gas/welding/attack_self(mob/user)
 	weldingvisortoggle(user)
 
@@ -79,7 +83,6 @@
 	name = "explorer gas mask"
 	desc = "Противогаз военного качества, который можно подключить к системе подачи воздуха."
 	icon_state = "gas_mining"
-	actions_types = list(/datum/action/item_action/adjust)
 	armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 0, BIO = 50, FIRE = 20, ACID = 40)
 	resistance_flags = FIRE_PROOF
 	can_toggle = TRUE
@@ -111,6 +114,10 @@
 		INSTRUMENTAL = "противогазом исследователя",
 		PREPOSITIONAL = "противогазе исследователя",
 	)
+
+/obj/item/clothing/mask/gas/explorer/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Поднять/Опустить [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/mask/gas/explorer/attack_self(mob/user)
 	adjustmask(user)
@@ -609,6 +616,10 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, INNATE_TRAIT)
 
+/obj/item/clothing/mask/gas/owl_mask/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Ухнуть")
+
 /obj/item/clothing/mask/gas/owl_mask/attack_self()
 	hoot()
 
@@ -635,7 +646,7 @@
 	var/aggressiveness = 1
 	var/safety = 1
 	can_toggle = TRUE
-	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/adjust, /datum/action/item_action/selectphrase)
+	actions_types = list(/datum/action/item_action/halt)
 	custom_price = PAYCHECK_CREW
 	var/static/list/phrase_list = list(
 
@@ -673,6 +684,10 @@
 	. = ..()
 	AddElement(/datum/element/tts_modifier, SOUND_EFFECT_MASKFILTER)
 
+/obj/item/clothing/mask/gas/sechailer/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Поднять/Опустить [declent_ru(ACCUSATIVE)]")
+
 /obj/item/clothing/mask/gas/sechailer/adjustmask(user)
 	. = ..()
 	if(.)
@@ -696,7 +711,7 @@
 	aggressiveness = 3
 	phrase = 12
 	can_toggle = FALSE
-	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/selectphrase)
+	actions_types = list(/datum/action/item_action/halt)
 	custom_price = PAYCHECK_COMMAND
 
 /obj/item/clothing/mask/gas/sechailer/tactical/get_ru_names()
@@ -717,7 +732,7 @@
 	aggressiveness = 3
 	phrase = 12
 	can_toggle = FALSE
-	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/selectphrase)
+	actions_types = list(/datum/action/item_action/halt)
 
 /obj/item/clothing/mask/gas/sechailer/hos/get_ru_names()
 	return list(
@@ -737,7 +752,7 @@
 	aggressiveness = 3
 	phrase = 12
 	can_toggle = FALSE
-	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/selectphrase)
+	actions_types = list(/datum/action/item_action/halt)
 
 /obj/item/clothing/mask/gas/sechailer/warden/get_ru_names()
 	return list(
@@ -757,7 +772,7 @@
 	aggressiveness = 3
 	phrase = 12
 	can_toggle = FALSE
-	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/selectphrase)
+	actions_types = list(/datum/action/item_action/halt)
 
 /obj/item/clothing/mask/gas/sechailer/swat/get_ru_names()
 	return list(
@@ -778,7 +793,7 @@
 	aggressiveness = 3
 	phrase = 12
 	can_toggle = FALSE
-	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/selectphrase)
+	actions_types = list(/datum/action/item_action/halt)
 
 /obj/item/clothing/mask/gas/sechailer/blue/get_ru_names()
 	return list(
@@ -796,7 +811,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "taperecorder_idle"
 	can_toggle = FALSE
-	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/selectphrase)
+	actions_types = list(/datum/action/item_action/halt)
 
 /obj/item/clothing/mask/gas/sechailer/cyborg/get_ru_names()
 	return list(
@@ -811,44 +826,51 @@
 /obj/item/clothing/mask/gas/sechailer/ui_action_click(mob/user, datum/action/action, leftclick)
 	if(istype(action, /datum/action/item_action/halt))
 		halt()
-	else if(istype(action, /datum/action/item_action/adjust))
-		adjustmask(user)
+	else if(istype(action, /datum/action/item_action/adjust) && leftclick)
+		if(leftclick)
+			adjustmask(user)
+		else
+			switch_halt_phrase(user)
 	else if(istype(action, /datum/action/item_action/selectphrase))
-		var/key = phrase_list[phrase]
-		var/message = phrase_list[key]
-
-		if(!safety)
-			to_chat(user, span_notice("You set the restrictor to: FUCK YOUR CUNT YOU SHIT EATING COCKSUCKER MAN EAT A DONG FUCKING ASS RAMMING SHIT FUCK EAT PENISES IN YOUR FUCK FACE AND SHIT OUT ABORTIONS OF FUCK AND DO SHIT IN YOUR ASS YOU COCK FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT."))
-			return
-
-		switch(aggressiveness)
-			if(1)
-				phrase = (phrase < 6) ? (phrase + 1) : 1
-				key = phrase_list[phrase]
-				message = phrase_list[key]
-				to_chat(user,span_notice("You set the restrictor to: [message]"))
-			if(2)
-				phrase = (phrase < 11 && phrase >= 7) ? (phrase + 1) : 7
-				key = phrase_list[phrase]
-				message = phrase_list[key]
-				to_chat(user,span_notice("You set the restrictor to: [message]"))
-			if(3)
-				phrase = (phrase < 18 && phrase >= 12 ) ? (phrase + 1) : 12
-				key = phrase_list[phrase]
-				message = phrase_list[key]
-				to_chat(user,span_notice("You set the restrictor to: [message]"))
-			if(4)
-				phrase = (phrase < 18 && phrase >= 1 ) ? (phrase + 1) : 1
-				key = phrase_list[phrase]
-				message = phrase_list[key]
-				to_chat(user,span_notice("You set the restrictor to: [message]"))
-			else
-				to_chat(user, span_notice("It's broken."))
-
+		var/key = switch_halt_phrase(user)
 		var/datum/action/item_action/halt/halt_action = locate() in actions
 		if(halt_action)
 			halt_action.name = "[uppertext(key)]!"
 			halt_action.UpdateButtonIcon()
+
+/obj/item/clothing/mask/gas/sechailer/proc/switch_halt_phrase(mob/user)
+	var/key = phrase_list[phrase]
+	var/message = phrase_list[key]
+
+	if(!safety)
+		to_chat(user, span_notice("You set the restrictor to: FUCK YOUR CUNT YOU SHIT EATING COCKSUCKER MAN EAT A DONG FUCKING ASS RAMMING SHIT FUCK EAT PENISES IN YOUR FUCK FACE AND SHIT OUT ABORTIONS OF FUCK AND DO SHIT IN YOUR ASS YOU COCK FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT."))
+		return
+
+	switch(aggressiveness)
+		if(1)
+			phrase = (phrase < 6) ? (phrase + 1) : 1
+			key = phrase_list[phrase]
+			message = phrase_list[key]
+			to_chat(user,span_notice("You set the restrictor to: [message]"))
+		if(2)
+			phrase = (phrase < 11 && phrase >= 7) ? (phrase + 1) : 7
+			key = phrase_list[phrase]
+			message = phrase_list[key]
+			to_chat(user,span_notice("You set the restrictor to: [message]"))
+		if(3)
+			phrase = (phrase < 18 && phrase >= 12 ) ? (phrase + 1) : 12
+			key = phrase_list[phrase]
+			message = phrase_list[key]
+			to_chat(user,span_notice("You set the restrictor to: [message]"))
+		if(4)
+			phrase = (phrase < 18 && phrase >= 1 ) ? (phrase + 1) : 1
+			key = phrase_list[phrase]
+			message = phrase_list[key]
+			to_chat(user,span_notice("You set the restrictor to: [message]"))
+		else
+			to_chat(user, span_notice("It's broken."))
+
+	return key
 
 /obj/item/clothing/mask/gas/sechailer/screwdriver_act(mob/living/user, obj/item/I)
 	. = TRUE

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -829,6 +829,10 @@
 			halt()
 		else
 			switch_halt_phrase(user)
+			var/datum/action/item_action/halt/halt_action = locate() in actions
+			if(halt_action)
+				halt_action.name = "[uppertext(key)]!"
+				halt_action.UpdateButtonIcon()
 	else if(istype(action, /datum/action/item_action/selectphrase))
 		var/key = switch_halt_phrase(user)
 		var/datum/action/item_action/halt/halt_action = locate() in actions

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -41,8 +41,7 @@
 		PREPOSITIONAL = "противогазе",
 	)
 
-// **** Welding gas mask ****
-
+// MARK: Welding gas mask
 /obj/item/clothing/mask/gas/welding
 	name = "welding gas mask"
 	desc = "Противогаз, со встроенным лицевым щитком и сварочными очками. Был спроектирован ботанами, поэтому выглядит как череп."
@@ -79,6 +78,7 @@
 /obj/item/clothing/mask/gas/welding/adjustmask(mob/living/carbon/human/user)
 	return
 
+//marK: Explorer gas mask
 /obj/item/clothing/mask/gas/explorer
 	name = "explorer gas mask"
 	desc = "Противогаз военного качества, который можно подключить к системе подачи воздуха."
@@ -158,6 +158,7 @@
 		PREPOSITIONAL = "маске Бейна",
 	)
 
+// MARK: Plague doctor
 //Plague Dr suit can be found in clothing/suits/bio.dm
 /obj/item/clothing/mask/gas/plaguedoctor
 	name = "plague doctor mask"
@@ -223,6 +224,7 @@
 		PREPOSITIONAL = "маске \"Синдиката\"",
 	)
 
+// MARK: Clown hat
 /obj/item/clothing/mask/gas/clown_hat
 	name = "clown wig and mask"
 	desc = "Маскарадный набор настоящего проказника. Клоун никогда не будет полноценным без своего парика и маски. Вы можете изменить её внешний вид в руках."
@@ -353,6 +355,8 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, INNATE_TRAIT)
 
+
+// MARK: Mime mask
 /obj/item/clothing/mask/gas/mime
 	name = "happy mime mask"
 	desc = "Классическая театральная маска, для мастеров пантомимы."
@@ -576,6 +580,7 @@
 		PREPOSITIONAL = "классической маске мима",
 	)
 
+// MARK: Cyborg gas mask
 /obj/item/clothing/mask/gas/cyborg
 	name = "cyborg visor"
 	desc = "Бип буп."
@@ -628,9 +633,13 @@
 		playsound(src.loc, 'sound/creatures/hoot.ogg', 50, TRUE)
 		cooldown = world.time
 
-// ********************************************************************
 
-// **** Security gas mask ****
+// MARK: Security gas mask
+#define AGGRESSIVENESS_FIRST_POSITION 1
+#define AGGRESSIVENESS_SECOND_POSITION 2
+#define AGGRESSIVENESS_THIRD_POSITION 3
+#define AGGRESSIVENESS_FOURTH_POSITION 4
+#define AGGRESSIVENESS_BROKEN 5
 
 /obj/item/clothing/mask/gas/sechailer
 	name = "security gas mask"
@@ -643,7 +652,7 @@
 	adjusted_flags_inv = HIDENAME
 	clothing_traits = list(TRAIT_SECDEATH)
 	var/phrase = 1
-	var/aggressiveness = 1
+	var/aggressiveness = AGGRESSIVENESS_FIRST_POSITION
 	var/safety = 1
 	can_toggle = TRUE
 	actions_types = list(/datum/action/item_action/halt)
@@ -708,7 +717,7 @@
 	desc = "Тактический противогаз чёрного цвета с красными обзорными стёклами. Разработан компанией \"Стальная Гвардия\" специально для сотрудников станционной службы безопасности \"Нанотрейзен\". Обеспечивает защиту лица, глаз и органов дыхания от неблагоприятных условий внешней среды."
 	icon_state = "tactical_mask"
 	armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 0, BIO = 50, FIRE = 10, ACID = 30)
-	aggressiveness = 3
+	aggressiveness = AGGRESSIVENESS_THIRD_POSITION
 	phrase = 12
 	can_toggle = FALSE
 	actions_types = list(/datum/action/item_action/halt)
@@ -729,7 +738,7 @@
 	desc = "Тактический противогаз чёрного цвета с более агрессивным Подчи-о-натором 3000."
 	icon_state = "hosmask"
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 50, FIRE = 100, ACID = 50)
-	aggressiveness = 3
+	aggressiveness = AGGRESSIVENESS_THIRD_POSITION
 	phrase = 12
 	can_toggle = FALSE
 	actions_types = list(/datum/action/item_action/halt)
@@ -749,7 +758,7 @@
 	desc = "Тактический противогаз синего цвета с более агрессивным Подчи-о-натором 3000."
 	icon_state = "wardenmask"
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 50, FIRE = 100, ACID = 50)
-	aggressiveness = 3
+	aggressiveness = AGGRESSIVENESS_THIRD_POSITION
 	phrase = 12
 	can_toggle = FALSE
 	actions_types = list(/datum/action/item_action/halt)
@@ -769,7 +778,7 @@
 	desc = "Тактический противогаз с более агрессивным Подчи-о-натором 3000."
 	icon_state = "officermask"
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 50, FIRE = 100, ACID = 50)
-	aggressiveness = 3
+	aggressiveness = AGGRESSIVENESS_THIRD_POSITION
 	phrase = 12
 	can_toggle = FALSE
 	actions_types = list(/datum/action/item_action/halt)
@@ -790,7 +799,7 @@
 	icon_state = "blue_sechailer"
 	item_state = "blue_sechailer"
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 50, FIRE = 100, ACID = 50)
-	aggressiveness = 3
+	aggressiveness = AGGRESSIVENESS_THIRD_POSITION
 	phrase = 12
 	can_toggle = FALSE
 	actions_types = list(/datum/action/item_action/halt)
@@ -842,22 +851,22 @@
 		return
 
 	switch(aggressiveness)
-		if(1)
+		if(AGGRESSIVENESS_FIRST_POSITION)
 			phrase = (phrase < 6) ? (phrase + 1) : 1
 			key = phrase_list[phrase]
 			message = phrase_list[key]
 			to_chat(user,span_notice("You set the restrictor to: [message]"))
-		if(2)
+		if(AGGRESSIVENESS_SECOND_POSITION)
 			phrase = (phrase < 11 && phrase >= 7) ? (phrase + 1) : 7
 			key = phrase_list[phrase]
 			message = phrase_list[key]
 			to_chat(user,span_notice("You set the restrictor to: [message]"))
-		if(3)
+		if(AGGRESSIVENESS_THIRD_POSITION)
 			phrase = (phrase < 18 && phrase >= 12 ) ? (phrase + 1) : 12
 			key = phrase_list[phrase]
 			message = phrase_list[key]
 			to_chat(user,span_notice("You set the restrictor to: [message]"))
-		if(4)
+		if(AGGRESSIVENESS_FOURTH_POSITION)
 			phrase = (phrase < 18 && phrase >= 1 ) ? (phrase + 1) : 1
 			key = phrase_list[phrase]
 			message = phrase_list[key]
@@ -872,36 +881,36 @@
 	if(!I.use_tool(src, user, volume = I.tool_volume))
 		return .
 	switch(aggressiveness)
-		if(1)
+		if(AGGRESSIVENESS_FIRST_POSITION)
 			to_chat(user, span_notice("You set the aggressiveness restrictor to the second position."))
-			aggressiveness = 2
+			aggressiveness = AGGRESSIVENESS_SECOND_POSITION
 			phrase = 7
-		if(2)
+		if(AGGRESSIVENESS_SECOND_POSITION)
 			to_chat(user, span_notice("You set the aggressiveness restrictor to the third position."))
-			aggressiveness = 3
+			aggressiveness = AGGRESSIVENESS_THIRD_POSITION
 			phrase = 13
-		if(3)
+		if(AGGRESSIVENESS_THIRD_POSITION)
 			to_chat(user, span_notice("You set the aggressiveness restrictor to the fourth position."))
-			aggressiveness = 4
+			aggressiveness = AGGRESSIVENESS_FOURTH_POSITION
 			phrase = 1
-		if(4)
+		if(AGGRESSIVENESS_FOURTH_POSITION)
 			to_chat(user, span_notice("You set the aggressiveness restrictor to the first position."))
-			aggressiveness = 1
+			aggressiveness = AGGRESSIVENESS_FIRST_POSITION
 			phrase = 1
 		if(5)
 			to_chat(user, span_warning("You adjust the restrictor but nothing happens, probably because its broken."))
 
 /obj/item/clothing/mask/gas/sechailer/wirecutter_act(mob/living/user, obj/item/I)
 	. = TRUE
-	if(aggressiveness == 5)
+	if(aggressiveness == AGGRESSIVENESS_BROKEN)
 		to_chat(user, span_warning("The [name] is already broken."))
 		return .
 	var/confirm = tgui_alert(user, "Do you want to cut off the voice modulator? Warning: It will destroy mask's functionality.", "Cut voice modulator?", list("Yes", "No"))
-	if(confirm != "Yes" || aggressiveness == 5 || !Adjacent(user) || user.incapacitated())
+	if(confirm != "Yes" || aggressiveness == AGGRESSIVENESS_BROKEN || !Adjacent(user) || user.incapacitated())
 		return .
 	if(!I.use_tool(src, user, volume = I.tool_volume))
 		return .
-	aggressiveness = 5
+	aggressiveness = AGGRESSIVENESS_BROKEN
 	to_chat(user, span_warning("You have cut off the voice modulator, the mask is broken now."))
 
 /obj/item/clothing/mask/gas/sechailer/attack_self(mob/user)
@@ -909,7 +918,7 @@
 
 /obj/item/clothing/mask/gas/sechailer/emag_act(mob/user)
 	if(safety)
-		safety = 0
+		safety = FALSE
 		if(user)
 			to_chat(user, "<span class='warning'>You silently fry [src]'s vocal circuit with the cryptographic sequencer.")
 
@@ -929,8 +938,13 @@
 		playsound(src.loc, "sound/voice/complionator/[key].ogg", 100, FALSE, 4)
 		cooldown = world.time
 
-// ********************************************************************
+#undef AGGRESSIVENESS_FIRST_POSITION
+#undef AGGRESSIVENESS_SECOND_POSITION
+#undef AGGRESSIVENESS_THIRD_POSITION
+#undef AGGRESSIVENESS_FOURTH_POSITION
+#undef AGGRESSIVENESS_BROKEN
 
+// MARK: Ghostface mask
 /obj/item/clothing/mask/gas/ghostface
 	name = "Ghostface mask"
 	desc = "Вытянутая белая маска, рот которой открыт в немом крике. Но вот в чём вопрос — ужаса, или ярости?"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -823,12 +823,10 @@
 		PREPOSITIONAL = "мегафоне службы безопасности",
 	)
 
-/obj/item/clothing/mask/gas/sechailer/ui_action_click(mob/user, datum/action/action, leftclick)
+/obj/item/clothing/mask/gas/sechailer/ui_action_click(mob/user, datum/action/action, leftclick = TRUE)
 	if(istype(action, /datum/action/item_action/halt))
-		halt()
-	else if(istype(action, /datum/action/item_action/adjust) && leftclick)
 		if(leftclick)
-			adjustmask(user)
+			halt()
 		else
 			switch_halt_phrase(user)
 	else if(istype(action, /datum/action/item_action/selectphrase))

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -824,16 +824,9 @@
 	)
 
 /obj/item/clothing/mask/gas/sechailer/ui_action_click(mob/user, datum/action/action, leftclick = TRUE)
-	if(istype(action, /datum/action/item_action/halt))
-		if(leftclick)
-			halt()
-		else
-			switch_halt_phrase(user)
-			var/datum/action/item_action/halt/halt_action = locate() in actions
-			if(halt_action)
-				halt_action.name = "[uppertext(key)]!"
-				halt_action.UpdateButtonIcon()
-	else if(istype(action, /datum/action/item_action/selectphrase))
+	if(istype(action, /datum/action/item_action/halt) && leftclick)
+		halt()
+	else if(istype(action, /datum/action/item_action/selectphrase) || (istype(action, /datum/action/item_action/halt) && !leftclick))
 		var/key = switch_halt_phrase(user)
 		var/datum/action/item_action/halt/halt_action = locate() in actions
 		if(halt_action)

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -227,7 +227,6 @@
 	permeability_coefficient = 0.01
 	can_toggle = TRUE
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 25, FIRE = 0, ACID = 0)
-	actions_types = list(/datum/action/item_action/adjust)
 
 	sprite_sheets = list(
 		SPECIES_VOX = 'icons/mob/clothing/species/vox/mask.dmi',
@@ -257,6 +256,10 @@
 		PREPOSITIONAL = "стерильной маске",
 	)
 
+/obj/item/clothing/mask/surgical/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Поднять/Опустить [declent_ru(ACCUSATIVE)]")
+
 /obj/item/clothing/mask/surgical/attack_self(mob/user)
 	adjustmask(user)
 
@@ -265,7 +268,6 @@
 	desc = "moustache is totally real."
 	icon_state = "fake-moustache"
 	flags_inv = HIDENAME
-	actions_types = list(/datum/action/item_action/pontificate)
 	dog_fashion = /datum/dog_fashion/head/not_ian
 
 	sprite_sheets = list(
@@ -284,6 +286,10 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/mask.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/mask.dmi',
 	)
+
+/obj/item/clothing/mask/fakemoustache/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Изменить")
 
 /obj/item/clothing/mask/fakemoustache/attack_self(mob/user)
 	pontificate(user)
@@ -544,8 +550,11 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/mask.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/mask.dmi',
 	)
-	actions_types = list(/datum/action/item_action/adjust)
 	dying_key = DYE_REGISTRY_BANDANA
+
+/obj/item/clothing/mask/bandana/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Поднять/Опустить [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/mask/bandana/attack_self(mob/user)
 	adjustmask(user)
@@ -697,7 +706,6 @@
 	armor = list(MELEE = 5, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 0)
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.90
-	actions_types = list(/datum/action/item_action/adjust)
 
 	sprite_sheets = list(
 		SPECIES_VOX = 'icons/mob/clothing/species/vox/mask.dmi',
@@ -712,6 +720,10 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/mask.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/mask.dmi',
 	)
+
+/obj/item/clothing/mask/secscarf/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Поднять/Опустить [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/mask/secscarf/attack_self(mob/user)
 	adjustmask(user)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -21,6 +21,10 @@
 	/// A list of traits we apply when we get activated
 	var/list/active_traits = list(TRAIT_NEGATES_GRAVITY, TRAIT_NO_SLIP_WATER, TRAIT_NO_SLIP_SLIDE)
 
+/obj/item/clothing/shoes/magboots/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить [declent_ru(ACCUSATIVE)]")
+
 /obj/item/clothing/shoes/magboots/atmos
 	desc = "Magnetic boots, made to withstand gusts of space wind over 500kmph."
 	name = "atmospheric magboots"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -133,8 +133,11 @@
 	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 	ignore_suitadjust = FALSE
-	actions_types = list(/datum/action/item_action/openclose)
 	adjust_flavour = "unzip"
+
+/obj/item/clothing/suit/armor/secjacket/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Открыть/Закрыть [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/suit/armor/hos
 	name = "armored coat"
@@ -155,8 +158,11 @@
 	item_state = "hostrench_open"
 	flags_inv_transparent = HIDEJUMPSUIT
 	ignore_suitadjust = FALSE
-	actions_types = list(/datum/action/item_action/openclose)
 	adjust_flavour = "unbutton"
+
+/obj/item/clothing/suit/armor/hos/alt/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Открыть/Закрыть [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/suit/armor/hos/jensen
 	name = "armored trenchcoat"

--- a/code/modules/clothing/suits/hood.dm
+++ b/code/modules/clothing/suits/hood.dm
@@ -14,6 +14,10 @@
 	hood = null
 	return ..()
 
+/obj/item/clothing/suit/armor/reactive/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Переключить [declent_ru(ACCUSATIVE)]")
+
 /obj/item/clothing/suit/hooded/proc/MakeHood()
 	item_color = initial(icon_state)
 	if(!hoodtype || hood)

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -94,8 +94,11 @@
 	)
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, fire = 50, acid = 50)
 	ignore_suitadjust = FALSE
-	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
+
+/obj/item/clothing/suit/storage/paramedic_jacket/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 //Brig Physician
 /obj/item/clothing/suit/storage/brigdoc
@@ -201,8 +204,11 @@
 	item_state = "cap_jacket_black_open"
 	ignore_suitadjust = FALSE
 	flags_inv_transparent = HIDEJUMPSUIT
-	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
+
+/obj/item/clothing/suit/captunic/parade/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/suit/captunic/parade/alt
 	icon_state = "dress_capjacket_black_open"
@@ -214,8 +220,11 @@
 	item_state = "cap_jacket_open"
 	ignore_suitadjust = FALSE
 	flags_inv_transparent = HIDEJUMPSUIT
-	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
+
+/obj/item/clothing/suit/captunic/jacket/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/suit/captunic/bomber
 	name = "captain's bomber jacket"
@@ -223,8 +232,11 @@
 	item_state = "bomber_captain_open"
 	ignore_suitadjust = FALSE
 	flags_inv_transparent = HIDEJUMPSUIT
-	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
+
+/obj/item/clothing/suit/captunic/bomber/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 //Chaplain
 /obj/item/clothing/suit/hooded/chaplain_hoodie
@@ -486,8 +498,11 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	ignore_suitadjust = FALSE
-	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
+
+/obj/item/clothing/suit/storage/lawyer/blackjacket/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/suit/storage/lawyer/bluejacket
 	name = "blue suit jacket"
@@ -497,8 +512,11 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	ignore_suitadjust = FALSE
-	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
+
+/obj/item/clothing/suit/storage/lawyer/bluejacket/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/suit/storage/lawyer/purpjacket
 	name = "purple suit jacket"
@@ -518,7 +536,6 @@
 	flags_inv_transparent = HIDEJUMPSUIT
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/storage/fancy/cigarettes, /obj/item/clothing/mask/cigarette, /obj/item/lighter, /obj/item/rcs, /obj/item/stack/packageWrap, /obj/item/stack/wrapping_paper, /obj/item/destTagger, /obj/item/pen, /obj/item/paper, /obj/item/stamp, /obj/item/qm_quest_tablet)
 	ignore_suitadjust = FALSE
-	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
 
 	sprite_sheets = list(
@@ -530,6 +547,10 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/suit.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/suit.dmi',
 	)
+
+/obj/item/clothing/suit/storage/qm/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 //Lawyer ex Internal Affairs
 /obj/item/clothing/suit/storage/internalaffairs
@@ -540,7 +561,6 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	ignore_suitadjust = FALSE
-	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
 
 	sprite_sheets = list(
@@ -552,6 +572,10 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/suit.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/suit.dmi',
 	)
+
+/obj/item/clothing/suit/storage/internalaffairs/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/suit/storage/ntrep
 	name = "Nanotrasen Representative jacket"
@@ -560,7 +584,6 @@
 	item_state = "ntrep"
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
-	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
 
 	sprite_sheets = list(
@@ -572,6 +595,10 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/suit.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/suit.dmi',
 	)
+
+/obj/item/clothing/suit/storage/ntrep/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 //Medical
 /obj/item/clothing/suit/storage/fr_jacket
@@ -614,7 +641,6 @@
 		/obj/item/tourniquet,
 	)
 	ignore_suitadjust = FALSE
-	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
 
 	sprite_sheets = list(
@@ -626,6 +652,10 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/suit.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/suit.dmi',
 	)
+
+/obj/item/clothing/suit/storage/fr_jacket/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 //Suspenders
 /obj/item/clothing/suit/suspenders
@@ -712,8 +742,11 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	ignore_suitadjust = FALSE
-	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
+
+/obj/item/clothing/suit/hop_jacket/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/suit/hop_jacket/female
 	icon_state = "suitjacket_hop_fem_open"

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -51,7 +51,6 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/suit.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/suit.dmi',
 	)
-	actions_types = list(/datum/action/item_action/button)
 	adjust_flavour = "unbutton"
 
 /obj/item/clothing/suit/storage/labcoat/get_ru_names()
@@ -63,6 +62,10 @@
 		INSTRUMENTAL = "лабораторным халатом",
 		PREPOSITIONAL = "лабораторном халате",
 	)
+
+/obj/item/clothing/suit/storage/labcoat/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/suit/storage/labcoat/cmo
 	name = "chief medical officer's labcoat"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -780,6 +780,10 @@
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/suit.dmi',
 	)
 
+/obj/item/clothing/suit/tracksuit/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Открыть/Закрыть [declent_ru(ACCUSATIVE)]")
+
 /obj/item/clothing/suit/tracksuit/green
 	name = "green tracksuit"
 	icon_state = "trackjacketgreen_open"
@@ -907,7 +911,6 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	actions_types = list(/datum/action/item_action/zipper)
 	adjust_flavour = "unzip"
 
 	sprite_sheets = list(
@@ -919,6 +922,10 @@
 		SPECIES_NEARA = 'icons/mob/clothing/species/monkey/suit.dmi',
 		SPECIES_STOK = 'icons/mob/clothing/species/monkey/suit.dmi',
 	)
+
+/obj/item/clothing/suit/jacket/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/right_click_mapper/attack_self, "Застегнуть/Расстегнуть [declent_ru(ACCUSATIVE)]")
 
 /obj/item/clothing/suit/jacket/pilot
 	name = "security bomber jacket"

--- a/paradise.dme
+++ b/paradise.dme
@@ -853,6 +853,7 @@
 #include "code\datums\elements\ranged_attacks.dm"
 #include "code\datums\elements\reagent_attack.dm"
 #include "code\datums\elements\ridable.dm"
+#include "code\datums\elements\right_click_mappers.dm"
 #include "code\datums\elements\ritual_dye_removal.dm"
 #include "code\datums\elements\rusted_weapon.dm"
 #include "code\datums\elements\simple_flying.dm"


### PR DESCRIPTION

## Что этот ПР делает
Юольшинство мусорных жкшнов перенесено вна клик правой кнопкой по самой одежде.
Например "поднять федору", "расстегнуть пуговицу" и прочее.

## Почему это хорошо для игры
QoL

## Список изменений
:cl:
qol: Перенос действий экшн кнопок на правый клик для одежды.
/:cl:
