### PR TITLE
Позволяем голосовать за следующую карту всем

### DIFF
--- a/code/modules/vote/vote_presets.dm
+++ b/code/modules/vote/vote_presets.dm
@@ -32,6 +32,7 @@
 		CRASH("Map Vote triggered before the `map_datum` is defined!")
 	..()
 	no_dead_vote = FALSE
+	no_offstation_vote = FALSE
 
 /datum/vote/map/generate_choices()
 	var/list/map_pool = subtypesof(/datum/map)


### PR DESCRIPTION

## Что этот ПР делает
Разрешаем вне станционным ролькам голосовать за следующую карту.

## Почему это хорошо для игры
Был багрепорт

## Список изменений
:cl:
bugfix: Разрешено вне станционным ролям голосовать за следующую карту.
/:cl:
