### PR TITLE
fix admin observer mouse drop

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -619,8 +619,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 //this is called when a ghost is drag clicked to something.
 /mob/dead/observer/mouse_drop_dragged(atom/over_object, mob/user, src_location, over_location, params)
-	if(isobserver(user) && user.client.holder && (isliving(over_object) || isAIEye(over_object)))
-		user.client.holder.cmd_ghost_drag(src, over_object)
+	if(!isobserver(user) || !user?.client?.holder || !over_object)
+		return
+
+	user.client.holder.cmd_ghost_drag(src, over_object)
 
 /**
  * Generates follow links for ghosts to track specific atoms, with special handling for AIs and observer mobs


### PR DESCRIPTION


## Список изменений
:cl:
bugfix: Админы снова могут управлять объектами, как живыми.
/:cl:
