### PR TITLE
Фикс флага CANUNCONSCIOUS

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -535,6 +535,8 @@
 
 /datum/status_effect/transient/drowsiness/on_apply()
 	. = ..()
+	if(HAS_TRAIT(owner, TRAIT_SLEEPIMMUNE) || !(owner.status_flags & CANUNCONSCIOUS))
+		return FALSE
 	delay_diff = CONFIG_GET(number/movedelay/walk_delay) - CONFIG_GET(number/movedelay/run_delay)
 	RegisterSignal(owner, COMSIG_MOB_MOVE_INTENT_TOGGLED, PROC_REF(on_move_intent_toggle))
 	on_move_intent_toggle()

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -25,7 +25,7 @@
 	var/move_delay_add = 0 // movement delay to add
 	var/caste_movement_delay = 0
 
-	status_flags = CANPARALYSE|CANPUSH
+	status_flags = CANPARALYSE |CANPUSH| CANUNCONSCIOUS
 
 	var/attack_damage = 20
 	var/armour_penetration = 20

--- a/code/modules/mob/living/simple_animal/friendly/snail.dm
+++ b/code/modules/mob/living/simple_animal/friendly/snail.dm
@@ -91,7 +91,7 @@
 	response_harm   = "топчет"
 	mobility_flags = MOBILITY_FLAGS_REST_CAPABLE_DEFAULT
 	pass_flags = PASSTABLE | PASSGRILLE
-	status_flags = CANPARALYSE | CANPUSH
+	status_flags = CANPARALYSE | CANPUSH | CANUNCONSCIOUS
 	mob_size = MOB_SIZE_SMALL
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/salmonmeat/turtlemeat = 10, /obj/item/stack/ore/tranquillite = 5)
 	footstep_type = FOOTSTEP_MOB_SLIME

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -38,7 +38,7 @@
 
 	// canstun and canknockdown don't affect slimes because they ignore stun and knockdown variables
 	// for the sake of cleanliness, though, here they are.
-	status_flags = CANPARALYSE | CANPUSH
+	status_flags = CANPARALYSE | CANPUSH | CANUNCONSCIOUS
 
 	footstep_type = FOOTSTEP_MOB_SLIME
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -218,7 +218,7 @@
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 
 	/// Bitflags defining which status effects can be inflicted (replaces canweaken, canstun, etc)
-	var/status_flags = CANSTUN|CANWEAKEN|CANKNOCKDOWN|CANPARALYSE|CANPUSH
+	var/status_flags = CANSTUN|CANWEAKEN|CANKNOCKDOWN|CANPARALYSE|CANPUSH|CANUNCONSCIOUS
 
 	var/area/lastarea = null
 


### PR DESCRIPTION
## Что этот ПР делает

Когда был добавлен этот флаг, то его забыли добавить мобам. Посмотрел где он на ТГ используется, примерно добавил ещё и туда.

Если автобусник увидит, TRAIT_SLEEPIMMUNE тоже надо до конца допортировать. 
Фикс радиационного лазера вообще, но его надо тоже править. **Радиационный** лазер работает на всех расах, а также кривая механика, что можно менять интенсивность после использования и увеличивать стан.

## Почему это хорошо для игры

Радиационный лазер с аплинка работает

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
bugfix: Мобам добавлен флаг CAN_UNCONSCIOUS
/:cl:
