### PR TITLE
Bunch of balance tweaks to guns 

### DIFF
--- a/code/modules/projectiles/guns/ballistic/auto_rifles.dm
+++ b/code/modules/projectiles/guns/ballistic/auto_rifles.dm
@@ -126,6 +126,7 @@
 	burst_size = 2
 	fire_delay = 1
 	accuracy = GUN_ACCURACY_RIFLE
+	weapon_weight = WEAPON_HEAVY
 	attachable_allowed = GUN_MODULE_CLASS_RIFLE_MUZZLE | GUN_MODULE_CLASS_RIFLE_RAIL | GUN_MODULE_CLASS_RIFLE_UNDER
 	attachable_offset = list(
 		ATTACHMENT_SLOT_MUZZLE = list(ATTACHMENT_OFFSET_X = 21, ATTACHMENT_OFFSET_Y = 1),

--- a/code/modules/projectiles/guns/ballistic/smg.dm
+++ b/code/modules/projectiles/guns/ballistic/smg.dm
@@ -131,7 +131,7 @@
 	desc = "An outdated personal defense weapon utilized by law enforcement. Chambered in 4.6x30mm."
 	icon_state = "wt550"
 	item_state = "arg"
-	accuracy = GUN_ACCURACY_RIFLE
+	accuracy = GUN_ACCURACY_RIFLE_EXTEND_SPREAD
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_sound = 'sound/weapons/gunshots/1wt.ogg'
 	magin_sound = 'sound/weapons/gun_interactions/batrifle_magin.ogg'
@@ -155,7 +155,7 @@
 	desc = "Компактный пистолет-пулемёт, предназначенный для подавления беспорядков."
 	icon_state = "sp91"
 	item_state = "SP-91-RC"
-	accuracy = GUN_ACCURACY_RIFLE
+	accuracy = GUN_ACCURACY_RIFLE_EXTEND_SPREAD
 	mag_type = /obj/item/ammo_box/magazine/sp91rc
 	fire_sound = 'sound/weapons/gunshots/1sp_91.ogg'
 	magin_sound = 'sound/weapons/gun_interactions/batrifle_magin.ogg'

--- a/code/modules/projectiles/guns/ballistic/smg.dm
+++ b/code/modules/projectiles/guns/ballistic/smg.dm
@@ -131,6 +131,7 @@
 	desc = "An outdated personal defense weapon utilized by law enforcement. Chambered in 4.6x30mm."
 	icon_state = "wt550"
 	item_state = "arg"
+	accuracy = GUN_ACCURACY_RIFLE
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_sound = 'sound/weapons/gunshots/1wt.ogg'
 	magin_sound = 'sound/weapons/gun_interactions/batrifle_magin.ogg'
@@ -151,9 +152,10 @@
 // MARK: SP-91-RC
 /obj/item/gun/projectile/automatic/smg/sp91rc
 	name = "SP-91-RC"
-	desc = "Компактный пистолет-пулемёт, предназначенный для \"нелетального\" подавления беспорядков."
+	desc = "Компактный пистолет-пулемёт, предназначенный для подавления беспорядков."
 	icon_state = "sp91"
 	item_state = "SP-91-RC"
+	accuracy = GUN_ACCURACY_RIFLE
 	mag_type = /obj/item/ammo_box/magazine/sp91rc
 	fire_sound = 'sound/weapons/gunshots/1sp_91.ogg'
 	magin_sound = 'sound/weapons/gun_interactions/batrifle_magin.ogg'

--- a/code/modules/projectiles/projectile/ballistic/intermediate.dm
+++ b/code/modules/projectiles/projectile/ballistic/intermediate.dm
@@ -17,6 +17,7 @@
 
 /obj/projectile/bullet/incendiary/foursix
 	damage = 15
+	damage_type = BURN
 	armour_penetration = 10
 
 // MARK: 5.45x39mm - Fusty

--- a/code/modules/projectiles/projectile/ballistic/intermediate.dm
+++ b/code/modules/projectiles/projectile/ballistic/intermediate.dm
@@ -7,16 +7,16 @@
 	damage = 15
 
 /obj/projectile/bullet/weakbullet3/foursix/ap
-	damage = 12
-	armour_penetration = 40
+	damage = 10
+	armour_penetration = 70
 
 /obj/projectile/bullet/weakbullet3/foursix/tox
 	damage = 10
 	damage_type = TOX
-	armour_penetration = 10
+	armour_penetration = 30
 
 /obj/projectile/bullet/incendiary/foursix
-	damage = 10
+	damage = 15
 	armour_penetration = 10
 
 // MARK: 5.45x39mm - Fusty

--- a/code/modules/projectiles/projectile/ballistic/pistol.dm
+++ b/code/modules/projectiles/projectile/ballistic/pistol.dm
@@ -86,8 +86,8 @@
 // MARK: .45 N&R
 /obj/projectile/bullet/weakbullet4/c45nr
 	name = "45 N&R"
-	damage = 12
-	stamina = 15
+	damage = 15
+	stamina = 10
 	ricochet_chance = 10
 
 // MARK: .45 Colt

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -2,7 +2,7 @@
 	name = "laser"
 	icon_state = "laser"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	damage = 23
+	damage = 25
 	damage_type = BURN
 	hitsound = 'sound/weapons/sear.ogg'
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -149,7 +149,6 @@
 /obj/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 25
 	shockbull = TRUE
 	damage_type = STAMINA
 	flag = ENERGY
@@ -173,7 +172,6 @@
 
 /obj/projectile/beam/specter/laser
 	name = "specter laser beam"
-	damage = 25
 
 /obj/projectile/beam/specter/disabler
 	name = "specter paralyzer beam"
@@ -658,7 +656,6 @@
 /obj/projectile/beam/dominator/paralyzer
 	name = "paralyzer beam"
 	icon_state = "omnilaser"
-	damage = 25
 	shockbull = TRUE
 	damage_type = STAMINA
 	flag = ENERGY


### PR DESCRIPTION
## Почему это хорошо для игры
Балансные правки согласованные с гапом и балансерами, которые по их мнению сделают боевку чуть интереснее

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
balance: ак-814 требует вторую свободную руку для стрельбы
balance: бронебойные патроны вт наносят 10 урона и имеют 70 бронепробития
balance: токсичные патроны вт имеют 30 бронепробития
balance: зажигательные пули вт наносят 15 берн урона при попадании
balance: патроны сп-91 наносят 15 урона и 10 урона по стамине
balance: большинство лазерок наносят 25 урона
spellcheck: удалена приписка про нелетальные задержания у сп-91
/:cl:
