### PR TITLE
Anchores closets

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -69,6 +69,7 @@
 	open_sound_volume = 15
 	close_sound_volume = 15
 	density = FALSE
+	anchorable = FALSE
 	pull_push_slowdown = 0
 	ignore_density_closed = TRUE
 	interaction_flags_mouse_drop = NEED_HANDS

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -6,6 +6,7 @@
 	desc = "Just a box..."
 	icon = 'icons/obj/cardboard_boxes.dmi'
 	icon_state = "cardboard"
+	anchorable = FALSE
 	resistance_flags = FLAMMABLE
 	max_integrity = 70
 	integrity_failure = 0

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -6,6 +6,7 @@
 	icon_closed = "fireaxe_full_0hits"
 	icon_opened = "fireaxe_full_open"
 	anchored = TRUE
+	anchorable = FALSE
 	density = FALSE
 	no_overlays = TRUE
 	armor = list(MELEE = 50, BULLET = 20, LASER = 0, ENERGY = 100, BOMB = 10, FIRE = 90, ACID = 50)

--- a/code/game/objects/structures/crates_lockers/closets/gun_stand.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gun_stand.dm
@@ -3,6 +3,7 @@
 	name = "gun stand"
 	desc = "Стойка, предназначенная для хранения определенного оружия. Вы не должны видеть это описание."
 	anchored = TRUE
+	anchorable = FALSE
 	density = FALSE
 	no_overlays = TRUE
 	armor = list(MELEE = 50, BULLET = 20, LASER = 0, ENERGY = 100, BOMB = 10, FIRE = 90, ACID = 50)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/statue.dmi'
 	icon_state = "human_male"
 	anchored = TRUE
+	anchorable = FALSE
 	max_integrity = 100 //destroying the statue kills the mob within
 	no_overlays = TRUE
 	var/intialTox = 0	//these are here to keep the mob from taking damage from things that logically wouldn't affect a rock

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -162,6 +162,7 @@
 	desc = "It's a storage unit for fire-fighting supplies."
 	icon_state = "hydrant"
 	anchored = TRUE
+	anchorable = FALSE
 	density = FALSE
 	wall_mounted = TRUE
 
@@ -181,6 +182,7 @@
 	desc = "It's wall-mounted storage unit for first aid supplies."
 	icon_state = "medical_wall"
 	anchored = TRUE
+	anchorable = FALSE
 	density = FALSE
 	wall_mounted = TRUE
 

--- a/code/game/objects/structures/crates_lockers/closets/wall_locker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wall_locker.dm
@@ -5,6 +5,7 @@
 	icon_state = "wall-locker"
 	density = FALSE
 	anchored = TRUE
+	anchorable = FALSE
 	ignore_density_closed = TRUE
 	no_overlays = TRUE
 	icon_closed = "wall-locker"


### PR DESCRIPTION

## Что этот ПР делает

Делает так, что нельзя закручивать несколько вещей, что являются "ящиками", но нелогично со стороны геймплея. В основном касается ящиков на стене.
Меняет: Настенные ящики для вещей (с топором, с молотом, с удочкой), настенные шкафы, картонную коробку, мешок для трупов, статую ангела.

## Почему это хорошо для игры

Игроки не будут отдирать настенные шкафы от стен и приделывать их по середине коридора.

## Список изменений
:cl:
tweak: Нельзя закрепить или открепить гаечным ключом настенные ящики для вещей (по тип топора), настенные шкафы, картонные коробки, мешки для трупов или статую ангела.
/:cl:
