### PR TITLE
Стартовый набор агента

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -875,10 +875,8 @@ GLOBAL_LIST_EMPTY(admin_objective_list)
 	antag_menu_name = "Получить снаряжение"
 	explanation_text = "Получить бесплатное снаряжение в определенном месте (необязательно)."
 	needs_target = FALSE
-	special_object_type = /obj/item/storage/box/syndie_kit/stechkin_pistol
-
-/datum/objective/get_equipment/check_completion()
-	return TRUE
+	special_object_type = /obj/item/storage/box/syndie_kit/agent_base_kit
+	completed = TRUE
 
 // MARK: Glorious death
 /datum/objective/die

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -931,10 +931,33 @@ To apply, hold the injector a short distance away from the outer thigh before ap
 
 /obj/item/storage/box/syndie_kit/stechkin_pistol/populate_contents()
 	new	/obj/item/gun/projectile/automatic/pistol(src)
+	new /obj/item/ammo_box/magazine/m10mm(src)
+	new /obj/item/ammo_box/magazine/m10mm(src)
+	new /obj/item/ammo_box/magazine/m10mm(src)
+
+/obj/item/storage/box/syndie_kit/agent_base_kit
+	name = "agent base kit"
+	desc = "Набор, содержащий минимальный комплект снаряжения для выполнения задач."
+
+/obj/item/storage/box/syndie_kit/agent_base_kit/get_ru_names()
+	return list(
+		NOMINATIVE = "базовый набор агента",
+		GENITIVE = "базового набора агента",
+		DATIVE = "базовому набору агента",
+		ACCUSATIVE = "базовый набор агента",
+		INSTRUMENTAL = "базовым набором агента",
+		PREPOSITIONAL = "базовом наборе агента",
+	)
+
+/obj/item/storage/box/syndie_kit/agent_base_kit/populate_contents()
+	new /obj/item/storage/box/survival/survival_syndi(src)
+	new /obj/item/clothing/under/syndicate(src)
+	new /obj/item/clothing/shoes/combat(src)
+	new /obj/item/clothing/gloves/combat(src)
+	new /obj/item/flashlight(src)
+	new /obj/item/reagent_containers/food/snacks/donkpocket(src)
+	new	/obj/item/storage/box/syndie_kit/stechkin_pistol(src)
 	new /obj/item/gun_module/muzzle/suppressor(src)
-	new /obj/item/ammo_box/magazine/m10mm(src)
-	new /obj/item/ammo_box/magazine/m10mm(src)
-	new /obj/item/ammo_box/magazine/m10mm(src)
 
 /obj/item/storage/box/syndie_kit/rsh12_revolver
 	name = "RSh-12 revolver kit"


### PR DESCRIPTION

## Что этот ПР делает
Заменяет бесплатный набор со стечкином стартовым набором синдиката, в который помимо него входят мелочи из админских лодаутов синдикат агента(тактикулка, комбат ботинки и перчи, синдикоробка выживания, донкпокет(простой), фонарик и глушитель)
## Список изменений
:cl:
balance: Бесплатный стечкин заменен на базовый набор агента.
balance: Из набора сс стечкином убран глушитель.
/:cl:
