### PR TITLE
Исправление отображение заряда батареек при осмотре

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -128,7 +128,7 @@
 /obj/item/stock_parts/cell/examine(mob/user)
 	. = ..()
 
-	. += span_notice("<b>Максимальная мощность:</b> [display_power(maxcharge)].")
+	. += span_notice("<b>Максимальная мощность:</b> [display_power(maxcharge, FALSE)].")  // пересчет джоулей в ватты для батарей не нужен
 
 	if(rigged)
 		. += span_notice("Судя по всему, химический элемент был модифицирован.")

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -128,7 +128,7 @@
 /obj/item/stock_parts/cell/examine(mob/user)
 	. = ..()
 
-	. += span_notice("<b>Максимальная мощность:</b> [display_power(maxcharge, FALSE)].")  // пересчет джоулей в ватты для батарей не нужен
+	. += span_notice("<b>Максимальная мощность:</b> [display_power(maxcharge, FALSE)].")
 
 	if(rigged)
 		. += span_notice("Судя по всему, химический элемент был модифицирован.")


### PR DESCRIPTION

## Что этот ПР делает
Чинит отображение заряда батареек при их осмотре.

Багрепорт
https://discord.com/channels/617003227182792704/1497308253883728003

## Почему это хорошо для игры
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
bugfix: Исправлено отображение заряда батареек при осмотре.
/:cl:
