### PR TITLE
Bioregenerative diode disk can be crafted

### DIFF
--- a/code/modules/research/designs/protolathe/power_designs.dm
+++ b/code/modules/research/designs/protolathe/power_designs.dm
@@ -103,7 +103,7 @@
 /datum/design/diode_disk_healing
 	id = "diode_disk_healing"
 	build_type = PROTOLATHE
-	req_tech = list(RESEARCH_TREE_PROGRAMMING = 5, RESEARCH_TREE_BIO = 5)
+	req_tech = list(RESEARCH_TREE_PROGRAMMING = 5, RESEARCH_TREE_BIOTECH = 5)
 	materials = list(MAT_METAL = SMALL_MATERIAL_AMOUNT * 0.5, MAT_GLASS = SMALL_MATERIAL_AMOUNT, MAT_SILVER = SMALL_MATERIAL_AMOUNT) //silver is medical metal. Why? who knows.
 	construction_time = 0.5 SECONDS
 	build_path = /obj/item/emitter_disk/healing


### PR DESCRIPTION

## Что этот ПР делает

Меняет RESEARCH_TREE_BIO (нету) на RESEARCH_TREE_BIOTECH ("biotech")

## Почему это хорошо для игры
Выглядело сломано:
<img width="324" height="63" alt="image" src="https://github.com/user-attachments/assets/5e49f0e4-5be4-4775-87dd-4c7ac7cbef55" />
## Список изменений
:cl:
bugfix: Починен крафт Bioregenerative диска на эмиттер
/:cl:
