### PR TITLE
kinesis nerf

### DIFF
--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -81,10 +81,6 @@ tier 3 - range 7-8, can lift conscious
 
 	var/calculated_range = round((core.get_strength() / 20))
 	grab_range = min(calculated_range, maximum_grab_range)
-	if(core.get_strength() > 100)
-		stat_required = CONSCIOUS
-	if(core.get_strength() > 200)
-		incapacitated_required = FALSE
 
 /obj/item/mod/module/anomaly_locked/kinesis/on_select_use(atom/target)
 	. = ..()

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -67,9 +67,7 @@
 	return ..()
 
 /*
-tier 1 - range 2-3
-tier 2 - range 5-6, can lift conscious with handcuffs on them
-tier 3 - range 7-8, can lift conscious
+range 2-3
 */
 
 /obj/item/mod/module/anomaly_locked/kinesis/update_core_powers()


### PR DESCRIPTION

## Что этот ПР делает
Нерфит базовый кинезис, убирая у него возможность таскать живых и без наручников, оставляя это только админскому
## Почему это хорошо для игры
Второй месяц, ровно 22го числа, я вижу как игроков на ролях антагонистов носящих бладред ловит рандомный чел в модуль кинезиса и они не могут сделать ничего против этого, я устал играть с таким в команде, это неинтересно, босс 
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
balance: кинезис теперь может носить только мертвых, админский может носить живых и без наручников
/:cl:
