### PR TITLE
Increased taser damage

### DIFF
--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -6,7 +6,7 @@
 	shockbull = TRUE
 	nodamage = TRUE
 	confused = 2.5 SECONDS
-	stamina = 20
+	stamina = 25
 	stutter = 8 SECONDS
 	jitter = 30 SECONDS
 	hitsound = 'sound/weapons/tase.ogg'


### PR DESCRIPTION

## Что этот ПР делает

Повышает стамина урон тазеру **с 20 до 25** единиц за попадание.

## Почему это хорошо для игры

Делает тазер более применимым в текущем балансе, что хорошо скажется на разнообразии: на данный момент используется **только** режим истощения _(синий)_.

Фактически в большинстве ситуаций это будет не 4 попадания, так как входящий урон по выносливости снижает броня, а скорость и дальность снаряда очень маленькие.

## Список изменений
:cl: Keslik
balance: Режим тазера наносит больше урона по выносливости (20 -> 25)
/:cl:
