### PR TITLE
balance: ДНК ускорение конфликтует с остальными ускорениями куклы

### DIFF
--- a/code/modules/movespeed/modifiers/innate.dm
+++ b/code/modules/movespeed/modifiers/innate.dm
@@ -4,8 +4,10 @@
 
 /datum/movespeed_modifier/dna_vault_speedup
 	blacklisted_movetypes = (FLYING|FLOATING)
+	conflicts_with = MOVE_CONFLICT_GOTTAGOFAST
 	multiplicative_slowdown = -1
 
 /datum/movespeed_modifier/increaserun
 	blacklisted_movetypes = (FLYING|FLOATING)
+	conflicts_with = MOVE_CONFLICT_GOTTAGOFAST
 	multiplicative_slowdown = -0.5


### PR DESCRIPTION
## Почему это хорошо для игры
Давно решили, что ускорение до соника это плохо, но днк забыли ограничить

## Список изменений
Ген "Повышение скорости" и ген из днк-хранилища (плюс антаг инъектор) теперь не стакаются с другими способами ускорения


:cl:
balance: Ген повышения скорости и ген ускорения с днк-хранилища теперь не стакаются
/:cl: