### PR TITLE
more mapping helpers

### DIFF
--- a/code/__DEFINES/directional.dm
+++ b/code/__DEFINES/directional.dm
@@ -32,28 +32,6 @@
 ///Flips the dir for east/west directions
 #define EWDIRFLIP(d) (d ^ (EAST|WEST))
 
-/// Create directional subtypes for a path to simplify mapping.
-#define MAPPING_DIRECTIONAL_HELPERS(path, offset) \
-##path/directional {\
-	abstract_type = ##path/directional; \
-} \
-##path/directional/north {\
-	dir = NORTH; \
-	pixel_y = offset; \
-} \
-##path/directional/south {\
-	dir = SOUTH; \
-	pixel_y = -offset; \
-} \
-##path/directional/east {\
-	dir = EAST; \
-	pixel_x = offset; \
-} \
-##path/directional/west {\
-	dir = WEST; \
-	pixel_x = -offset; \
-}
-
 // Names for directions (English)
 #define DIR_NAME_ENG_NORTH "NORTH"
 #define DIR_NAME_ENG_SOUTH "SOUTH"

--- a/code/__DEFINES/mappers.dm
+++ b/code/__DEFINES/mappers.dm
@@ -1,0 +1,115 @@
+/// Create directional subtypes for a path to simplify mapping.
+#define MAPPING_DIRECTIONAL_HELPERS(path, offset) \
+##path/directional {\
+	abstract_type = ##path/directional; \
+} \
+##path/directional/north {\
+	dir = NORTH; \
+	pixel_y = offset; \
+} \
+##path/directional/south {\
+	dir = SOUTH; \
+	pixel_y = -offset; \
+} \
+##path/directional/east {\
+	dir = EAST; \
+	pixel_x = offset; \
+} \
+##path/directional/west {\
+	dir = WEST; \
+	pixel_x = -offset; \
+}
+
+/// Create diagonal subtypes for a path to simplify mapping.
+#define MAPPING_DIAGONAL_HELPERS(path, offset) \
+##path/directional {\
+	abstract_type = ##path/directional; \
+} \
+##path/directional/northeast {\
+	dir = NORTHEAST; \
+	pixel_x = offset; \
+	pixel_y = offset; \
+} \
+##path/directional/northwest {\
+	dir = NORTHWEST; \
+	pixel_x = -offset; \
+	pixel_y = offset; \
+} \
+##path/directional/southeast {\
+	dir = SOUTHEAST; \
+	pixel_x = offset; \
+	pixel_y = -offset; \
+} \
+##path/directional/southwest {\
+	dir = SOUTHWEST; \
+	pixel_x = -offset; \
+	pixel_y = -offset; \
+}
+
+/// If we want to set custom offset to each cardinal direction.
+#define MAPPING_DIRECTIONAL_HELPERS_CUSTOM(path, offset_north, offset_south, offset_east, offset_west) \
+##path/directional {\
+	abstract_type = ##path/directional; \
+} \
+##path/directional/north {\
+	dir = NORTH; \
+	pixel_y = offset_north; \
+} \
+##path/directional/south {\
+	dir = SOUTH; \
+	pixel_y = offset_south; \
+} \
+##path/directional/east {\
+	dir = EAST; \
+	pixel_x = offset_east; \
+} \
+##path/directional/west {\
+	dir = WEST; \
+	pixel_x = offset_west; \
+}
+
+/// Creates subtypes for all 8 directions with a custom offset.
+#define MAPPING_BUTTON_HELPERS(path, offset_1, offset_2) \
+##path/offset {\
+	abstract_type = ##path/offset; \
+} \
+##path/offset/northwest {\
+	dir = NORTHWEST; \
+	pixel_x = -offset_2; \
+	pixel_y = offset_1; \
+} \
+##path/offset/north {\
+	dir = NORTH; \
+	pixel_x = offset_2; \
+	pixel_y = offset_1; \
+} \
+##path/offset/northeast {\
+	dir = NORTHEAST; \
+	pixel_x = offset_1; \
+	pixel_y = offset_2; \
+} \
+##path/offset/east {\
+	dir = EAST; \
+	pixel_x = offset_1; \
+	pixel_y = -offset_2; \
+} \
+##path/offset/southeast {\
+	dir = SOUTHEAST; \
+	pixel_x = offset_2; \
+	pixel_y = -offset_1; \
+} \
+##path/offset/south {\
+	dir = SOUTH; \
+	pixel_x = -offset_2; \
+	pixel_y = -offset_1; \
+} \
+##path/offset/southwest {\
+	dir = SOUTHWEST; \
+	pixel_x = -offset_1; \
+	pixel_y = -offset_2; \
+} \
+##path/offset/west {\
+	dir = WEST; \
+	pixel_x = -offset_1; \
+	pixel_y = offset_2; \
+}

--- a/paradise.dme
+++ b/paradise.dme
@@ -126,6 +126,7 @@
 #include "code\__DEFINES\localization.dm"
 #include "code\__DEFINES\logs.dm"
 #include "code\__DEFINES\machines.dm"
+#include "code\__DEFINES\mappers.dm"
 #include "code\__DEFINES\mapping.dm"
 #include "code\__DEFINES\maps.dm"
 #include "code\__DEFINES\martial_arts.dm"


### PR DESCRIPTION

## Что этот ПР делает
Дополнительные маппинг хелперы для оффсета настенных объектов. Сплит.
- `MAPPING_DIAGONAL_HELPERS` - 4 диагональных направления с одинаковым оффсетом. Просто диагональный аналог базового `MAPPING_DIRECTIONAL_HELPERS`.
- `MAPPING_DIRECTIONAL_HELPERS_CUSTOM` - 4 направления по сторонам света с настраиваемым оффсетом для каждого отдельно. Применимо к раковинам каким-нибудь.
- `MAPPING_BUTTON_HELPERS` - 8 направлений с настраиваемым оффсетом для `x` и `y`. Применимо к кнопкам, чтобы шифтить по 2 на стену.

## Список изменений
n/a