### PR TITLE
Book Carving Bugfix

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -403,7 +403,7 @@
 /obj/item/book/proc/carve_book(mob/user, obj/item/I)
 	if(I.tool_behaviour != TOOL_WIRECUTTER) //Only sharp and wirecutter things can carve books
 		return FALSE
-	if(I.sharp)
+	if(!I.sharp)
 		balloon_alert(user, "недостаточно острое!")
 		return FALSE
 	if(carved)


### PR DESCRIPTION

## Что этот ПР делает

Теперь страницы книг можно изрезать и засунуть маленький предмет.

## Почему это хорошо для игры

багфиксбагфиксбагфиксбагфиксбагфиксбагфикс

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
<img width="360" height="406" alt="dreamseeker_KVTHKpL0BV" src="https://github.com/user-attachments/assets/abd2e496-a115-4f6e-b384-323c56a952e9" />

</p>
</details>

## Список изменений
:cl:

bugfix: Страницы в книгах вновь можно резать и прятать в них маленькие предметы.

/:cl:
