### PR TITLE
фиксы доступности

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -18,10 +18,10 @@
  *
  * Note that this proc can be overridden, and is in the case of screen objects.
  */
-/atom/Click(location,control,params)
+/atom/Click(location, control, params)
 	usr.ClickOn(src, params, location)
 
-/atom/DblClick(location,control,params)
+/atom/DblClick(location, control, params)
 	usr.DblClickOn(src,params)
 
 /**
@@ -145,46 +145,37 @@
 			return
 
 	// operate three levels deep here (item in backpack in src; item in box in backpack in src, not any deeper)
-	var/sdepth = A.storage_depth(src)
-	if(A == loc || (A in loc) || (sdepth != -1 && sdepth <= 2))
-		// No adjacency needed
+	if(A in DirectAccess())
 		beforeAdjacentClick(A, modifiers)
 		if(W)
 			W.melee_attack_chain(src, A, modifiers)
 		else
 			if(ismob(A))
 				changeNext_move(CLICK_CD_MELEE)
-			UnarmedAttack(A, 1, modifiers)
-
+			UnarmedAttack(A, TRUE, modifiers)
 		return
 
 	if(!loc.allow_click()) // This is going to stop you from telekinesing from inside a closet, but I don't shed many tears for that
 		return
 
 	// Allows you to click on a box's contents, if that box is on the ground, but no deeper than that
-	sdepth = A.storage_depth_turf()
-	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
-		if(A.IsReachableBy(src, W?.reach))
-			beforeAdjacentClick(A, modifiers)
-			if(W)
-				W.melee_attack_chain(src, A, modifiers)
+	if(A.IsReachableBy(src, W?.reach))
+		beforeAdjacentClick(A, modifiers)
+		if(W)
+			W.melee_attack_chain(src, A, modifiers)
+		else
+			if(ismob(A))
+				changeNext_move(CLICK_CD_MELEE)
+			UnarmedAttack(A, TRUE, modifiers)
+	else // non-adjacent click
+		beforeRangedClick(A, modifiers)
+		if(W)
+			A.base_ranged_item_interaction(src, W, modifiers)
+		else
+			if(LAZYACCESS(modifiers, RIGHT_CLICK))
+				ranged_secondary_attack(A, modifiers)
 			else
-				if(ismob(A))
-					changeNext_move(CLICK_CD_MELEE)
-				UnarmedAttack(A, 1, modifiers)
-
-			return
-		else // non-adjacent click
-			beforeRangedClick(A, modifiers)
-			if(W)
-				A.base_ranged_item_interaction(src, W, modifiers)
-			else
-				if(LAZYACCESS(modifiers, RIGHT_CLICK))
-					ranged_secondary_attack(A, modifiers)
-				else
-					RangedAttack(A, modifiers)
-
-	return
+				RangedAttack(A, modifiers)
 
 /mob/proc/beforeAdjacentClick(atom/A, list/modifiers)
 	return
@@ -240,6 +231,7 @@
 
 	if(isnull(loc) || isarea(loc))
 		return FALSE
+
 	if(!HAS_TRAIT(src, TRAIT_SKIP_BASIC_REACH_CHECK) && !loc.IsContainedAtomAccessible(src, user))
 		return FALSE
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -102,14 +102,12 @@
 		return
 
 	// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc && isturf(A.loc.loc))
-	if(isturf(A) || isturf(A.loc))
-		if(A.IsReachableBy(src, W?.reach))
-			W.melee_attack_chain(src, A, modifiers)
-			return
-		else
-			A.base_ranged_item_interaction(src, W, modifiers)
-			return
-	return
+	if(A.IsReachableBy(src, W?.reach))
+		W.melee_attack_chain(src, A, modifiers)
+		return
+	else if(isturf(A) || isturf(A.loc))
+		A.base_ranged_item_interaction(src, W, modifiers)
+		return
 
 //Ctrl+Middle click cycles through modules
 /mob/living/silicon/robot/proc/CtrlMiddleClickOn(atom/A)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -14,7 +14,6 @@
 	// You shouldn't need this, but if you ever do and it's widespread, reconsider what you're doing.
 	plane = HUD_PLANE
 	appearance_flags = NO_CLIENT_COLOR
-	interaction_flags_click = BYPASS_ADJACENCY
 	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_MOUSEDROP_IGNORE_CHECKS
 	flags = NO_SCREENTIPS
 	var/obj/master = null	//A reference to the object in the slot. Grabs or items, generally.
@@ -201,23 +200,6 @@
 		storage_master.attempt_insert(item)
 	return TRUE
 
-/atom/movable/screen/storage/proc/is_item_accessible(obj/item/I, mob/user)
-	if(!user || !I)
-		return FALSE
-
-	var/storage_depth = I.storage_depth(user)
-	if((I in user.loc) || (storage_depth != -1))
-		return TRUE
-
-	if(!isturf(user.loc))
-		return FALSE
-
-	var/storage_depth_turf = I.storage_depth_turf()
-	if(isturf(I.loc) || (storage_depth_turf != -1))
-		if(I.Adjacent(user))
-			return TRUE
-	return FALSE
-
 /atom/movable/screen/storage/mouse_drop_receive(obj/item/I, mob/user, params)
 	if(!user || !master || !istype(I) || user.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || ismecha(user.loc))
 		return FALSE
@@ -227,10 +209,6 @@
 
 	var/obj/item/storage/S = master
 	if(!S)
-		return FALSE
-
-	if(!is_item_accessible(I, user))
-		add_game_logs("tried to abuse storage remote drag&drop with '[I]' at [atom_loc_line(I)] into '[S]' at [atom_loc_line(S)]", user)
 		return FALSE
 
 	if(I in S.contents) // If the item is already in the storage, move them to the end of the list
@@ -473,7 +451,9 @@
 	M.check_languages()
 
 /atom/movable/screen/inventory
-	var/slot_id	//The indentifier for the slot. It has nothing to do with ID cards.
+	/// The identifier for the slot. It has nothing to do with ID cards.
+	var/slot_id
+	/// The overlay when hovering over with an item in your hand
 	var/image/object_overlay
 
 /atom/movable/screen/inventory/MouseEntered(location, control, params)
@@ -571,7 +551,7 @@
 	I.pickup(user)
 
 /atom/movable/screen/inventory/hand
-	interaction_flags_atom = NONE //so dragging objects into hands icon don't skip adjacency & other checks
+	//interaction_flags_atom = NONE //so dragging objects into hands icon don't skip adjacency & other checks
 	/// Previous UI style, used by user. Requires to properly update user's active hand overlay.
 	var/prev_ui_style
 	/// Currently used overlay for active hand. It's icon switches with user's theme.
@@ -662,7 +642,7 @@
 #undef HAND_GRAB_KILL
 #undef HAND_GRAB_SUPPRESS_BLOODLOSS
 
-/atom/movable/screen/inventory/hand/Click()
+/atom/movable/screen/inventory/hand/Click(location, control, params)
 	// At this point in client Click() code we have passed the 1/10 sec check and little else
 	// We don't even know if it's a middle click
 	var/mob/user = hud?.mymob

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -73,7 +73,8 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	var/stealthy_audio = FALSE
 	var/w_class = WEIGHT_CLASS_NORMAL
 	pressure_resistance = 4
-	//	causeerrorheresoifixthis
+	/// This var exists as a weird proxy "owner" ref
+	/// It's used in a few places. Stop using it, and optimially replace all uses please
 	var/obj/item/master = null
 
 	/// Price of an item in a vending machine, overriding the base vending machine price. Define in terms of PAYCHECK defines as opposed to raw numbers.

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -35,7 +35,7 @@
  */
 /obj/item/storage/internal/proc/handle_mousedrop(mob/living/carbon/human/user, obj/over_object)
 	. = FALSE
-	if(over_object == user && ishuman(user) && !user.incapacitated() && !HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) && !ismecha(user.loc) && !is_ventcrawling(user) && user.Adjacent(master_item))
+	if(over_object == user && ishuman(user) && !user.incapacitated() && !HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) && !ismecha(user.loc) && !is_ventcrawling(user) && master_item.IsReachableBy(user))
 		open(user)
 		master_item.add_fingerprint(user)
 		return TRUE

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -142,7 +142,7 @@
 		var/obj/item/storage = over_object
 		if(!(storage.item_flags & IN_STORAGE))
 			dump_storage(user, over_object)
-			return
+			return TRUE
 
 	if((!istype(src, /obj/item/storage/lockbox) && (istable(over_object) || isfloorturf(over_object)) \
 		&& length(contents) && loc == user && !user.incapacitated() && over_object.IsReachableBy(user)))
@@ -960,42 +960,6 @@
 	var/obj/item/stack/I = new foldable(get_turf(src), foldable_amt)
 	user.put_in_hands(I)
 	qdel(src)
-
-//Returns the storage depth of an atom. This is the number of storage items the atom is contained in before reaching toplevel (the area).
-//Returns -1 if the atom was not found on container.
-/atom/proc/storage_depth(atom/container)
-	var/depth = 0
-	var/atom/cur_atom = src
-
-	while(cur_atom && !(cur_atom in container.contents))
-		if(isarea(cur_atom))
-			return -1
-		if(isstorage(cur_atom.loc))
-			depth++
-		cur_atom = cur_atom.loc
-
-	if(!cur_atom)
-		return -1	//inside something with a null loc.
-
-	return depth
-
-//Like storage depth, but returns the depth to the nearest turf
-//Returns -1 if no top level turf (a loc was null somewhere, or a non-turf atom's loc was an area somehow).
-/atom/proc/storage_depth_turf()
-	var/depth = 0
-	var/atom/cur_atom = src
-
-	while(cur_atom && !isturf(cur_atom))
-		if(isarea(cur_atom))
-			return -1
-		if(isstorage(cur_atom.loc))
-			depth++
-		cur_atom = cur_atom.loc
-
-	if(!cur_atom)
-		return -1	//inside something with a null loc.
-
-	return depth
 
 /obj/item/storage/serialize()
 	var/data = ..()

--- a/code/modules/mob/holder_pet_carrier.dm
+++ b/code/modules/mob/holder_pet_carrier.dm
@@ -220,7 +220,7 @@
 	if(ismecha(drag_user.loc) || is_ventcrawling(drag_user) || drag_user.incapacitated() || HAS_TRAIT(drag_user, TRAIT_HANDS_BLOCKED))
 		return FALSE
 
-	if(over_object == drag_user && drag_user.Adjacent(src)) // this must come before the screen objects only block
+	if(over_object == drag_user && IsReachableBy(drag_user)) // this must come before the screen objects only block
 		try_free_content(user = drag_user)
 		return FALSE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -938,7 +938,7 @@
 	if(isliving(pulling))
 		set_pull_offsets(pulling, grab_state)
 
-	if(s_active && !(s_active in contents) && get_turf(s_active) != get_turf(src))	//check !(s_active in contents) first so we hopefully don't have to call get_turf() so much.
+	if(s_active && !(s_active.IsReachableBy(src)))	//check !(s_active in contents) first so we hopefully don't have to call get_turf() so much.
 		s_active.close(src)
 
 	if(body_position == LYING_DOWN && !buckled && prob(getBruteLoss() * 200 / maxHealth))


### PR DESCRIPTION

## Что этот ПР делает
С уходом от адских проверок на положение через локации и турфы, а так же Adjacent() к IsReachableBy, и рефакторе маусдропов с флагами, пропала надобность в бесполезных проках глубины инвентаря. Глубина инвентаря ограничивала подъем только из 3+, а это, если не упускаю какие-то абузы только аптечка в коробке?

Глубина исследования инвентаря была 

## Список изменений
:cl:
qol: Теперь при открытии storage на турфе, он не закрывается в приделах досягаемости куклы.
bugfix: Исправление перетаскивания предметов в руки.
/:cl:
