### PR TITLE
workflows update

### DIFF
--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -17,7 +17,7 @@ jobs:
           echo "SECRETS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
 
       - name: Send Discord notification
-        uses: MiraHell/discord-notify@v3.3
+        uses: littleboobs/discord-notify@v1.0-ss1984
         if: ${{ steps.secrets_set.outputs.SECRETS_ENABLED }}
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -54,7 +54,7 @@ jobs:
           dotnet-version: 9.x
 
       - name: Install OpenDream
-        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f
+        uses: robinraju/release-downloader@v1.13
         with:
           repository: "OpenDreamProject/OpenDream"
           tag: "latest"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -38,9 +38,11 @@ jobs:
       - name: Filter staled pull requests for announcement
         id: filter-prs
         uses: actions/github-script@v9
+        env:
+          input: ${{steps.stale.outputs.staled-issues-prs}}
         with:
           script: |
-            return JSON.parse(`${{steps.stale.outputs.staled-issues-prs}}`)
+            return JSON.parse(process.env.input)
                        .filter(issue => !!issue.pull_request)
                        .map(pr => ({
                         title: pr.title,
@@ -65,7 +67,7 @@ jobs:
           if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi
           echo "SECRETS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
       - name: Send Discord notification
-        uses: tgstation/discord-notify@v3
+        uses: littleboobs/discord-notify@v1.0-ss1984
         if: >
           steps.secrets_set.outputs.SECRETS_ENABLED
         with:


### PR DESCRIPTION

## Что этот ПР делает
Замена хэша экшена для скачивания ОД на релиз, чтобы не срало https://github.com/tgstation/tgstation/pull/95834
Очередной фикс стейл бота лол https://github.com/tgstation/tgstation/pull/95823
Замена экшена дискорд анонсера на мой форк от ТГ анонсера, который они сделали недавно, потому что автор оригинального рипнулся?, а ноду жс надо было обновить до 24. Мой форк, поскольку у нас очищается тело, вероятно надо сделать опцию на очистку через параметр экшена и залить к ним в форк, чтобы не зависит в обновлениях, которых никогда больше не будет, от меня.

## Список изменений
n/a
