### PR TITLE
Добавление штык ножей для шахтеров

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -352,6 +352,8 @@
 	)
 	prize_list["Kinetic Accelerator"] = list(
 		EQUIPMENT("Kinetic Accelerator", /obj/item/gun/energy/kinetic_accelerator, 1000),
+		EQUIPMENT("Bayonet knife", /obj/item/gun_module/under/bayonet, 250),
+		EQUIPMENT("Long bayonet knife", /obj/item/gun_module/under/bayonet/long, 2000),
 		EQUIPMENT("KA Adjustable Tracer Rounds", /obj/item/borg/upgrade/modkit/tracer/adjustable, 200),
 		EQUIPMENT("KA AoE Damage", /obj/item/borg/upgrade/modkit/aoe/mobs, 2500),
 		EQUIPMENT("KA Cooldown Decrease", /obj/item/borg/upgrade/modkit/cooldown/haste, 1500),

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -248,6 +248,7 @@
 			new /obj/item/borg/upgrade/modkit/range(drop_location)
 			new /obj/item/storage/bag/ore/bigger(drop_location)
 			new /obj/item/mining_satchel_upgrade(drop_location)
+			new /obj/item/gun_module/under/bayonet(drop_location)
 
 	qdel(voucher)
 


### PR DESCRIPTION

## Что этот ПР делает
Добавляет штык ножи для шахтеров:
- входит в набор улучшений КА с ваучера.
- можно купить обычный штык-нож за 250 очков шахты.
- можно купить длинный штык-нож за 2000 очков шахты.


## Почему это хорошо для игры
После изменения кода с штык ножами шахтеры остались без штыков, возвращаем, но платно.

## Список изменений
:cl:
add: Новые штык ножи в ваучер шахты и в вендор оборудования шахтеров.
/:cl:
