### PR TITLE
iron wall's smoothing

### DIFF
--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -204,6 +204,8 @@
 	icon_state = "iron"
 	base_icon_state = "iron_wall"
 	smooth = SMOOTH_BITMASK
+	canSmoothWith = SMOOTH_GROUP_IRON_WALLS
+	smoothing_groups = SMOOTH_GROUP_IRON_WALLS
 
 /turf/simulated/wall/indestructible/bananium
 	name = "bananium wall"

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -225,6 +225,7 @@
 	icon_state = "iron"
 	sheet_type = /obj/item/stack/rods
 	sheet_amount = 5
+	base_icon_state = "iron_wall"
 	smooth = SMOOTH_BITMASK
 	canSmoothWith = SMOOTH_GROUP_IRON_WALLS
 	smoothing_groups = SMOOTH_GROUP_IRON_WALLS

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -225,6 +225,7 @@
 	icon_state = "iron"
 	sheet_type = /obj/item/stack/rods
 	sheet_amount = 5
+	smooth = SMOOTH_BITMASK
 	canSmoothWith = SMOOTH_GROUP_IRON_WALLS
 	smoothing_groups = SMOOTH_GROUP_IRON_WALLS
 


### PR DESCRIPTION

## Что этот ПР делает

Добавляет смузинг у железных (которые делаются из iron rods) стен, чтобы они хорошо выглядели.

## Почему это хорошо для игры

Стены выглядят классно.

## Демонстрация изменений

<!-- Разместите изображения внутри блока ниже, если Вы меняли спрайты, карту или ваши изменения требуют визуальной демонстрации изменений. -->

<details><summary>Изображения и видео</summary>
<p>
<img width="729" height="653" alt="image" src="https://github.com/user-attachments/assets/f3c528e9-6fb2-46c4-b658-7ae237d35ebd" />

</p>
</details>

## Список изменений
:cl:
bugfix: Исправлено сглаживание у железных стен.
/:cl:
