### PR TITLE
Новый смайт самоконтроля

### DIFF
--- a/code/__DEFINES/smites.dm
+++ b/code/__DEFINES/smites.dm
@@ -30,6 +30,7 @@
 #define SMITE_JACKBOOTS "Фантомный топот"
 #define SMITE_MACHINERY "Разумная машинерия"
 #define SMITE_HEADHIT "Головой об шлюзы"
+#define SMITE_SELF_CONTROL "Самоконтроль"
 
 GLOBAL_LIST_INIT(smites_not_human, list(
 	SMITE_LIGHTING = /datum/smite/lighting,
@@ -58,6 +59,7 @@ GLOBAL_LIST_INIT(smites_human, list(
 	SMITE_DEMOTE = /datum/smite/demote, // Nothing that need being human, but you can't demote corgi.
 	SMITE_VIRUS = /datum/smite/virus,
 	SMITE_BRAINROTBRAINDAMAGE = /datum/smite/brainrot_braingamage,
+	SMITE_SELF_CONTROL = /datum/smite/self_control,
 ))
 
 GLOBAL_LIST_INIT(default_brainrot, list(

--- a/code/modules/admin/smites.dm
+++ b/code/modules/admin/smites.dm
@@ -584,6 +584,7 @@
 	ADD_TRAIT(target, TRAIT_AIRLOCK_HIT, ADMIN_TRAIT)
 	to_chat(target, span_userdanger("Вы чувствуете что стали на пару сантиметров выше. К чему бы это? Может это наказание за [reason]?"))
 
+// MARK: Self Control
 /datum/smite/self_control
 	name = SMITE_SELF_CONTROL
 	desc = "Покажите свои возможности к самоконтролю!"

--- a/code/modules/admin/smites.dm
+++ b/code/modules/admin/smites.dm
@@ -595,8 +595,7 @@
 	var/obj/item/reagent_containers/food/snacks/watermelonslice/self_control_watermelon = new()
 	self_control_watermelon.name = "Самоконтроль"
 	self_control_watermelon.desc = "Показатель невероятного самоконтроля Божественной сущности."
-	target.drop_r_hand()
-	target.equip_to_slot_or_del(self_control_watermelon, ITEM_SLOT_HAND_RIGHT)
+	target.put_in_any_hand_if_possible(self_control_watermelon)
 	to_chat(target, span_userdanger("Вы чувствуете, что в вашей руке появилась долька арбуза. Но что она значит?"))
 
 // MARK: Admin smite proc

--- a/code/modules/admin/smites.dm
+++ b/code/modules/admin/smites.dm
@@ -592,9 +592,7 @@
 	category = SMITE_CATEGORY_CONTROL
 
 /datum/smite/self_control/apply_effect(mob/living/target, reason)
-	var/obj/item/reagent_containers/food/snacks/watermelonslice/self_control_watermelon = new()
-	self_control_watermelon.name = "Самоконтроль"
-	self_control_watermelon.desc = "Показатель невероятного самоконтроля Божественной сущности."
+	var/obj/item/reagent_containers/food/snacks/watermelonslice/self_control_slice/self_control_watermelon = new()
 	target.put_in_any_hand_if_possible(self_control_watermelon)
 	to_chat(target, span_userdanger("Вы чувствуете, что в вашей руке появилась долька арбуза. Но что она значит?"))
 

--- a/code/modules/admin/smites.dm
+++ b/code/modules/admin/smites.dm
@@ -584,6 +584,20 @@
 	ADD_TRAIT(target, TRAIT_AIRLOCK_HIT, ADMIN_TRAIT)
 	to_chat(target, span_userdanger("Вы чувствуете что стали на пару сантиметров выше. К чему бы это? Может это наказание за [reason]?"))
 
+/datum/smite/self_control
+	name = SMITE_SELF_CONTROL
+	desc = "Покажите свои возможности к самоконтролю!"
+	logmsg = "self control watermelon"
+	category = SMITE_CATEGORY_CONTROL
+
+/datum/smite/self_control/apply_effect(mob/living/target, reason)
+	var/obj/item/reagent_containers/food/snacks/watermelonslice/self_control_watermelon = new()
+	self_control_watermelon.name = "Самоконтроль"
+	self_control_watermelon.desc = "Показатель невероятного самоконтроля Божественной сущности."
+	target.drop_r_hand()
+	target.equip_to_slot_or_del(self_control_watermelon, ITEM_SLOT_HAND_RIGHT)
+	to_chat(target, span_userdanger("Вы чувствуете, что в вашей руке появилась долька арбуза. Но что она значит?"))
+
 // MARK: Admin smite proc
 ADMIN_VERB_ONLY_CONTEXT_MENU(admin_smite, R_ADMIN|R_EVENT, "Smite", mob/living/target in GLOB.mob_list)
 	if(!istype(target))

--- a/code/modules/food_and_drinks/food/foods/ingredients.dm
+++ b/code/modules/food_and_drinks/food/foods/ingredients.dm
@@ -126,6 +126,20 @@
 	tastes = list("watermelon" = 1)
 	foodtype = FRUIT
 
+/obj/item/reagent_containers/food/snacks/watermelonslice/self_control_slice
+	name = "self control"
+	desc = "Показатель невероятного самоконтроля Божественной сущности."
+
+/obj/item/reagent_containers/food/snacks/watermelonslice/self_control_slice/get_ru_names()
+		return list(
+		NOMINATIVE = "Самоконтроль",
+		GENITIVE = "Самоконтроля",
+		DATIVE = "Самоконтролю",
+		ACCUSATIVE = "Самоконтроль",
+		INSTRUMENTAL = "Самоконтролем",
+		PREPOSITIONAL = "Самоконтроле",
+	)
+
 /obj/item/reagent_containers/food/snacks/pineappleslice
 	name = "pineapple slices"
 	desc = "Rings of pineapple."


### PR DESCRIPTION

## Что этот ПР делает
Добавляет смайт "Самоконтроль", который выдает дольку арбуза с названием "Самоконтроль" и описанием "Показатель невероятного самоконтроля Божественной сущности."
## Почему это хорошо для игры
Безобидный смайт, мягко намекающий на кринжевое поведение игрока

https://github.com/user-attachments/assets/30c9723d-c802-4f6b-8dcc-345c7eb09543

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:

admin: Новый смайт "Самоконтроль"

/:cl:
