### PR TITLE
Фикс абуза имплантов хила и адренала

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_adrenalin.dm
+++ b/code/game/objects/items/weapons/implants/implant_adrenalin.dm
@@ -18,8 +18,9 @@
 	QDEL_NULL(action)
 
 /obj/item/implant/adrenalin/implant(mob/living/carbon/human/source, mob/user, force)
-	add_item_action(action)
 	. = ..()
+	if(.)
+		add_item_action(action)
 
 /obj/item/implant/adrenalin/create_new_cooldown()
 	var/datum/implant_cooldown/charges/C = new
@@ -27,6 +28,11 @@
 	C.recharge_duration = base_cooldown
 	C.charge_duration = 1 SECONDS
 	return C
+
+/obj/item/implant/adrenalin/can_implant(mob/source, mob/user)
+	if(HAS_TRAIT(source, TRAIT_NO_HUNGER) || HAS_TRAIT(source, TRAIT_NO_BLOOD))
+		return FALSE
+	return ..()
 
 /obj/item/implant/adrenalin/activate()
 	var/datum/implant_cooldown/charges/charges_cooldown = cooldown_system

--- a/code/game/objects/items/weapons/implants/implant_explosive.dm
+++ b/code/game/objects/items/weapons/implants/implant_explosive.dm
@@ -84,15 +84,20 @@
 	self_destruct()
 
 /obj/item/implant/explosive/implant(mob/living/carbon/human/source, mob/user, force = FALSE)
+	. = ..()
+	if(!.)
+		return
+
 	var/obj/item/implant/explosive/same_imp = locate(type) in source
-	if(same_imp && same_imp != src)
-		same_imp.heavy += heavy
-		same_imp.medium += medium
-		same_imp.weak += weak
-		same_imp.delay += delay
-		qdel(src)
-		return TRUE
-	return ..()
+	if(!same_imp || same_imp == src)
+		return
+
+	same_imp.heavy += heavy
+	same_imp.medium += medium
+	same_imp.weak += weak
+	same_imp.delay += delay
+	qdel(src)
+	return TRUE
 
 /obj/item/implant/explosive/macro
 	name = "macrobomb bio-chip"
@@ -114,17 +119,22 @@
 	timed_explosion()
 
 /obj/item/implant/explosive/macro/implant(mob/living/carbon/human/source, mob/user, force = FALSE)
+	. = ..()
+	if(!.)
+		return
+
 	var/obj/item/implant/explosive/same_imp = locate(type) in source
 	if(same_imp && same_imp != src)
 		return FALSE
 	same_imp = locate(/obj/item/implant/explosive) in source
-	if(same_imp && same_imp != src)
-		heavy += same_imp.heavy
-		medium += same_imp.medium
-		weak += same_imp.weak
-		delay += same_imp.delay
-		qdel(same_imp)
-	return ..()
+	if(!same_imp || same_imp == src)
+		return
+
+	heavy += same_imp.heavy
+	medium += same_imp.medium
+	weak += same_imp.weak
+	delay += same_imp.delay
+	qdel(same_imp)
 
 /obj/item/implanter/explosive
 	name = "bio-chip implanter (micro-explosive)"

--- a/code/game/objects/items/weapons/implants/implant_heal.dm
+++ b/code/game/objects/items/weapons/implants/implant_heal.dm
@@ -17,9 +17,15 @@
 	. = ..()
 	QDEL_NULL(action)
 
+/obj/item/implant/heal/can_implant(mob/source, mob/user)
+	if(HAS_TRAIT(source, TRAIT_NO_HUNGER))
+		return FALSE
+	return ..()
+
 /obj/item/implant/heal/implant(mob/living/carbon/human/source, mob/user, force)
-	add_item_action(action)
 	. = ..()
+	if(.)
+		add_item_action(action)
 
 /obj/item/implant/heal/create_new_cooldown()
 	var/datum/implant_cooldown/charges/charges_cooldown = new

--- a/code/game/objects/items/weapons/implants/implant_storage.dm
+++ b/code/game/objects/items/weapons/implants/implant_storage.dm
@@ -36,21 +36,25 @@
 		storage.remove_from_storage(item, drop_location())
 
 /obj/item/implant/storage/implant(mob/living/source, mob/user, force = FALSE)
+	. = ..()
+	if(!.)
+		return
+
 	var/obj/item/implant/storage/imp_e = locate(src.type) in source
-	if(imp_e)
-		imp_e.storage.storage_slots += storage.storage_slots
-		imp_e.storage.max_combined_w_class += storage.max_combined_w_class
-		imp_e.storage.contents += storage.contents
+	if(!imp_e)
+		return
 
-		for(var/mob/check in range(1))
-			if(check.s_active == storage)
-				storage.close(check)
-		storage.show_to(source)
+	imp_e.storage.storage_slots += storage.storage_slots
+	imp_e.storage.max_combined_w_class += storage.max_combined_w_class
+	imp_e.storage.contents += storage.contents
 
-		qdel(src)
-		return TRUE
+	for(var/mob/check in range(1))
+		if(check.s_active == storage)
+			storage.close(check)
+	storage.show_to(source)
 
-	return ..()
+	qdel(src)
+	return TRUE
 
 /obj/item/implant/storage/proc/get_contents() //Used for swiftly returning a list of the implant's contents i.e. for checking a theft objective's completion.
 	if(storage?.contents)

--- a/code/game/objects/items/weapons/implants/implant_traitor.dm
+++ b/code/game/objects/items/weapons/implants/implant_traitor.dm
@@ -9,6 +9,10 @@
 	var/mindslave_UID
 
 /obj/item/implant/traitor/implant(mob/living/carbon/human/mindslave_target, mob/living/carbon/human/user, force = FALSE)
+	. = ..()
+	if(!.)
+		return
+
 	// Check `implanted` here so you can't just keep taking it out and putting it back into other people.
 	if(implanted == BIOCHIP_USED || !ishuman(mindslave_target) || !ishuman(user)) // Both the target and the user need to be human.
 		return FALSE

--- a/code/modules/mini_games/thunderdome/items/implants.dm
+++ b/code/modules/mini_games/thunderdome/items/implants.dm
@@ -15,6 +15,9 @@
 
 /obj/item/implant/postponed_death/implant(mob/source, mob/user)
 	. = ..()
+	if(!.)
+		return
+
 	addtimer(CALLBACK(src, PROC_REF(activate)), time_to_live)
 
 /obj/item/implant/postponed_death/activate()


### PR DESCRIPTION

## Что этот ПР делает
1. Добавлена проверка на кровь и нутрименты для импланта адреналина. 
2. Добавлена проверка на нутрименты для импланта лечения. 
3. Добавлена пропущенная проверка can_implant для всех имплантов.

То есть если у куклы нет крови или нутриментов - он не может использовать имплант адренала. Ну и если нету нутриментов - нельзя использовать имплант лечения.


## Почему это хорошо для игры
Потому что сейчас плазмачи могут использовать данные импланты без негативных эффектов, так как у них нет крови и нутриментов. Адренал должен давать защиту от стана и скорость взамен крови и нутриментов, все должно быть честно.

PS: это не баланс, а багфикс.

## Список изменений
:cl:
bugfix: Добавлена проверка на кровь и нутрименты для импланта адреналина.
bugfix: Добавлена проверка на нутрименты для импланта лечения.
bugfix: Добавлены проверки на can_implant для многих имплантов в которых она пропущена.
/:cl:
