### PR TITLE
mouse drop dragged & mouse drop receive fixes

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -200,42 +200,41 @@
 		storage_master.attempt_insert(item)
 	return TRUE
 
-/atom/movable/screen/storage/mouse_drop_receive(obj/item/I, mob/user, params)
-	if(!user || !master || !istype(I) || user.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || ismecha(user.loc))
-		return FALSE
+/atom/movable/screen/storage/mouse_drop_receive(obj/item/dropped, mob/user, params)
+	if(!user || !master || !istype(dropped) || user.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || ismecha(user.loc))
+		return
 
 	if(is_ventcrawling(user))
-		return FALSE
+		return
 
 	var/obj/item/storage/S = master
 	if(!S)
-		return FALSE
+		return
 
-	if(I in S.contents) // If the item is already in the storage, move them to the end of the list
-		if(S.contents[length(S.contents)] == I) // No point moving them at the end if they're already there!
-			return FALSE
+	if(dropped in S.contents) // If the item is already in the storage, move them to the end of the list
+		if(S.contents[length(S.contents)] == dropped) // No point moving them at the end if they're already there!
+			return
 
 		var/list/new_contents = S.contents.Copy()
 		if(S.display_contents_with_number)
-			// Basically move all occurences of I to the end of the list.
+			// Basically move all occurences of dropped to the end of the list.
 			var/list/obj/item/to_append = list()
 			for(var/obj/item/stored_item in S.contents)
-				if(S.can_items_stack(stored_item, I))
+				if(S.can_items_stack(stored_item, dropped))
 					new_contents -= stored_item
 					to_append += stored_item
 
 			new_contents.Add(to_append)
 		else
-			new_contents -= I
-			new_contents += I // oof
+			new_contents -= dropped
+			new_contents += dropped // oof
 		S.contents = new_contents
 
 		if(user.s_active == S)
 			S.orient2hud(user)
 			S.show_to(user)
 	else // If it's not in the storage, try putting it inside
-		S.attempt_insert(I)
-	return TRUE
+		S.attempt_insert(dropped)
 
 /atom/movable/screen/storage/space_box
 	screen_loc = "7,7 to 10,8"
@@ -513,42 +512,42 @@
 
 	return TRUE
 
-/atom/movable/screen/inventory/mouse_drop_receive(obj/item/I, mob/user, params)
-	if(!user || !istype(I) || user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || ismecha(user.loc) || is_ventcrawling(user))
-		return FALSE
+/atom/movable/screen/inventory/mouse_drop_receive(obj/item/dropped, mob/user, params)
+	if(!user || !istype(dropped) || user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || ismecha(user.loc) || is_ventcrawling(user))
+		return
 
-	if(isalien(user) && !I.allowed_for_alien())	// We need to do this here
-		return FALSE
+	if(isalien(user) && !dropped.allowed_for_alien())	// We need to do this here
+		return
 
-	if(!in_range(get_turf(I), get_turf(user)))
-		return FALSE
+	if(!in_range(get_turf(dropped), get_turf(user)))
+		return
 
 	if(!hud?.mymob || !slot_id)
-		return FALSE
+		return
 
 	if(hud.mymob != user)
-		return FALSE
+		return
 
 	if(!(slot_id & ITEM_SLOT_HANDS))
-		return FALSE
+		return
 
-	if(I.loc == user)
-		if(I.equip_delay_self > 0 && !user.is_general_slot(user.get_slot_by_item(I)))
+	if(dropped.loc == user)
+		if(dropped.equip_delay_self > 0 && !user.is_general_slot(user.get_slot_by_item(dropped)))
 			user.visible_message(
-				span_notice("[user] начина[PLUR_ET_UT(user)] снимать [I.declent_ru(ACCUSATIVE)]..."),
-				span_notice("Вы начинаете снимать [I.declent_ru(ACCUSATIVE)]..."),
+				span_notice("[user] начина[PLUR_ET_UT(user)] снимать [dropped.declent_ru(ACCUSATIVE)]..."),
+				span_notice("Вы начинаете снимать [dropped.declent_ru(ACCUSATIVE)]..."),
 			)
-			if(!do_after(user, I.equip_delay_self, user, timed_action_flags = (DA_IGNORE_LYING|DA_IGNORE_USER_LOC_CHANGE), max_interact_count = 1, cancel_on_max = TRUE, cancel_message = span_warning("Снятие [I.declent_ru(GENITIVE)] было прервано!")))
-				return FALSE
+			if(!do_after(user, dropped.equip_delay_self, user, timed_action_flags = (DA_IGNORE_LYING|DA_IGNORE_USER_LOC_CHANGE), max_interact_count = 1, cancel_on_max = TRUE, cancel_message = span_warning("Снятие [dropped.declent_ru(GENITIVE)] было прервано!")))
+				return
 
-		if(!user.drop_item_ground(I))
-			return FALSE
+		if(!user.drop_item_ground(dropped))
+			return
 
-	if((slot_id == ITEM_SLOT_HAND_LEFT && !user.put_in_l_hand(I, ignore_anim = FALSE)) || \
-		(slot_id == ITEM_SLOT_HAND_RIGHT && !user.put_in_r_hand(I, ignore_anim = FALSE)))
-		return FALSE
+	if((slot_id == ITEM_SLOT_HAND_LEFT && !user.put_in_l_hand(dropped, ignore_anim = FALSE)) || \
+		(slot_id == ITEM_SLOT_HAND_RIGHT && !user.put_in_r_hand(dropped, ignore_anim = FALSE)))
+		return
 
-	I.pickup(user)
+	dropped.pickup(user)
 
 /atom/movable/screen/inventory/hand
 	//interaction_flags_atom = NONE //so dragging objects into hands icon don't skip adjacency & other checks

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -149,39 +149,38 @@
 		for(var/mob/M in src)//Failsafe so you can get mobs out
 			M.forceMove(get_turf(src))
 
-/obj/machinery/dna_scannernew/mouse_drop_receive(atom/movable/O, mob/user, params)
-	if(!istype(O))
+/obj/machinery/dna_scannernew/mouse_drop_receive(atom/movable/dropped, mob/user, params)
+	if(!istype(dropped))
 		return
-	if(O.loc == user) //no you can't pull things out of your ass
+	if(dropped.loc == user) //no you can't pull things out of your ass
 		return
 	if(user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED)) //are you cuffed, dying, lying, stunned or other
 		return
-	if(O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1 || user.contents.Find(src)) // is the mob anchored, too far away from you, or are you too far away from the source
+	if(dropped.anchored || get_dist(user, src) > 1 || get_dist(user, dropped) > 1 || user.contents.Find(src)) // is the mob anchored, too far away from you, or are you too far away from the source
 		return
-	if(!ismob(O)) //humans only
+	if(!ismob(dropped)) //humans only
 		return
-	if(isanimal(O) || issilicon(O)) //animals and robutts dont fit
+	if(isanimal(dropped) || issilicon(dropped)) //animals and robutts dont fit
 		return
 	if(!ishuman(user) && !isrobot(user)) //No ghosts or mice putting people into the sleeper
 		return
 	if(user.loc==null) // just in case someone manages to get a closet into the blue light dimension, as unlikely as that seems
 		return
-	if(!isturf(user.loc) || !isturf(O.loc)) // are you in a container/closet/pod/etc?
+	if(!isturf(user.loc) || !isturf(dropped.loc)) // are you in a container/closet/pod/etc?
 		return
 	if(occupant)
 		balloon_alert(user, "внутри кто-то есть!")
-		return TRUE
-	var/mob/living/L = O
-	if(!istype(L) || L.buckled)
 		return
-	if(L.abiotic())
+	var/mob/living/living_mob = dropped
+	if(!istype(living_mob) || living_mob.buckled)
+		return
+	if(living_mob.abiotic())
 		balloon_alert(user, "руки субъекта заняты!")
-		return TRUE
-	if(L.has_buckled_mobs()) //mob attached to us
-		to_chat(user, span_warning("[L] не помест[PLUR_IT_YAT(L)]ся в [declent_ru(ACCUSATIVE)], пока на [GEND_ON_IN_HIM(L)] сидит слайм!"))
-		return TRUE
-	put_in(L, user)
-	return TRUE
+		return
+	if(living_mob.has_buckled_mobs()) //mob attached to us
+		to_chat(user, span_warning("[living_mob] не помест[PLUR_IT_YAT(living_mob)]ся в [declent_ru(ACCUSATIVE)], пока на [GEND_ON_IN_HIM(living_mob)] сидит слайм!"))
+		return
+	put_in(living_mob, user)
 
 /obj/machinery/dna_scannernew/attackby(obj/item/I, mob/user, params)
 	if(user.a_intent == INTENT_HARM)

--- a/code/game/gamemodes/clockwork/clockheart.dm
+++ b/code/game/gamemodes/clockwork/clockheart.dm
@@ -320,7 +320,7 @@ GLOBAL_DATUM(heart, /obj/structure/clockwork/functional/heart)
 	parent.take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)
 
 /obj/structure/heart_filler/mouse_drop_receive(atom/movable/dropping, mob/user, params)
-	parent.mouse_drop_receive(dropping, user, params)
+	return parent.mouse_drop_receive(dropping, user, params)
 
 /obj/structure/heart_filler/attackby(obj/item/I, mob/user, params)
 	parent.attackby(I, user, params)

--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -30,19 +30,18 @@
 		return
 	if(occupant)
 		to_chat(user, span_notice("[src] is already occupied."))
-		return TRUE //occupied
+		return //occupied
 	if(target.buckled)
 		return
 	if(target.has_buckled_mobs()) //mob attached to us
 		to_chat(user, span_warning("[target] will not fit into [src] because [target.p_they()] [target.p_have()] a slime latched onto [target.p_their()] head."))
-		return TRUE
+		return
 	visible_message("[user] puts [target] into the [src].")
 
 	target.forceMove(src)
 	occupant = target
 	update_icon(UPDATE_ICON_STATE)
 	add_fingerprint(user)
-	return TRUE
 
 /obj/machinery/abductor/experiment/attack_hand(mob/user)
 	if(..())

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -52,7 +52,6 @@
 		return
 	add_fingerprint(user)
 	take_patient(O, user)
-	return TRUE
 
 /**
  * Updates the `patient` var to be the mob occupying the table

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -508,30 +508,29 @@
 		return
 	if(!ishuman(user) && !isrobot(user)) //No ghosts or mice putting people into the sleeper
 		return
-	if(user.loc==null) // just in case someone manages to get a closet into the blue light dimension, as unlikely as that seems
+	if(user.loc == null) // just in case someone manages to get a closet into the blue light dimension, as unlikely as that seems
 		return
 	if(!isturf(user.loc) || !isturf(O.loc)) // are you in a container/closet/pod/etc?
 		return
 	if(panel_open)
 		balloon_alert(user, "техпанель открыта!")
-		return TRUE
+		return
 	if(occupant)
 		balloon_alert(user, "внутри кто-то есть!")
-		return TRUE
+		return
 	var/mob/living/L = O
 	if(!istype(L) || L.buckled)
 		return
 	if(L.abiotic())
 		balloon_alert(user, "руки субъекта заняты!")
-		return TRUE
+		return
 	if(L.has_buckled_mobs()) //mob attached to us
 		to_chat(user, span_warning("[L] не помест[PLUR_IT_YAT(L)]ся в [declent_ru(ACCUSATIVE)], пока на [GEND_ON_IN_HIM(L)] сидит слайм!"))
-		return TRUE
+		return
 	if(L == user)
 		visible_message("[user] начина[PLUR_ET_YUT(user)] залезать в [declent_ru(ACCUSATIVE)].")
 	else
 		visible_message("[user] начина[PLUR_ET_YUT(user)] укладывать [L.name] в [declent_ru(ACCUSATIVE)].")
-	. = TRUE
 	INVOKE_ASYNC(src, PROC_REF(put_in), L, user)
 
 /obj/machinery/sleeper/proc/put_in(mob/living/L, mob/user)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -123,29 +123,29 @@
 
 /obj/machinery/bodyscanner/mouse_drop_receive(mob/living/carbon/human/H, mob/user, params)
 	if(!istype(H))
-		return FALSE //not human
+		return //not human
 	if(user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-		return FALSE //user shouldn't be doing things
+		return //user shouldn't be doing things
 	if(H.anchored)
-		return FALSE //mob is anchored???
+		return //mob is anchored???
 	if(get_dist(user, src) > 1 || get_dist(user, H) > 1)
-		return FALSE //doesn't use adjacent() to allow for non-cardinal (fuck my life)
+		return //doesn't use adjacent() to allow for non-cardinal (fuck my life)
 	if(!ishuman(user) && !isrobot(user))
-		return FALSE //not a borg or human
+		return //not a borg or human
 	if(panel_open)
 		balloon_alert(user, "техпанель открыта!")
-		return TRUE //panel open
+		return //panel open
 	if(occupant)
 		balloon_alert(user, "внутри кто-то есть!")
-		return TRUE //occupied
+		return //occupied
 	if(H.buckled)
-		return FALSE
+		return
 	if(H.abiotic())
 		balloon_alert(user, "руки субъекта заняты!")
-		return TRUE
+		return
 	if(H.has_buckled_mobs()) //mob attached to us
 		to_chat(user, span_warning("Вы не поместитесь в [declent_ru(ACCUSATIVE)], пока на вас сидит слайм!"))
-		return TRUE
+		return
 
 	if(H == user)
 		visible_message("[user] начина[PLUR_ET_YUT(user)] залезать в [declent_ru(ACCUSATIVE)].")
@@ -161,7 +161,6 @@
 	to_chat(H, span_boldnotice("Крышка [declent_ru(GENITIVE)] закрывается и окружающие звуки сразу становятся тише. Вы видите вокруг множество датчиков и слышите тихое гудение внутренних систем аппарата."))
 	add_fingerprint(user)
 	SStgui.update_uis(src)
-	return TRUE
 
 /obj/machinery/bodyscanner/attack_ai(user)
 	return attack_hand(user)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -149,26 +149,26 @@
 		return
 	if(occupant)
 		balloon_alert(user, "внутри кто-то есть!")
-		return TRUE
+		return
 	var/mob/living/L = O
 	if(!istype(L) || L.buckled)
 		return
 	if(L.abiotic())
 		balloon_alert(user, "руки субъекта заняты!")
-		return TRUE
+		return
 	if(L.has_buckled_mobs()) //mob attached to us
 		to_chat(user, span_warning("[L] не помест[PLUR_IT_YAT(L)]ся в [declent_ru(ACCUSATIVE)], пока на [GEND_ON_IN_HIM(L)] сидит слайм!"))
-		return TRUE
-	. = TRUE
-	if(put_mob(L))
-		if(L == user)
-			visible_message("[user] начинает[PLUR_ET_YUT(user)] залезать в [declent_ru(ACCUSATIVE)].")
-		else
-			visible_message("[user] начина[PLUR_ET_YUT(user)] укладывать [L] в [declent_ru(ACCUSATIVE)].")
-			add_attack_logs(user, L, "put into a cryo cell at [COORD(src)].", ATKLOG_ALL)
-			if(user.pulling == L)
-				user.stop_pulling()
-		SStgui.update_uis(src)
+		return
+	if(!put_mob(L))
+		return
+	if(L == user)
+		visible_message("[user] начинает[PLUR_ET_YUT(user)] залезать в [declent_ru(ACCUSATIVE)].")
+	else
+		visible_message("[user] начина[PLUR_ET_YUT(user)] укладывать [L] в [declent_ru(ACCUSATIVE)].")
+		add_attack_logs(user, L, "put into a cryo cell at [COORD(src)].", ATKLOG_ALL)
+		if(user.pulling == L)
+			user.stop_pulling()
+	SStgui.update_uis(src)
 
 /obj/machinery/atmospherics/unary/cryo_cell/process()
 	..()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -551,7 +551,7 @@
 		return
 	if(occupant)
 		to_chat(user, span_boldnotice("The cryo pod is already occupied!"))
-		return TRUE
+		return
 
 	var/mob/living/L = O
 	if(!istype(L) || L.buckled)
@@ -559,18 +559,17 @@
 
 	if(L.stat == DEAD)
 		to_chat(user, span_notice("Dead people can not be put into cryo."))
-		return TRUE
+		return
 
 	if(!L.mind)
 		to_chat(user, span_notice("Catatonic people are not allowed into cryo."))
-		return TRUE
+		return
 
 	if(L.has_buckled_mobs()) //mob attached to us
 		to_chat(user, span_warning("[L] will not fit into [src] because [L.p_they()] [L.p_have()] a slime latched onto [L.p_their()] head."))
-		return TRUE
+		return
 
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/obj/machinery/cryopod, put_in), user, L)
-	return TRUE
 
 /obj/machinery/cryopod/proc/put_in(mob/user, mob/living/L) // need this proc to use INVOKE_ASYNC in other proc. You're not recommended to use that one
 	var/willing = null //We don't want to allow people to be forced into despawning.

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -215,7 +215,6 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 
 /obj/machinery/door/airlock/mouse_drop_receive(atom/dropping, mob/user, params)
 	. = ..()
-
 	//Adds the component only once. We do it here & not in Initialize() because there are tons of airlocks & we don't want to add to their init times
 	LoadComponent(/datum/component/leanable, dropping)
 

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -144,7 +144,6 @@
 		return
 
 	qdel(pipe)
-	return TRUE
 
 /obj/machinery/pipedispenser/disposal/attack_hand(mob/user)
 	if(..())

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -399,7 +399,6 @@
 /obj/machinery/suit_storage_unit/mouse_drop_receive(atom/A, mob/user, params)
 	if(user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user) || !Adjacent(A) || !isliving(A))
 		return
-	. = TRUE
 	var/mob/living/target = A
 	if(!state_open)
 		to_chat(user, span_warning("The [src]'s doors are shut!"))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1327,15 +1327,14 @@
 /obj/mecha/mouse_drop_receive(mob/M, mob/user, params)
 	if(frozen)
 		to_chat(user, span_warning("Do not enter Admin-Frozen mechs."))
-		return TRUE
+		return
 	if(user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
 	if(user != M)
 		return
 	if(occupant)
 		to_chat(user, span_warning("The [src] is already occupied!"))
-
-		return TRUE
+		return
 	var/passed
 	if(dna_lock)
 		if(ishuman(user))
@@ -1345,19 +1344,18 @@
 		passed = TRUE
 	if(!passed)
 		to_chat(user, span_warning("Access denied."))
-		return TRUE
+		return
 	if(user.buckled)
 		to_chat(user, span_warning("You are currently buckled and cannot move."))
-		return TRUE
+		return
 	if(user.has_buckled_mobs()) //mob attached to us
 		to_chat(user, span_warning("You can't enter the exosuit with other creatures attached to you!"))
-		return TRUE
+		return
 	if(ratvarized && !isclocker(user))
 		balloon_alert(user, "запечатано!")
-		return TRUE
+		return
 	visible_message(span_notice("[user] starts to climb into [src]"))
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/obj/mecha, put_in), user)
-	return TRUE
 
 /obj/mecha/proc/put_in(mob/user)
 	if(do_after(user, mech_enter_time, src, category = DA_CAT_TOOL))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1176,12 +1176,12 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 
 /obj/item/mouse_drop_receive(atom/dropping, mob/user, params)
 	if(!user || user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || src == dropping)
-		return FALSE
+		return
 
 	if(loc && dropping.loc == loc && isstorage(loc) && loc.Adjacent(user)) // Are we trying to swap two items in the storage?
 		var/obj/item/storage/S = loc
 		S.swap_items(src, dropping, user)
-		return TRUE
+		return
 	remove_outline() //get rid of the hover effect in case the mouse exit isn't called if someone drags and drops an item and somthing goes wrong
 
 /obj/item/proc/apply_outline(mob/user, outline_color = null)

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -201,7 +201,7 @@
 
 /obj/item/storage/firstaid/brute/Initialize(mapload)
 	. = ..()
-	
+
 	icon_state = pick("brute", "brute2")
 
 /obj/item/storage/firstaid/brute/populate_contents()
@@ -681,7 +681,7 @@
 
 /obj/item/storage/pill_bottle/mouse_drop_dragged(atom/over_object, mob/user, src_location, over_location, params)
 	if(!iscarbon(user) || src != user.get_active_hand() || over_object != user)
-		return
+		return ..()
 
 	if(!length(contents))
 		balloon_alert(user, "пусто!")
@@ -689,10 +689,9 @@
 
 	get_use_start_message(user)
 
-	if(!do_after(user, 10 SECONDS, user, NONE) || src != user.get_active_hand())
-		return
-
 	for(var/obj/item/reagent_containers/food/pill/pill in src)
+		if(!do_after(user, 2 SECONDS, user, NONE) || src != user.get_active_hand())
+			return
 		pill.attack(user, user)
 
 	get_use_end_message(user)
@@ -727,10 +726,10 @@
 	)
 
 /obj/item/storage/pill_bottle/patch_pack/filled/populate_contents()
-	for(var/I in 1 to 10)
+	for(var/i in 1 to 10)
 		new /obj/item/reagent_containers/food/pill/patch/silver_sulf(src)
 
-	for(var/I in 1 to 10)
+	for(var/i in 1 to 10)
 		new /obj/item/reagent_containers/food/pill/patch/styptic(src)
 
 /obj/item/storage/pill_bottle/patch_pack/get_use_start_message(mob/user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -134,7 +134,7 @@
 	if(ismecha(user.loc) || is_ventcrawling(user) || user.incapacitated())
 		return
 
-	if(over_object == user && IsReachableBy(user))
+	if(over_object == user && IsReachableBy(user)) // this must come before the screen objects only block
 		open(user)
 		return
 
@@ -142,22 +142,15 @@
 		var/obj/item/storage = over_object
 		if(!(storage.item_flags & IN_STORAGE))
 			dump_storage(user, over_object)
-		return
+			return
 
-	// Checking the possibility to dump the contents on the table /floor
-	if(istype(src, /obj/item/storage/lockbox))
-		return
-
-	if(!istable(over_object) && !isfloorturf(over_object))
-		return
-
-	if(!length(contents) || loc != user || user.incapacitated() || !over_object.IsReachableBy(user))
+	if(istype(src, /obj/item/storage/lockbox) || (!istable(over_object) && !isfloorturf(over_object)) \
+		|| !length(contents) || loc != user || user.incapacitated() || !over_object.IsReachableBy(user))
 		return
 
 	if(tgui_alert(user, "Опустошить содержимое [declent_ru(GENITIVE)] на [over_object.declent_ru(ACCUSATIVE)]?", "Подтверждение", list("Да", "Нет")) != "Да")
 		return
 
-	// Re-checking after the alert
 	if(!user || !over_object || user.incapacitated() || loc != user || !over_object.IsReachableBy(user))
 		return
 
@@ -169,12 +162,11 @@
 		span_notice("[user] опустоша[PLUR_ET_YUT(user)] содерижмое [declent_ru(GENITIVE)] на [over_object.declent_ru(ACCUSATIVE)]."),
 		span_notice("Вы опустошаете содержимое [declent_ru(ACCUSATIVE)] на [over_object.declent_ru(ACCUSATIVE)]."),
 	)
-
 	var/turf/object_turf = get_turf(over_object)
 	for(var/obj/item/item in src)
 		remove_from_storage(item, object_turf)
 
-	update_appearance()
+	update_appearance() // For content-sensitive icons
 
 /obj/item/storage/click_alt(mob/user)
 	if(isobserver(user))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -79,7 +79,7 @@
 	. = ..()
 	if(!. && dropping == user)
 		do_climb(user)
-		return TRUE
+		return
 
 /obj/structure/proc/density_check(mob/living/user)
 	var/turf/source_turf = get_turf(src)
@@ -91,7 +91,6 @@
 			if((check.flags & ON_BORDER) && user.loc != loc && border_dir != check.dir)
 				continue
 			return check
-	return null
 
 /obj/structure/proc/do_climb(mob/living/user)
 	if(!can_touch(user) || !climbable)

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -38,8 +38,7 @@
 	return ..()
 
 /obj/structure/coatrack/mouse_drop_receive(obj/item/I, mob/user, params)
-	. = TRUE
-	move_on_rack(I, user)
+	return move_on_rack(I, user)
 
 /obj/structure/coatrack/Bumped(atom/movable/moving_atom)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/closet.dm
+++ b/code/game/objects/structures/crates_lockers/closet.dm
@@ -373,8 +373,7 @@ GLOBAL_LIST_EMPTY(closets)
 		bust_open()
 
 /obj/structure/closet/grab_attack(mob/living/grabber, atom/movable/grabbed_thing)
-	mouse_drop_receive(grabbed_thing, grabber)	//act like they were dragged onto the closet
-	return TRUE
+	return mouse_drop_receive(grabbed_thing, grabber) //act like they were dragged onto the closet
 
 /obj/structure/closet/attackby(obj/item/used, mob/user, params)
 	if(opened)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -305,7 +305,6 @@
 
 	if(user != dropping)
 		user.visible_message(span_warning("[user] помеща[PLUR_ET_YUT(user)] [dropping.declent_ru(GENITIVE)] на [declent_ru(GENITIVE)]!"))
-	return TRUE
 
 /obj/structure/m_tray/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
@@ -724,7 +723,6 @@ GLOBAL_LIST_EMPTY(crematoriums)
 
 	if(user != dropping)
 		user.visible_message(span_warning("[user] помеща[PLUR_ET_YUT(user)] [dropping.declent_ru(GENITIVE)] на [declent_ru(GENITIVE)]!"))
-	return TRUE
 
 /obj/structure/c_tray/Process_Spacemove(movement_dir = NONE, continuous_move = FALSE)
 	return TRUE

--- a/code/game/objects/structures/racks/racks.dm
+++ b/code/game/objects/structures/racks/racks.dm
@@ -53,11 +53,10 @@
 
 /obj/structure/rack/mouse_drop_receive(obj/item/dropped_item, mob/user, params)
 	if(!isitem(dropped_item) || user.get_active_hand() != dropped_item || isrobot(user))
-		return FALSE
+		return
 	if(dropped_item.loc != loc && user.transfer_item_to_loc(dropped_item, loc))
 		add_fingerprint(user)
-		return TRUE
-	return FALSE
+		return
 
 /obj/structure/rack/base_item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	. = ..()
@@ -211,10 +210,6 @@
 
 /obj/structure/rack/wooden/add_debris_element()
 	AddElement(/datum/element/debris, DEBRIS_WOOD, -40, 5)
-
-/obj/structure/rack/wooden/mouse_drop_receive(obj/item/dropped_item, mob/user, params)
-	. = ..()
-	update_icon(UPDATE_OVERLAYS)
 
 /obj/structure/rack/wooden/update_overlays()
 	. = ..()

--- a/code/game/objects/structures/tables.dm
+++ b/code/game/objects/structures/tables.dm
@@ -209,20 +209,18 @@
 		return FALSE
 
 /obj/structure/table/mouse_drop_receive(obj/dropping, mob/user, params)
-	if(..())
-		return TRUE
 	if(!isitem(dropping) || user.get_active_hand() != dropping)
-		return FALSE
+		return ..()
 	if(isrobot(user) || user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-		return FALSE
+		return
 	if(istype(dropping, /obj/item/storage/bag/tray)) // we don't put the tray on the table
-		return FALSE
+		return
 	if(!user.drop_item_ground(dropping))
-		return FALSE
+		return
 	if(dropping.loc != loc)
 		add_fingerprint(user)
 		step(dropping, get_dir(dropping, src))
-		return TRUE
+		return
 
 /obj/structure/table/proc/tablepush(mob/living/victim, mob/user)
 	if(HAS_TRAIT(user, TRAIT_PACIFISM) || GLOB.pacifism_after_gt)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -123,7 +123,6 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 
 /obj/structure/window/mouse_drop_receive(atom/dropping, mob/user, params)
 	. = ..()
-
 	//Adds the component only once. We do it here & not in Initialize() because there are tons of windows & we don't want to add to their init times
 	LoadComponent(/datum/component/leanable, dropping)
 

--- a/code/modules/antagonists/space_ninja/machinery/ninja_mindscan_machine.dm
+++ b/code/modules/antagonists/space_ninja/machinery/ninja_mindscan_machine.dm
@@ -106,7 +106,6 @@
 	if(!Adjacent(dropped_mob) && !Adjacent(user))
 		to_chat(user, span_boldnotice("You're not close enough to [src]."))
 		return
-	. = TRUE
 	if(dropped_mob != user)
 		visible_message("[user] starts putting [dropped_mob] into the [src].")
 	if(do_after(user, 2 SECONDS, dropped_mob))

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -606,24 +606,20 @@
 	reverse_dropoff_coords = list(picked_turf.x, picked_turf.y, picked_turf.z)
 	return ..()
 
-/obj/structure/closet/supplypod/mouse_drop_receive(atom/movable/O, mob/living/user, params)
-	if(!(SEND_SIGNAL(src, COMSIG_SUPPLYPOD_CLIMB_CHECK, O, user) & COMPONENT_CLIMB))
+/obj/structure/closet/supplypod/mouse_drop_receive(atom/movable/target_movable, mob/living/user, params)
+	if(!(SEND_SIGNAL(src, COMSIG_SUPPLYPOD_CLIMB_CHECK, target_movable, user) & COMPONENT_CLIMB))
 		return ..()
 
-	to_chat(user, span_notice("Вы начинаетезаталкивать"))
+	balloon_alert(user, "заталкивание...")
 	user.visible_message(
-		span_notice("[DECLENT_RU_CAP(user, NOMINATIVE)] начинает запихивать [O.declent_ru(ACCUSATIVE)] в [declent_ru(ACCUSATIVE)]."),
-		span_notice("Вы начинаете запихивать [O.declent_ru(ACCUSATIVE)] в [declent_ru(ACCUSATIVE)]."),
+		span_notice("[DECLENT_RU_CAP(user, NOMINATIVE)] начинает запихивать [target_movable.declent_ru(ACCUSATIVE)] в [declent_ru(ACCUSATIVE)]."),
+		span_notice("Вы начинаете запихивать [target_movable.declent_ru(ACCUSATIVE)] в [declent_ru(ACCUSATIVE)]."),
 	)
 
 	if(!do_after(user, 5 SECONDS, src))
 		return
 
-	. = ..()
-	if(!.)
-		return
-
-	O.forceMove(get_turf(src))
+	target_movable.forceMove(get_turf(src))
 
 /obj/structure/closet/supplypod/set_opened() //Proc exists here, as well as in any atom that can assume the role of a "holder" of a supplypod. Check the open_pod() proc for more details
 	opened = TRUE

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -611,14 +611,15 @@
 		return ..()
 
 	to_chat(user, span_notice("Вы начинаетезаталкивать"))
-	user.visible_message(span_notice("[DECLENT_RU_CAP(user, NOMINATIVE)] начинает запихивать [O.declent_ru(ACCUSATIVE)] в [declent_ru(ACCUSATIVE)]."),
-						span_notice("Вы начинаете запихивать [O.declent_ru(ACCUSATIVE)] в [declent_ru(ACCUSATIVE)]."))
+	user.visible_message(
+		span_notice("[DECLENT_RU_CAP(user, NOMINATIVE)] начинает запихивать [O.declent_ru(ACCUSATIVE)] в [declent_ru(ACCUSATIVE)]."),
+		span_notice("Вы начинаете запихивать [O.declent_ru(ACCUSATIVE)] в [declent_ru(ACCUSATIVE)]."),
+	)
 
 	if(!do_after(user, 5 SECONDS, src))
 		return
 
 	. = ..()
-
 	if(!.)
 		return
 

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -137,7 +137,7 @@
 
 	if(targetl.buckled)
 		return
-	. = TRUE
+
 	add_fingerprint(user)
 	move_into_gibber(user,target)
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -263,17 +263,17 @@
 //Drag pill bottle to fridge to empty it into the fridge
 /obj/machinery/smartfridge/mouse_drop_receive(obj/over_object, mob/user, params)
 	if(!ishuman(user) || user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-		return TRUE
+		return
 	if(!istype(over_object, /obj/item/storage/pill_bottle)) //Only pill bottles, please
-		return TRUE
+		return
 	if(stat & (BROKEN|NOPOWER))
 		balloon_alert(user, "не работает!")
-		return TRUE
+		return
 
 	var/obj/item/storage/box/pillbottles/P = over_object
 	if(!length(P.contents))
 		balloon_alert(user, "нечего выгружать!")
-		return TRUE
+		return
 
 	add_fingerprint(user)
 	var/items_loaded = 0
@@ -290,7 +290,6 @@
 	var/failed = length(P.contents)
 	if(failed)
 		to_chat(user, span_notice("[failed] предмет[DECL_CREDIT(failed)] не был[declension_ru(failed, "", "и", "и")] загружен[declension_ru(failed, "", "ы", "ы")]."))
-	return TRUE
 
 /obj/machinery/smartfridge/ui_interact(mob/user, datum/tgui/ui = null)
 	user.set_machine(src)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1018,8 +1018,6 @@
 		check_self_for_injuries()
 		return
 
-	SEND_SIGNAL(src, COMSIG_MOUSEDROP_ONTO, usr, usr)
-
 /**
  * Set up DNA and species.
  *

--- a/code/modules/mob/living/carbon/human/interactions.dm
+++ b/code/modules/mob/living/carbon/human/interactions.dm
@@ -7,9 +7,6 @@
 		return
 	interact(over_object)
 
-/mob/proc/make_interaction()
-	return
-
 //Distant interactions
 /mob/living/carbon/human/verb/interact(mob/M as mob)
 	set name = "Взаимодействовать"
@@ -20,9 +17,9 @@
 		make_interaction(machine)
 
 /mob/living/carbon/human/proc/is_nude()
-	return (!wear_suit && !w_uniform) ? 1 : 0 //TODO: Nudity check for underwear
+	return (!wear_suit && !w_uniform) ? TRUE : FALSE //TODO: Nudity check for underwear
 
-/mob/living/carbon/human/make_interaction()
+/mob/living/carbon/human/proc/make_interaction()
 	set_machine(src)
 
 	var/mob/living/carbon/human/H = usr

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -423,12 +423,10 @@
 // mousedrop a crate to load the bot
 // can load anything if hacked
 /mob/living/simple_animal/bot/mulebot/mouse_drop_receive(atom/movable/AM, mob/user, params)
-
 	if(!istype(AM) || user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !in_range(user, src))
-		return FALSE
+		return 
 
 	load(AM)
-	return TRUE
 
 // called to load a crate
 /mob/living/simple_animal/bot/mulebot/proc/load(atom/movable/AM)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -790,7 +790,6 @@
 		return
 	if(isLivingSSD(src) && user.client?.send_ssd_warning(src))
 		return
-	SEND_SIGNAL(src, COMSIG_MOUSEDROP_ONTO, user, user)
 
 /**
  * Checks whether a mob can perform an action to interact with an object

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -715,7 +715,6 @@
 	playsound(loc, 'sound/machines/ping.ogg', 50, FALSE)
 	atom_say("Внимание: На стеклянной плаформе обнаружены ягодицы!", FALSE)
 	SStgui.update_uis(src)
-	return TRUE
 
 /obj/machinery/photocopier/Destroy()
 	QDEL_LIST(saved_documents)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -279,7 +279,6 @@
 		else
 			viewer.show_message("[DECLENT_RU_CAP(user, NOMINATIVE)] начина[PLUR_ET_YUT(user)] заталкивать [target.declent_ru(ACCUSATIVE)] в мусоропровод.", 3)
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/obj/machinery/disposal, put_in), target, user)
-	return TRUE
 
 /obj/machinery/disposal/proc/put_in(mob/living/target, mob/living/user) // need this proc to use INVOKE_ASYNC in other proc. You're not recommended to use that one
 	var/msg

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -784,21 +784,20 @@
 
 /obj/spacepod/mouse_drop_receive(mob/living/dropping, mob/living/user, params)
 	if(user == pilot || (user in passengers) || !isliving(user) || user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-		return FALSE
+		return
 
-	. = TRUE
 	if(isliving(dropping))
 		occupant_sanity_check()
 
 		if(dropping != user && unlocked && (dropping.stat == DEAD || dropping.incapacitated()))
 			if(length(passengers) >= max_passengers && !pilot)
 				to_chat(user, span_danger("<b>Этот человек не может управлять челноком!</b>"))
-				return .
+				return
 			if(length(passengers) < max_passengers)
 				visible_message(span_danger("[user.name] начина[PLUR_ET_YUT(user)] загрузку [dropping.declent_ru(GENITIVE)] в челнок!"))
 				if(do_after(user, 5 SECONDS, dropping))
 					moved_other_inside(dropping)
-			return .
+			return
 
 		if(dropping == user)
 			enter_pod(user)

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -467,21 +467,20 @@
 
 	if(occupant)
 		balloon_alert(user, "внутри кто-то есть!")
-		return TRUE
+		return
 
 	if(target.buckled)
 		return
 
 	if(target.abiotic())
 		balloon_alert(user, "руки субъекта заняты!")
-		return TRUE
+		return
 
 	if(target.has_buckled_mobs()) //mob attached to us
 		to_chat(user, span_warning("[target] не помест[PLUR_IT_YAT(target)]ся в [declent_ru(ACCUSATIVE)], пока на [GEND_ON_IN_HIM(target)] сидит слайм!"))
-		return TRUE
+		return
 
 	put_in(target, user)
-	return TRUE
 
 /obj/machinery/bci_implanter/grab_attack(mob/living/grabber, atom/movable/grabbed_thing)
 	. = TRUE


### PR DESCRIPTION
## Что этот ПР делает
Баг-репорты:
https://discord.com/channels/617003227182792704/1498663498769502478
https://discord.com/channels/617003227182792704/1497595437144871154
https://discord.com/channels/617003227182792704/1498653215523340298
https://discord.com/channels/617003227182792704/1497594372978507897
https://discord.com/channels/617003227182792704/1495072235675979856

## Список изменений
:cl:
bugfix: Больше нельзя засунуть за 10 секунд всё содержимое таблетница/патчницы в куклу.
bugfix: Под контрактора больше не вызывает двойной ду афтер.
bugfix: Патчница/таблетница снова высвобождает содержимое на стол.
bugfix: Меню взаимодействия снова работает при перетягивании своей куклы на другую.
refactor: mouse_drop_receive
/:cl:
