### PR TITLE
Замена плазмы на БЗ у гланды абдукторов

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -323,25 +323,23 @@
 	for(var/mob/living/carbon/human/H in oview(3, owner)) // Blood decals for simple animals would be neat. aka Carp with blood on it.
 		H.add_mob_blood(owner)
 
-/obj/item/organ/internal/heart/gland/plasma
+/obj/item/organ/internal/heart/gland/toxic_gas
 	cooldown_low = 1200
 	cooldown_high = 1800
 	origin_tech = "materials=4;biotech=4;plasmatech=6;abductor=3"
 	uses = -1
 	mind_control_duration = 800
 
-/obj/item/organ/internal/heart/gland/plasma/activate()
-	spawn(0)
-		to_chat(owner, span_warning("Вы чувствуете тяжесть в животе."))
-		sleep(150)
-		if(!owner)
-			return
-		to_chat(owner, span_userdanger("Вас охватывает мучительная боль в желудке."))
-		sleep(50)
-		if(!owner)
-			return
-		owner.visible_message(span_danger("[capitalize(owner)] отрыгива[PLUR_ET_YUT(owner)] облако плазмы!"))
-		var/turf/simulated/T = get_turf(owner)
-		if(istype(T))
-			T.atmos_spawn_air(LINDA_SPAWN_TOXINS, 50, T20C)
-		owner.vomit()
+/obj/item/organ/internal/heart/gland/toxic_gas/activate()
+	to_chat(owner, span_warning("Вы чувствуете тяжесть в животе."))
+	addtimer(CALLBACK(src, PROC_REF(timered_gas_spawn)), 30 SECONDS)
+
+/obj/item/organ/internal/heart/gland/toxic_gas/proc/timered_gas_spawn()
+	if(!owner)
+		return
+	to_chat(owner, span_userdanger("Вас охватывает мучительная боль в желудке."))
+	owner.visible_message(span_danger("[capitalize(owner.name)] отрыгива[PLUR_ET_YUT(owner)] облако неизвестного газа!"))
+	var/turf/simulated/turf = get_turf(owner)
+	if(istype(turf))
+		turf.atmos_spawn_air(LINDA_SPAWN_BZ, 50, T20C)
+	owner.vomit()


### PR DESCRIPTION

## Что этот ПР делает
Заменяет газ создаваемый гландой абдуктора с плазмы на БЗ. Уменьшает время между активацией и спавном газа до 30с. Переводит код этой железы на таймер вместо sleep
## Почему это хорошо для игры
Смотреть скриншоты, почему плазма - не хорошо. А БЗ создает небольшой хаос, не уничтожая отдел в ноль
<img width="730" height="689" alt="изображение" src="https://github.com/user-attachments/assets/9f05decb-973a-42ef-8db6-159582c2ab93" />
<img width="882" height="569" alt="изображение" src="https://github.com/user-attachments/assets/90f24470-73ab-420b-89ae-3ea4b7726d5a" />
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
balance: Уменьшение задержки между активацией и спавном газа газовой железы абдуктора до 30с
tweak: Замена плазмы на БЗ у газовой железы абдуктора
refactor: sleep() -> addtimer() у газовой железы абдуктора
/:cl:
