### PR TITLE
RamleyDude - твик автоимплантера предателя

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1744,9 +1744,9 @@
 
 /datum/uplink_item/device_tools/autoimplanter
 	name = "Syndicate Autoimplanter"
-	desc = "Cheaper version of nuclear operatives autoimplanter, this model allows you to install three cybernetic implants on the field."
+	desc = "Cheaper version of nuclear operatives autoimplanter, this model allows you to install a cybernetic implant on the field."
 	item = /obj/item/autoimplanter/traitor
-	cost = 28
+	cost = 9
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 //Space Suits and Hardsuits

--- a/code/modules/surgery/organs/autoimplanter.dm
+++ b/code/modules/surgery/organs/autoimplanter.dm
@@ -116,8 +116,8 @@
 	storedorgan = new /obj/item/organ/internal/cyberimp/tail/blade/laser/syndi
 
 /obj/item/autoimplanter/traitor
-	desc = "A device that automatically injects a cyber-implant into the user without the hassle of extensive surgery. This model is capable of implanting up to three implants before destroing."
-	var/uses = 3
+	desc = "A device that automatically injects a cyber-implant into the user without the hassle of extensive surgery. This model is capable of implanting only once before destroing."
+	var/uses = 1
 
 
 /obj/item/autoimplanter/traitor/autoimplant(mob/living/carbon/human/user)


### PR DESCRIPTION

## Что этот ПР делает

Делает автоимплантер предателя единоразовым и пропорционально дешевле. Также изменены описания, а конкретно: упоминания про "три использования"
## Почему это хорошо для игры

Потому что платить за три импланта наперёд не очень удобно. Пусть предатели платят отдельно за один имплант без надобности ставить себе какую-нибудь дыхательную трубку ибо "ну блин жалко выбрасывать"
## Демонстрация изменений

Не требуется, полагаю. Изменения вполне наглядны по описаниям выше/ниже
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений

Цена автоимплантера: 28 ТК -> 9 ТК (по сути дешевле на 1/3 ТК (омг мегабафф!!1!)). Автоимплантер теперь имеет только одно использование вместо трёх. Этим всё, в целом, сказано
:cl:
tweak: автоимплантер стал единоразовым и удешевлён (почти то же соотношение требуемых ТК на одну установку импланта)
/:cl:
