### PR TITLE
mouse pointer fixes

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -9,14 +9,16 @@
 /obj/mecha/combat/moved_inside(mob/living/carbon/human/H)
 	if(..())
 		if(H.client)
-			H.client.mouse_pointer_icon = file("icons/obj/mecha/mecha_mouse.dmi")
+			H.client.mouse_override_icon = file("icons/obj/mecha/mecha_mouse.dmi")
+			H.client.mouse_pointer_icon = H.client.mouse_override_icon
 		return TRUE
 	return FALSE
 
 /obj/mecha/combat/mmi_moved_inside(obj/item/mmi/mmi_as_oc, mob/user)
 	if(..())
 		if(occupant.client)
-			occupant.client.mouse_pointer_icon = file("icons/obj/mecha/mecha_mouse.dmi")
+			occupant.client.mouse_override_icon = file("icons/obj/mecha/mecha_mouse.dmi")
+			occupant.client.mouse_pointer_icon = occupant.client.mouse_override_icon
 		return TRUE
 	return FALSE
 

--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -9,7 +9,7 @@
 /obj/mecha/combat/moved_inside(mob/living/carbon/human/H)
 	if(..())
 		if(H.client)
-			H.client.mouse_override_icon = file("icons/obj/mecha/mecha_mouse.dmi")
+			H.client.mouse_override_icon = 'icons/obj/mecha/mecha_mouse.dmi'
 			H.client.mouse_pointer_icon = H.client.mouse_override_icon
 		return TRUE
 	return FALSE
@@ -17,7 +17,7 @@
 /obj/mecha/combat/mmi_moved_inside(obj/item/mmi/mmi_as_oc, mob/user)
 	if(..())
 		if(occupant.client)
-			occupant.client.mouse_override_icon = file("icons/obj/mecha/mecha_mouse.dmi")
+			occupant.client.mouse_override_icon = 'icons/obj/mecha/mecha_mouse.dmi'
 			occupant.client.mouse_pointer_icon = occupant.client.mouse_override_icon
 		return TRUE
 	return FALSE

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1492,6 +1492,7 @@
 			H.stop_supressing(H.holding)
 
 	if(occupant?.client)
+		occupant.client.mouse_override_icon = null
 		occupant.client.mouse_pointer_icon = initial(occupant.client.mouse_pointer_icon)
 
 	if(ishuman(occupant))

--- a/code/modules/anomalies/items/fauna_bomb/fauna_bomb.dm
+++ b/code/modules/anomalies/items/fauna_bomb/fauna_bomb.dm
@@ -317,7 +317,8 @@
 	choose_target_timer = addtimer(CALLBACK(src, PROC_REF(choosing_target_off), cur_choosing), 3 SECONDS)
 	chooser = client
 	in_choose_mode = TRUE
-	if(chooser?.mouse_pointer_icon == initial(chooser.mouse_pointer_icon))
+	if(!chooser?.mouse_override_icon)
+		chooser.mouse_override_icon = CHOOSING_ICON
 		chooser.mouse_pointer_icon = CHOOSING_ICON
 
 /obj/item/fauna_bomb/proc/choosing_target_off(choosing_num)
@@ -326,7 +327,8 @@
 
 	choose_target_timer = null
 	in_choose_mode = FALSE
-	if(chooser?.mouse_pointer_icon == CHOOSING_ICON)
+	if(chooser?.mouse_override_icon == CHOOSING_ICON)
+		chooser.mouse_override_icon = null
 		chooser.mouse_pointer_icon = initial(chooser.mouse_pointer_icon)
 
 #undef CHOOSING_ICON

--- a/code/modules/antagonists/space_ninja/energy_katana.dm
+++ b/code/modules/antagonists/space_ninja/energy_katana.dm
@@ -57,7 +57,7 @@
 		if(isninja(user))
 			jaunt.teleport(user, target)
 			if(user.client)
-				user.client.mouse_override_icon = file(jaunt.update_cursor())
+				user.client.mouse_override_icon = jaunt.update_cursor()
 				user.client.mouse_pointer_icon = user.client.mouse_override_icon
 				jaunt.update_action_style(color_style)
 		else
@@ -73,7 +73,7 @@
 	. = ..()
 	if(user?.client)
 		jaunt.Grant(user, src)
-		user.client.mouse_override_icon = file(jaunt.update_cursor())
+		user.client.mouse_override_icon = jaunt.update_cursor()
 		user.client.mouse_pointer_icon = user.client.mouse_override_icon
 		jaunt.update_action_style(color_style)
 		user.update_icons()
@@ -179,13 +179,13 @@
 /datum/action/innate/dash/ninja/proc/update_cursor()
 	switch(current_charges)
 		if(3)
-			return "icons/misc/mouse_pointers/ninja_cursor_three.dmi"
+			return 'icons/misc/mouse_pointers/ninja_cursor_three.dmi'
 		if(2)
-			return "icons/misc/mouse_pointers/ninja_cursor_two.dmi"
+			return 'icons/misc/mouse_pointers/ninja_cursor_two.dmi'
 		if(1)
-			return "icons/misc/mouse_pointers/ninja_cursor_one.dmi"
+			return 'icons/misc/mouse_pointers/ninja_cursor_one.dmi'
 		if(0)
-			return "icons/misc/mouse_pointers/ninja_cursor_off.dmi"
+			return 'icons/misc/mouse_pointers/ninja_cursor_off.dmi'
 
 /datum/action/innate/dash/ninja/proc/update_action_style(color_style)
 	button_icon_state = "arrows_[clamp(current_charges, 0, max_charges)]" //Защита от потери иконок при админ абузе
@@ -197,7 +197,7 @@
 /datum/action/innate/dash/ninja/charge()
 	. = ..()
 	if(owner?.client)
-		owner.client.mouse_override_icon = file(update_cursor())
+		owner.client.mouse_override_icon = update_cursor()
 		owner.client.mouse_pointer_icon = owner.client.mouse_override_icon
 		var/obj/item/melee/energy_katana/katana = dashing_item
 		update_action_style(katana.color_style)

--- a/code/modules/antagonists/space_ninja/energy_katana.dm
+++ b/code/modules/antagonists/space_ninja/energy_katana.dm
@@ -57,7 +57,8 @@
 		if(isninja(user))
 			jaunt.teleport(user, target)
 			if(user.client)
-				user.client.mouse_pointer_icon = file(jaunt.update_cursor())
+				user.client.mouse_override_icon = file(jaunt.update_cursor())
+				user.client.mouse_pointer_icon = user.client.mouse_override_icon
 				jaunt.update_action_style(color_style)
 		else
 			var/mob/living/carbon/human/H = user
@@ -72,7 +73,8 @@
 	. = ..()
 	if(user?.client)
 		jaunt.Grant(user, src)
-		user.client.mouse_pointer_icon = file(jaunt.update_cursor())
+		user.client.mouse_override_icon = file(jaunt.update_cursor())
+		user.client.mouse_pointer_icon = user.client.mouse_override_icon
 		jaunt.update_action_style(color_style)
 		user.update_icons()
 		playsound(get_turf(src), 'sound/items/unsheath.ogg', 25, TRUE, 5)
@@ -85,6 +87,7 @@
 	. = ..()
 	if(user?.client)
 		jaunt.Remove(user)
+		user.client.mouse_override_icon = null
 		user.client.mouse_pointer_icon = initial(user.client.mouse_pointer_icon)
 		user.update_icons()
 
@@ -194,7 +197,8 @@
 /datum/action/innate/dash/ninja/charge()
 	. = ..()
 	if(owner?.client)
-		owner.client.mouse_pointer_icon = file(update_cursor())
+		owner.client.mouse_override_icon = file(update_cursor())
+		owner.client.mouse_pointer_icon = owner.client.mouse_override_icon
 		var/obj/item/melee/energy_katana/katana = dashing_item
 		update_action_style(katana.color_style)
 

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -9,3 +9,4 @@
 		can_reenter_corpse = 0
 		GLOB.respawnable_list -= src
 	update_admin_actions()
+	client?.set_right_click_menu_mode(FALSE)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -562,7 +562,8 @@
 	in_throw_mode = FALSE
 	if(throw_icon) //in case we don't have the HUD and we use the hotkey
 		throw_icon.icon_state = "act_throw_off"
-	if(client?.mouse_pointer_icon == THROW_MODE_ICON)
+	if(client?.mouse_override_icon == THROW_MODE_ICON)
+		client.mouse_override_icon = null
 		client.mouse_pointer_icon = initial(client.mouse_pointer_icon)
 
 /mob/living/carbon/proc/throw_mode_on()
@@ -572,7 +573,8 @@
 	in_throw_mode = TRUE
 	if(throw_icon)
 		throw_icon.icon_state = "act_throw_on"
-	if(client?.mouse_pointer_icon == initial(client.mouse_pointer_icon))
+	if(!client.mouse_override_icon)
+		client.mouse_override_icon = THROW_MODE_ICON
 		client.mouse_pointer_icon = THROW_MODE_ICON
 	// we nullify click cd when someone tries to throw a grabbed mob
 	// improves combat robustness a lot

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -127,8 +127,9 @@
 
 /datum/click_intercept/give/New(client/C)
 	..()
-	holder.mouse_override_icon = 'icons/misc/mouse_icons/give_item.dmi'
-	holder.mouse_pointer_icon = holder.mouse_override_icon
+	if(!holder.mouse_override_icon)
+		holder.mouse_override_icon = 'icons/misc/mouse_icons/give_item.dmi'
+		holder.mouse_pointer_icon = holder.mouse_override_icon
 
 	giver = holder.mob
 	giving_item = giver.get_active_hand()
@@ -137,8 +138,9 @@
 	RegisterSignal(giver, list(COMSIG_QDELETING, COMSIG_MOB_SWAP_HANDS, SIGNAL_ADDTRAIT(TRAIT_HANDS_BLOCKED)), PROC_REF(signal_qdel))
 
 /datum/click_intercept/give/Destroy(force = FALSE)
-	holder.mouse_override_icon = null
-	holder.mouse_pointer_icon = initial(holder.mouse_pointer_icon)
+	if(holder.mouse_override_icon == 'icons/misc/mouse_icons/give_item.dmi')
+		holder.mouse_override_icon = null
+		holder.mouse_pointer_icon = initial(holder.mouse_pointer_icon)
 	if(!item_offered)
 		to_chat(giver, span_notice("Вы прекратили попытку передачи предмета."))
 	if(giving_item)

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -127,14 +127,17 @@
 
 /datum/click_intercept/give/New(client/C)
 	..()
+	holder.mouse_override_icon = 'icons/misc/mouse_icons/give_item.dmi'
+	holder.mouse_pointer_icon = holder.mouse_override_icon
+
 	giver = holder.mob
 	giving_item = giver.get_active_hand()
-	holder.mouse_pointer_icon = 'icons/misc/mouse_icons/give_item.dmi'
 	to_chat(giver, span_notice("ЛКМ по игроку — предложить предмет в руке."))
 	RegisterSignal(giving_item, list(COMSIG_QDELETING, COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED), PROC_REF(signal_qdel))
 	RegisterSignal(giver, list(COMSIG_QDELETING, COMSIG_MOB_SWAP_HANDS, SIGNAL_ADDTRAIT(TRAIT_HANDS_BLOCKED)), PROC_REF(signal_qdel))
 
 /datum/click_intercept/give/Destroy(force = FALSE)
+	holder.mouse_override_icon = null
 	holder.mouse_pointer_icon = initial(holder.mouse_pointer_icon)
 	if(!item_offered)
 		to_chat(giver, span_notice("Вы прекратили попытку передачи предмета."))


### PR DESCRIPTION

## Что этот ПР делает
В https://github.com/ss220-space/Paradise/pull/9041 изменилась логика update_mouse_pointer(), он вызывается на каждое нажатие/отпускание клавиши и сбрасывает client.mouse_pointer_icon обратно в initial(), сохраняя только mouse_override_icon и шифт иконку. Исправил поинтеры, которые задавали только mouse_pointer_icon, поэтому курсор сбрасывался при следующем же нажатии любой клавиши.

Правильно задавать поинтеры через mouse_override_icon + mouse_pointer_icon, так сделано во всем новом коде, что портирован с ТГ, теперь старые поинтеры работают так же.

Баг-репорты:
https://discord.com/channels/617003227182792704/1498725964941889697
https://discord.com/channels/617003227182792704/1497595911126257674
https://discord.com/channels/617003227182792704/1497595053751668847

## Список изменений
:cl:
bugfix: Иконки курсора мышки меняются снова.
/:cl:
