### PR TITLE
Фикс алерта зарядки мехов

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1480,6 +1480,7 @@
 
 	var/atom/movable/mob_container
 
+	occupant.clear_alert("charge")
 	occupant.clear_alert("locked")
 	occupant.clear_alert("mech damage")
 	occupant.clear_alert("mechaport")


### PR DESCRIPTION
## Список изменений
:cl:
bugfix: Теперь алерт зарядки меха исчезает при выходе из него.
/:cl:
