### PR TITLE
Убирает лишнюю скобку в ачивментах (boobs vulp)

### DIFF
--- a/code/datums/achievements/_awards.dm
+++ b/code/datums/achievements/_awards.dm
@@ -127,7 +127,7 @@
 		return
 
 	var/percent = FLOOR(times_achieved / SSachievements.most_unlocked_achievement.times_achieved * 100, 0.01)
-	.["achieve_tooltip"] = "[(times_achieved && !percent) ? "Менее 0,01" : percent]% от показателя самого популярного достижения: \"[SSachievements.most_unlocked_achievement.name])\""
+	.["achieve_tooltip"] = "[(times_achieved && !percent) ? "Менее 0,01" : percent]% от показателя самого популярного достижения: \"[SSachievements.most_unlocked_achievement.name]\""
 
 /datum/award/achievement/parse_value(raw_value)
 	return raw_value > 0


### PR DESCRIPTION

## Что этот ПР делает
Убирает лишнюю скобку в предложении "*процент* от показателя самого популярного достижения: *ачивка_нейм*"
Смотрите дифф короче
## Почему это хорошо для игры
Бугфикс
## Список изменений
:cl:
bugfix: Убрана лишняя скобка в достижениях
/:cl:
