### PR TITLE
add: Maintenance drone now have a trash bag

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1049,6 +1049,7 @@
 	modules += new /obj/item/extinguisher(src)
 	modules += new /obj/item/reagent_containers/spray/cleaner/drone(src)
 	modules += new /obj/item/soap(src)
+	modules += new /obj/item/storage/bag/trash/cyborg(src)
 	modules += new /obj/item/rpd(src)
 	modules += new /obj/item/t_scanner(src)
 	modules += new /obj/item/analyzer(src)


### PR DESCRIPTION

## Что этот ПР делает
Добавляет дронам обслуживания мусорный мешок
## Почему это хорошо для игры
Станция будет чище и дроны смогут убирать мусор с техов
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
add: Добавлен мусорный мешок дронам обслуживания
/:cl:
