### PR TITLE
Макро-бомба дедам + ДНК лок на МЭКи ОБР и дедов

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -397,7 +397,10 @@
 		/obj/item/reagent_containers/applicator/abductor/industrial = 1,
 	)
 
-	implants = list(/obj/item/implant/mindshield/ert)
+	implants = list(
+	/obj/item/implant/mindshield/ert,
+	/obj/item/implant/explosive/macro,
+	)
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/eyes/map/ert,

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -398,8 +398,9 @@
 	)
 
 	implants = list(
-	/obj/item/implant/mindshield/ert,
-	/obj/item/implant/explosive/macro,
+
+		/obj/item/implant/mindshield/ert,
+		/obj/item/implant/explosive/macro,
 	)
 
 	cybernetic_implants = list(

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -398,7 +398,6 @@
 	)
 
 	implants = list(
-
 		/obj/item/implant/mindshield/ert,
 		/obj/item/implant/explosive/macro,
 	)

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -413,7 +413,7 @@
 	applied_modules = list(
 		/obj/item/mod/module/storage/bluespace,
 		/obj/item/mod/module/welding,
-		/obj/item/mod/module/emp_shield,
+		/obj/item/mod/module/dna_lock/emp_shield,
 		/obj/item/mod/module/status_readout,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/magboot/advanced,
@@ -424,6 +424,7 @@
 	default_pins = list(
 		/obj/item/mod/module/magboot/advanced,
 		/obj/item/mod/module/jetpack/advanced,
+		/obj/item/mod/module/dna_lock/emp_shield,
 	)
 	/// The insignia type, insignias show what sort of member of the ERT you're dealing with.
 	var/insignia_type = /obj/item/mod/module/insignia
@@ -471,7 +472,7 @@
 	applied_modules = list(
 		/obj/item/mod/module/storage/bluespace,
 		/obj/item/mod/module/welding,
-		/obj/item/mod/module/emp_shield,
+		/obj/item/mod/module/dna_lock/emp_shield,
 		/obj/item/mod/module/status_readout,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/magboot/advanced/elite,
@@ -484,6 +485,7 @@
 	default_pins = list(
 		/obj/item/mod/module/magboot/advanced/elite,
 		/obj/item/mod/module/jetpack/advanced,
+		/obj/item/mod/module/dna_lock/emp_shield,
 	)
 
 /obj/item/mod/control/pre_equipped/responsory/inquisitory/commander
@@ -509,7 +511,7 @@
 	applied_modules = list(
 		/obj/item/mod/module/storage/bluespace,
 		/obj/item/mod/module/welding,
-		/obj/item/mod/module/emp_shield,
+		/obj/item/mod/module/dna_lock/emp_shield,
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/status_readout,
 		/obj/item/mod/module/magboot/advanced/elite,
@@ -524,13 +526,14 @@
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/magboot/advanced/elite,
 		/obj/item/mod/module/visor/thermal,
+		/obj/item/mod/module/dna_lock/emp_shield,
 	)
 
 /obj/item/mod/control/pre_equipped/apocryphal/officer
 	applied_modules = list(
 		/obj/item/mod/module/storage/bluespace,
 		/obj/item/mod/module/welding,
-		/obj/item/mod/module/emp_shield,
+		/obj/item/mod/module/dna_lock/emp_shield,
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/status_readout,
 		/obj/item/mod/module/magboot/advanced/elite,
@@ -540,6 +543,7 @@
 	default_pins = list(
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/magboot/advanced/elite,
+		/obj/item/mod/module/dna_lock/emp_shield,
 		/obj/item/mod/module/power_kick, //If you are not drop kicking a xenomorph, what are you doing as an DS commander?
 	)
 
@@ -558,6 +562,7 @@
 		/obj/item/mod/module/jump_jet,
 		/obj/item/mod/module/longfall,
 		/obj/item/mod/module/hat_stabilizer,
+		/obj/item/mod/module/chameleon,
 	)
 	default_pins = list(
 		/obj/item/mod/module/anomaly_locked/kinesis/plus,


### PR DESCRIPTION
## Что этот ПР делает

- МЭКи ОБР получили модуль блокировки по ДНК.
- МЭКи Дедов получили модуль блокировки по ДНК.
- ЦКшный МЭК (щитспавн) получил модуль маскировки под рюкзак.
- Деды получили имплант макро-бомбы.

## Почему это хорошо для игры

Логично, что НТ не допустит, эм, попадание своих технологий вражеским корпорациям/агентам так просто. Хз, почему на МЭКах ОБР и дедов раньше не стоял ДНК лок.

Ну а про макро-бомбы дедам - хз смешно стало, решил добавить. Если вы каким-то образом убили деда, он смешно лопнет, забрав вас с собой.

## Список изменений

:cl:
add: Макро-бомба дедам + ДНК лок на МЭКи ОБР и дедов.

/:cl: