### PR TITLE
Sol traders buff

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -949,8 +949,9 @@
 	name = "Sol Trader"
 
 	uniform = /obj/item/clothing/under/rank/cargotech
+	suit = /obj/item/clothing/suit/armor/vest/combat
 	back = /obj/item/storage/backpack/industrial
-	belt = /obj/item/melee/baton
+	belt = /obj/item/storage/belt/military/assault/marines/cats/full
 	head = /obj/item/clothing/head/soft
 	shoes = /obj/item/clothing/shoes/color/black
 	l_ear = /obj/item/radio/headset
@@ -961,7 +962,9 @@
 		/obj/item/storage/box/survival = 1,
 		/obj/item/hand_labeler = 1,
 		/obj/item/hand_labeler_refill = 1,
+		/obj/item/melee/baton = 1,
 	)
+	suit_store = /obj/item/gun/projectile/automatic/cats
 
 /datum/outfit/admin/sol_trader/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()


### PR DESCRIPTION

## Что этот ПР делает
Выдает сол трейдерам армор, дробовик и патроны к нему
## Почему это хорошо для игры
Торговцы без какой либо охраны отправляются на станцию? *гифка из шрека где закрывается книга с фразой "ну и бредятина"*
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
balance: торговцы теперь спавнятся с броней и пушкой
/:cl:
