### PR TITLE
Ослабление взрыва когда два мага дают пять

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -76,7 +76,7 @@
 			user.visible_message(span_biggerdanger("<b>[user.name]</b> и <b>[check.name]</b> [critical_success]"))
 			ADD_TRAIT(user, TRAIT_GODMODE, UNIQUE_TRAIT_SOURCE(src))
 			ADD_TRAIT(check, TRAIT_GODMODE, UNIQUE_TRAIT_SOURCE(src))
-			explosion(get_turf(user), devastation_range = 5, heavy_impact_range = 2, light_impact_range = 1, flash_range = 3, cause = id)
+			explosion(get_turf(user), devastation_range = 0, heavy_impact_range = 1, light_impact_range = 2, flash_range = 2, cause = id)
 			// explosions have a spawn so this makes sure that we don't get gibbed
 			addtimer(CALLBACK(src, PROC_REF(wiz_cleanup), user, check), 0.3 SECONDS) //I want to be sure this lasts long enough, with lag.
 			add_attack_logs(user, check, "caused a wizard [id] explosion")


### PR DESCRIPTION

## Что этот ПР делает
Уменьшение мощности взрыва когда два мага дают пять.

## Почему это хорошо для игры
Делать разгермы 5 на 5 без кд это не очень смешно.

## Список изменений
:cl:
balance: Снижена мощность взрыва когда два мага дают пять.
/:cl:
