### PR TITLE
Добавляет почти все пачки сигарет в вендор сигарет

### DIFF
--- a/code/modules/vending/cigarette.dm
+++ b/code/modules/vending/cigarette.dm
@@ -32,13 +32,17 @@
 
 	product_categories = list(
 		list(
-			"name" = "Курительные приспособления",
+			"name" = "Никотиновая продукция",
 			"icon" = "smoking",
 			"products" = list(
 				/obj/item/storage/fancy/cigarettes/cigpack_robust = 8,
 				/obj/item/storage/fancy/cigarettes/cigpack_uplift = 8,
-				/obj/item/storage/fancy/cigarettes/cigpack_random = 8,
+				/obj/item/storage/fancy/cigarettes/cigpack_midori = 8,
+				/obj/item/storage/fancy/cigarettes/cigpack_carp = 8,
+				/obj/item/storage/fancy/cigarettes/dromedaryco = 8,
+				/obj/item/storage/fancy/cigarettes/cigpack_richard = 8,
 				/obj/item/ecig = 4,
+				/obj/item/reagent_containers/food/pill/patch/nicotine = 10,
 			),
 		),
 		list(
@@ -54,7 +58,6 @@
 			"name" = "Другое",
 			"icon" = "ellipsis",
 			"products" = list(
-				/obj/item/reagent_containers/food/pill/patch/nicotine = 10,
 				/obj/item/storage/fancy/rollingpapers = 3,
 			),
 		),


### PR DESCRIPTION

## Что этот ПР делает
## Почему это хорошо для игры
Часть этих сигарет является невосполнимой, если ты взял их в лодауте. Что, кмк, кринж. Исправляю этот недочет.
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
<img width="428" height="628" alt="image" src="https://github.com/user-attachments/assets/6ae538fe-c88e-4b1c-83d9-891dce1d4dc3" />

</p>
</details>

## Список изменений
:cl:
tweak: переименовал "курительные приспособления" в "никотиновая продукция"
tweak: вендор с сигаретами теперь продает большую часть сигарет (в т.ч из лодаута)
/:cl:
