### PR TITLE
Сила замедления экспансивных патронов стечкина

### DIFF
--- a/code/modules/projectiles/projectile/ballistic/pistol.dm
+++ b/code/modules/projectiles/projectile/ballistic/pistol.dm
@@ -33,8 +33,8 @@
 
 /obj/projectile/bullet/midbullet3/hp/on_hit(atom/target, blocked, hit_zone)
 	if(..(target, blocked))
-		var/mob/living/mob = target
-		mob.Slowed(2 SECONDS, 2)
+		var/mob/living/target_mob = target
+		target_mob.Slowed(2 SECONDS, 2)
 
 /obj/projectile/bullet/midbullet3/ap
 	damage = 27

--- a/code/modules/projectiles/projectile/ballistic/pistol.dm
+++ b/code/modules/projectiles/projectile/ballistic/pistol.dm
@@ -33,8 +33,8 @@
 
 /obj/projectile/bullet/midbullet3/hp/on_hit(atom/target, blocked, hit_zone)
 	if(..(target, blocked))
-		var/mob/living/M = target
-		M.Slowed(2 SECONDS)
+		var/mob/living/mob = target
+		mob.Slowed(2 SECONDS, 2)
 
 /obj/projectile/bullet/midbullet3/ap
 	damage = 27


### PR DESCRIPTION
## Почему это хорошо для игры
Голопаразиту убрали замедление на 10, а экспансивки почему-то замедляют
## Список изменений
Сила slowdown эффекта экспансивных патронов 10мм уменьшен с 10 до 2.

:cl:
balance: уменьшена сила замедления у 10мм экспансивных патронов.
/:cl:
