### PR TITLE
Фикс способностей ниндзя после второго шанса

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -2295,6 +2295,7 @@
 				ninja_datum.give_equip = FALSE
 				ninja_datum.give_objectives = FALSE
 				ninja_datum.generate_antags = FALSE
+				ninja_datum.change_species(current)
 				add_antag_datum(ninja_datum)
 				log_admin("[key_name(usr)] has made [key_name(current)] into a \"Ninja\"")
 				message_admins("[key_name_admin(usr)] has made [key_name_admin(current)] into a \"Ninja\"")

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -461,7 +461,7 @@
 	. = ..()
 	icon_state = "scan_[scan_type]_[scan_color]"
 	if(scan_type == "alpha")
-		beta = new(get_turf(src), scan_color)
+		beta = new /obj/effect/temp_visual/holo_scan/beta(get_turf(src), scan_color)
 
 /obj/effect/temp_visual/holo_scan/Destroy()
 	QDEL_NULL(beta)

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -455,7 +455,7 @@
 	pixel_y = -8
 	duration = 2 SECONDS
 	var/scan_type = "alpha"
-	var/obj/effect/temp_visual/holo_scan/beta
+	var/obj/effect/temp_visual/holo_scan/beta/beta
 
 /obj/effect/temp_visual/holo_scan/Initialize(mapload, scan_color = "red")
 	. = ..()

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -461,7 +461,7 @@
 	. = ..()
 	icon_state = "scan_[scan_type]_[scan_color]"
 	if(scan_type == "alpha")
-		beta = new /obj/effect/temp_visual/holo_scan/beta(get_turf(src), scan_color)
+		beta = new(get_turf(src), scan_color)
 
 /obj/effect/temp_visual/holo_scan/Destroy()
 	QDEL_NULL(beta)

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_adrenaline.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_adrenaline.dm
@@ -12,6 +12,18 @@
 	background_icon_state = "background_green_active"
 	action_initialisation_text = "Integrated Adrenaline Injector"
 
+/datum/action/item_action/advanced/ninja/ninjaboost/Grant(mob/living/carbon/human/ninja)
+	var/obj/item/clothing/suit/space/space_ninja/ninja_suit = target
+	if(ninja_suit && istype(ninja_suit))
+		ninja_suit.a_boost = src
+	return ..()
+
+/datum/action/item_action/advanced/ninja/ninjaboost/Remove(mob/living/carbon/human/ninja)
+	var/obj/item/clothing/suit/space/space_ninja/ninja_suit = target
+	if(ninja_suit && istype(ninja_suit))
+		ninja_suit.a_boost = null
+	return ..()
+
 /**
  * Proc called to activate space ninja's adrenaline.
  *
@@ -38,12 +50,11 @@
 	//Никакого омнизина как в трейторском адренале. Наш адренал не хилит!
 	ninja.say(pick(boost_phrases))
 	to_chat(ninja, span_notice("Вы чувствуете мощный прилив адреналина!"))
-	for(var/datum/action/item_action/advanced/ninja/ninjaboost/ninja_action in actions)
-		ninja_action.use_action()
-		if(!ninja_action.charge_counter)
-			ninja_action.action_ready = FALSE
-			ninja_action.toggle_button_on_off()
-		break
+	var/datum/action/item_action/advanced/ninja/ninjaboost/ninjaboost = locate() in ninja.actions
+	ninjaboost.use_action()
+	if(!ninjaboost.charge_counter)
+		ninjaboost.action_ready = FALSE
+		ninjaboost.toggle_button_on_off()
 	addtimer(CALLBACK(src, PROC_REF(ninjaboost_after)), 7 SECONDS)
 
 /**

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_autodust.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_autodust.dm
@@ -33,8 +33,8 @@
 	else if(auto_dust)
 		auto_dust = FALSE
 		user.show_message("Вы выключили программу [span_warning("\"Автосжигания\"")]")
-	for(var/datum/action/item_action/advanced/ninja/ninja_autodust/ninja_action in actions)
-		ninja_action.use_action()
+	var/datum/action/item_action/advanced/ninja/ninja_autodust/ninja_autodust = locate() in affecting.actions
+	ninja_autodust.use_action()
 	s_busy = FALSE
 /**
  * Proc called to dust the ninja!

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_caltrops.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_caltrops.dm
@@ -43,12 +43,11 @@
 		for(var/turf/spawn_turf in possible_turfs)
 			if(!iswallturf(spawn_turf) && !locate(/obj/structure/grille) in spawn_turf)
 				new /obj/structure/energy_caltrops(spawn_turf)
-		for(var/datum/action/item_action/advanced/ninja/ninja_caltrops/ninja_action in actions)
-			ninja_action.use_action()
-			break
+		var/datum/action/item_action/advanced/ninja/ninja_caltrops/ninja_caltrops = locate() in ninja.actions
+		ninja_caltrops.use_action()
 		playsound(ninja, 'sound/effects/glass_step_sm.ogg', 50, TRUE)
 		if(auto_smoke)
-			if(locate(/datum/action/item_action/advanced/ninja/ninja_smoke_bomb) in actions)
+			if(locate(/datum/action/item_action/advanced/ninja/ninja_smoke_bomb) in ninja.actions)
 				prime_smoke(lowcost = TRUE)
 
 ///The caltrops object

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_chameleon.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_chameleon.dm
@@ -17,15 +17,15 @@
 	if(chameleon_scanner)
 		qdel(chameleon_scanner)
 		chameleon_scanner = null
-	else
-		chameleon_scanner = new
-		chameleon_scanner.my_suit = src
-		for(var/datum/action/item_action/advanced/ninja/ninja_chameleon/ninja_action in actions)
-			chameleon_scanner.my_action = ninja_action
-			break
-		if(disguise_active)
-			chameleon_scanner.icon_state = "[initial(chameleon_scanner.icon_state)]_act"
-		ninja.put_in_hands(chameleon_scanner)
+		return
+
+	chameleon_scanner = new
+	chameleon_scanner.my_suit = src
+	var/datum/action/item_action/advanced/ninja/ninja_chameleon/ninja_chameleon = locate() in ninja.actions
+	chameleon_scanner.my_action = ninja_chameleon
+	if(disguise_active)
+		chameleon_scanner.icon_state = "[initial(chameleon_scanner.icon_state)]_act"
+	ninja.put_in_hands(chameleon_scanner)
 
 /*
  * The scanner object and all the logic behind it below
@@ -43,10 +43,10 @@
 	var/datum/action/item_action/advanced/ninja/ninja_chameleon/my_action = null
 
 /obj/item/ninja_chameleon_scanner/Destroy()
-	. = ..()
 	my_suit.chameleon_scanner = null
 	my_suit = null
 	my_action = null
+	return ..()
 
 /obj/item/ninja_chameleon_scanner/equip_to_best_slot(mob/user, force = FALSE, drop_on_fail = FALSE, qdel_on_fail = FALSE)
 	qdel(src)
@@ -155,9 +155,9 @@
 		if(chameleon_scanner)
 			chameleon_scanner.icon_state = "[initial(chameleon_scanner.icon_state)]_act"
 		//Action icon
-		for(var/datum/action/item_action/advanced/ninja/ninja_chameleon/ninja_action in actions)
-			ninja_action.action_ready = TRUE
-			ninja_action.use_action()
+		var/datum/action/item_action/advanced/ninja/ninja_chameleon/ninja_chameleon = locate() in ninja.actions
+		ninja_chameleon.action_ready = TRUE
+		ninja_chameleon.use_action()
 		ninja.cut_overlays()
 	else
 		ninja.cut_overlay(disguise.overlays)
@@ -204,9 +204,9 @@
 	if(chameleon_scanner)
 		chameleon_scanner.icon_state = "[initial(chameleon_scanner.icon_state)]"
 	//Action icon
-	for(var/datum/action/item_action/advanced/ninja/ninja_chameleon/ninja_action in actions)
-		ninja_action.action_ready = FALSE
-		ninja_action.use_action()
+	var/datum/action/item_action/advanced/ninja/ninja_chameleon/ninja_chameleon = locate() in ninja.actions
+	ninja_chameleon.action_ready = FALSE
+	ninja_chameleon.use_action()
 	//Components
 	qdel(ninja.GetComponent(/datum/component/examine_override))
 	qdel(ninja.GetComponent(/datum/component/ninja_states_breaker))

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_clone.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_clone.dm
@@ -14,14 +14,13 @@
 		return
 	if(!ninjacost(4000))
 		playsound(ninja, 'sound/effects/clone_jutsu.ogg', 50, TRUE)
-		for(var/datum/action/item_action/advanced/ninja/ninja_clones/ninja_action in actions)
-			ninja_action.use_action()
-			break
+		var/datum/action/item_action/advanced/ninja/ninja_clones/ninja_clones = locate() in ninja.actions
+		ninja_clones.use_action()
 		addtimer(CALLBACK(src, PROC_REF(spawn_ninja_clones), ninja), 15)
 
 /obj/item/clothing/suit/space/space_ninja/proc/spawn_ninja_clones(mob/living/carbon/human/ninja)
 	if(auto_smoke)
-		if(locate(/datum/action/item_action/advanced/ninja/ninja_smoke_bomb) in actions)
+		if(locate(/datum/action/item_action/advanced/ninja/ninja_smoke_bomb) in ninja.actions)
 			prime_smoke(lowcost = TRUE)
 	do_sparks(3, FALSE, ninja)
 	add_attack_logs(ninja, null, "Activated Energy Clones")

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_emergency_blink.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_emergency_blink.dm
@@ -17,11 +17,10 @@
 	if(!ninjacost(1500))
 		var/turf/T = get_turf(ninja)
 		if(auto_smoke)
-			if(locate(/datum/action/item_action/advanced/ninja/ninja_smoke_bomb) in actions)
+			if(locate(/datum/action/item_action/advanced/ninja/ninja_smoke_bomb) in ninja.actions)
 				prime_smoke(lowcost = TRUE)
 		do_teleport(ninja, T, 8, asoundin = 'sound/effects/phasein.ogg', ignore_bluespace_interference = TRUE)
 		add_attack_logs(ninja, null, "Emergency blinked from [COORD(T)] to [COORD(ninja)].")
 		investigate_log("[key_name_log(ninja)] Emergency blinked from [COORD(T)] to [COORD(ninja)].", INVESTIGATE_TELEPORTATION)
-		for(var/datum/action/item_action/advanced/ninja/ninja_emergency_blink/ninja_action in actions)
-			ninja_action.use_action()
-			break
+		var/datum/action/item_action/advanced/ninja/ninja_emergency_blink/ninja_emergency_blink = locate() in ninja.actions
+		ninja_emergency_blink.use_action()

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_empulse.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_empulse.dm
@@ -22,8 +22,7 @@
 	playsound(H.loc, 'sound/effects/empulse.ogg', 60, TRUE)
 	empulse(H, 4, 6, TRUE, "Ninja EM Burst") //Procs sure are nice. Slightly weaker than wizard's disable tch.
 	if(auto_smoke)
-		if(locate(/datum/action/item_action/advanced/ninja/ninja_smoke_bomb) in actions)
+		if(locate(/datum/action/item_action/advanced/ninja/ninja_smoke_bomb) in affecting.actions)
 			prime_smoke(lowcost = TRUE)
-	for(var/datum/action/item_action/advanced/ninja/ninjapulse/ninja_action in actions)
-		ninja_action.use_action()
-		break
+	var/datum/action/item_action/advanced/ninja/ninjapulse/ninjapulse = locate() in affecting.actions
+	ninjapulse.use_action()

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_energy_stars.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_energy_stars.dm
@@ -14,15 +14,15 @@
 	if(shuriken_emitter)
 		qdel(shuriken_emitter)
 		shuriken_emitter = null
-	else
-		shuriken_emitter = new
-		shuriken_emitter.my_suit = src
-		for(var/datum/action/item_action/advanced/ninja/toggle_shuriken_fire_mode/ninja_action in actions)
-			shuriken_emitter.my_action = ninja_action
-			ninja_action.action_ready = TRUE
-			ninja_action.use_action()
-			break
-		ninja.put_in_hands(shuriken_emitter)
+		return
+
+	shuriken_emitter = new
+	shuriken_emitter.my_suit = src
+	var/datum/action/item_action/advanced/ninja/toggle_shuriken_fire_mode/toggle_shuriken_fire_mode = locate() in ninja.actions
+	shuriken_emitter.my_action = toggle_shuriken_fire_mode
+	toggle_shuriken_fire_mode.action_ready = TRUE
+	toggle_shuriken_fire_mode.use_action()
+	ninja.put_in_hands(shuriken_emitter)
 
 /obj/effect/temp_visual/impact_effect/green_particles
 	icon_state = "mech_toxin"

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_healing_chems.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_healing_chems.dm
@@ -11,6 +11,18 @@
 	background_icon_state = "background_green_active"
 	action_initialisation_text = "Integrated Restorative Cocktail Mixer"
 
+/datum/action/item_action/advanced/ninja/ninjaheal/Grant(mob/living/carbon/human/ninja)
+	var/obj/item/clothing/suit/space/space_ninja/ninja_suit = target
+	if(ninja_suit && istype(ninja_suit))
+		ninja_suit.heal_chems = src
+	return ..()
+
+/datum/action/item_action/advanced/ninja/ninjaheal/Remove(mob/living/carbon/human/ninja)
+	var/obj/item/clothing/suit/space/space_ninja/ninja_suit = target
+	if(ninja_suit && istype(ninja_suit))
+		ninja_suit.heal_chems = null
+	return ..()
+
 /obj/item/clothing/suit/space/space_ninja/proc/ninjaheal()
 	if(ninjacost(0,N_HEAL))
 		return
@@ -19,12 +31,13 @@
 	balloon_alert(ninja, "чиюризин введён")
 	atom_say("Spider-OS напоминает вам, вы можете отслеживать количество реагента в крови с помощью встроенных сканеров.")
 	add_attack_logs(ninja, null, "Activated healing chems.")
-	for(var/datum/action/item_action/advanced/ninja/ninjaheal/ninja_action in actions)
-		ninja_action.use_action()
-		if(!ninja_action.charge_counter)
-			ninja_action.action_ready = FALSE
-			ninja_action.toggle_button_on_off()
-		break
+	var/datum/action/item_action/advanced/ninja/ninjaheal/ninjaheal = locate() in ninja.actions
+	ninjaheal.use_action()
+	if(!ninjaheal.charge_counter)
+		ninjaheal.action_ready = FALSE
+		ninjaheal.toggle_button_on_off()
+
+
 
 // A reality rift designated to contain our ninja inside it.
 // Created via the "chiyurizine" reagent.

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_healing_chems.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_healing_chems.dm
@@ -37,8 +37,6 @@
 		ninjaheal.action_ready = FALSE
 		ninjaheal.toggle_button_on_off()
 
-
-
 // A reality rift designated to contain our ninja inside it.
 // Created via the "chiyurizine" reagent.
 /obj/effect/temp_visual/ninja_rend

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_johyo.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_johyo.dm
@@ -14,15 +14,16 @@
 	if(integrated_harpoon)
 		qdel(integrated_harpoon)
 		integrated_harpoon = null
-	else
-		integrated_harpoon = new
-		integrated_harpoon.my_suit = src
-		for(var/datum/action/item_action/advanced/ninja/johyo/ninja_action in actions)
-			integrated_harpoon.my_action = ninja_action
-			ninja_action.action_ready = TRUE
-			ninja_action.toggle_button_on_off()
-			break
-		ninja.put_in_hands(integrated_harpoon)
+		return
+
+	integrated_harpoon = new
+	integrated_harpoon.my_suit = src
+	var/datum/action/item_action/advanced/ninja/johyo/johyo = locate() in ninja.actions
+	integrated_harpoon.my_action = johyo
+	johyo.action_ready = TRUE
+	johyo.toggle_button_on_off()
+
+	ninja.put_in_hands(integrated_harpoon)
 
 //Harpoon
 
@@ -58,12 +59,12 @@
 	)
 
 /obj/item/gun/magic/johyo/Destroy()
-	. = ..()
 	my_suit.integrated_harpoon = null
 	my_suit = null
 	my_action.action_ready = FALSE
 	my_action.toggle_button_on_off()
 	my_action = null
+	return ..()
 
 /obj/item/gun/magic/johyo/equip_to_best_slot(mob/user, force = FALSE, drop_on_fail = FALSE, qdel_on_fail = FALSE)
 	qdel(src)

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_net.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_net.dm
@@ -13,15 +13,15 @@
 	if(net_emitter)
 		qdel(net_emitter)
 		net_emitter = null
-	else
-		net_emitter = new
-		net_emitter.my_suit = src
-		for(var/datum/action/item_action/advanced/ninja/ninjanet/ninja_action in actions)
-			net_emitter.my_action = ninja_action
-			ninja_action.action_ready = TRUE
-			ninja_action.use_action()
-			break
-		ninja.put_in_hands(net_emitter)
+		return
+
+	net_emitter = new
+	net_emitter.my_suit = src
+	var/datum/action/item_action/advanced/ninja/ninjanet/ninjanet = locate() in ninja.actions
+	net_emitter.my_action = ninjanet
+	ninjanet.action_ready = TRUE
+	ninjanet.use_action()
+	ninja.put_in_hands(net_emitter)
 
 /obj/item/ninja_net_emitter
 	name = "Energy Net Emitter"
@@ -45,12 +45,12 @@
 	)
 
 /obj/item/ninja_net_emitter/Destroy()
-	. = ..()
 	my_suit.net_emitter = null
 	my_suit = null
 	my_action.action_ready = FALSE
 	my_action.use_action()
 	my_action = null
+	return ..()
 
 /obj/item/ninja_net_emitter/equip_to_best_slot(mob/user, force = FALSE, drop_on_fail = FALSE, qdel_on_fail = FALSE)
 	qdel(src)

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_smoke_bomb.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_smoke_bomb.dm
@@ -19,8 +19,8 @@
 	action_initialisation_text = null
 
 /obj/item/clothing/suit/space/space_ninja/proc/prime_smoke(lowcost = FALSE)
-	var/datum/action/item_action/advanced/ninja/ninja_smoke_bomb/ninja_action = locate() in actions
-	if(!ninja_action.IsAvailable(feedback = FALSE))
+	var/datum/action/item_action/advanced/ninja/ninja_smoke_bomb/ninja_smoke_bomb = locate() in affecting.actions
+	if(!ninja_smoke_bomb.IsAvailable(feedback = FALSE))
 		return
 	var/cost = lowcost ? 250 : 1000
 	if(!ninjacost(cost))
@@ -28,10 +28,9 @@
 		var/smoke_amount = lowcost ? 5 : 20
 		smoke_system.set_up(amount = smoke_amount, location = src)
 		smoke_system.start()
-		ninja_action.use_action()
+		ninja_smoke_bomb.use_action()
 
 /obj/item/clothing/suit/space/space_ninja/proc/toggle_smoke()
-	for(var/datum/action/item_action/advanced/ninja/ninja_smoke_bomb_toggle_auto/ninja_action in actions)
-		ninja_action.use_action()
-		auto_smoke = !auto_smoke
-		break
+	var/datum/action/item_action/advanced/ninja/ninja_smoke_bomb_toggle_auto/ninja_smoke_bomb_toggle_auto = locate() in affecting.actions
+	ninja_smoke_bomb_toggle_auto.use_action()
+	auto_smoke = !auto_smoke

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_spirit_form.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_spirit_form.dm
@@ -43,11 +43,10 @@
 			to_chat(ninja, span_notice("Теперь вы можете пройти почти через все."))	// Если же невидимы — пишем только себе
 		ninja.pass_flags |= PASSEVERYTHING
 		drop_restraints()
-		for(var/datum/action/item_action/advanced/ninja/ninja_spirit_form/ninja_action in actions)
-			ninja_action.use_action()
-			ninja_action.action_ready = TRUE
-			ninja_action.toggle_button_on_off()
-			break
+		var/datum/action/item_action/advanced/ninja/ninja_spirit_form/ninja_spirit_form = locate() in ninja.actions
+		ninja_spirit_form.use_action()
+		ninja_spirit_form.action_ready = TRUE
+		ninja_spirit_form.toggle_button_on_off()
 
 /**
  * Proc called to cancel spirit form.
@@ -71,9 +70,9 @@
 		else
 			to_chat(ninja, span_notice("Вы теряете способность проходить сквозь материальные объекты.")) // Если же невидимы — пишем только себе
 		ninja.pass_flags = 0	//Отнимать этот флаг - "PASS_EVERYTHING" по нормальному он не хочет, значит сделаем полный сброс.
-		for(var/datum/action/item_action/advanced/ninja/ninja_spirit_form/ninja_action in actions)
-			ninja_action.action_ready = FALSE
-			ninja_action.toggle_button_on_off()
+		var/datum/action/item_action/advanced/ninja/ninja_spirit_form/ninja_spirit_form = locate() in ninja.actions
+		ninja_spirit_form.action_ready = FALSE
+		ninja_spirit_form.toggle_button_on_off()
 		return TRUE
 	return FALSE
 

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_stealth.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_stealth.dm
@@ -40,11 +40,10 @@
 			if(auto_smoke)
 				if(locate(/datum/action/item_action/advanced/ninja/ninja_smoke_bomb) in actions)
 					prime_smoke(lowcost = TRUE)
-			for(var/datum/action/item_action/advanced/ninja/ninja_stealth/ninja_action in actions)
-				ninja_action.use_action()
-				ninja_action.action_ready = TRUE
-				ninja_action.toggle_button_on_off()
-				break
+			var/datum/action/item_action/advanced/ninja/ninja_stealth/ninja_stealth = locate() in ninja.actions
+			ninja_stealth.use_action()
+			ninja_stealth.action_ready = TRUE
+			ninja_stealth.toggle_button_on_off()
 			s_busy = FALSE
 
 /**
@@ -59,18 +58,18 @@
 	var/mob/living/carbon/human/ninja = affecting
 	if(!ninja)
 		return FALSE
-	if(stealth)
-		stealth = !stealth
-		n_shoes.silence_steps = FALSE
-		var/stealth_alpha
-		stealth_alpha = spirited ? NINJA_ALPHA_SPIRIT_FORM : NINJA_ALPHA_NORMAL
-		animate(ninja, alpha = stealth_alpha, time = 6)
-		ninja.alpha_set(standartize_alpha(stealth_alpha), ALPHA_SOURCE_NINJA)
-		new /obj/effect/temp_visual/dir_setting/ninja(get_turf(ninja), ninja.dir)
-		ninja.visible_message(span_warning("[ninja.name] появил[GEND_SYA_AS_OS_IS(ninja) ] из воздуха!"), span_notice("Теперь вас снова видно невооружённым глазом."))
-		qdel(ninja.GetComponent(/datum/component/ninja_states_breaker))
-		for(var/datum/action/item_action/advanced/ninja/ninja_stealth/ninja_action in actions)
-			ninja_action.action_ready = FALSE
-			ninja_action.toggle_button_on_off()
-		return TRUE
-	return FALSE
+	if(!stealth)
+		return FALSE
+	stealth = !stealth
+	n_shoes.silence_steps = FALSE
+	var/stealth_alpha
+	stealth_alpha = spirited ? NINJA_ALPHA_SPIRIT_FORM : NINJA_ALPHA_NORMAL
+	animate(ninja, alpha = stealth_alpha, time = 6)
+	ninja.alpha_set(standartize_alpha(stealth_alpha), ALPHA_SOURCE_NINJA)
+	new /obj/effect/temp_visual/dir_setting/ninja(get_turf(ninja), ninja.dir)
+	ninja.visible_message(span_warning("[ninja.name] появил[GEND_SYA_AS_OS_IS(ninja) ] из воздуха!"), span_notice("Теперь вас снова видно невооружённым глазом."))
+	qdel(ninja.GetComponent(/datum/component/ninja_states_breaker))
+	var/datum/action/item_action/advanced/ninja/ninja_stealth/ninja_stealth = locate() in ninja.actions
+	ninja_stealth.action_ready = FALSE
+	ninja_stealth.toggle_button_on_off()
+	return TRUE

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_suit_initialisation.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_suit_initialisation.dm
@@ -50,10 +50,10 @@
 	cell.self_recharge = TRUE
 	cell.maxcharge = 50000
 	START_PROCESSING(SSobj, cell)
-	for(var/datum/action/item_action/advanced/ninja/SpiderOS/ninja_action in actions)
-		ninja_action.action_ready = TRUE
-		ninja_action.use_action()
-		break
+	var/datum/action/item_action/advanced/ninja/SpiderOS/SpiderOS = locate() in ninja.actions
+	SpiderOS.action_ready = TRUE
+	SpiderOS.use_action()
+
 /**
  * Toggles the ninja suit on/off
  *
@@ -126,10 +126,9 @@
 			toggle_emp_proof(ninja.bodyparts, TRUE)
 			toggle_emp_proof(ninja.internal_organs, TRUE)
 			start()
-			for(var/datum/action/item_action/advanced/ninja/SpiderOS/ninja_action in actions)
-				ninja_action.action_ready = TRUE
-				ninja_action.use_action()
-				break
+			var/datum/action/item_action/advanced/ninja/SpiderOS/SpiderOS = locate() in ninja.actions
+			SpiderOS.action_ready = TRUE
+			SpiderOS.use_action()
 			s_busy = FALSE
 //	to_chat(ninja, span_notice("[message]"))
 	current_initialisation_text = message
@@ -195,10 +194,9 @@
 		if(NINJA_DEINIT_COMPLETE_PHASE)
 			toggle_emp_proof(ninja.bodyparts, FALSE)
 			toggle_emp_proof(ninja.internal_organs, FALSE)
-			for(var/datum/action/item_action/advanced/ninja/SpiderOS/ninja_action in actions)
-				ninja_action.action_ready = FALSE
-				ninja_action.use_action()
-				break
+			var/datum/action/item_action/advanced/ninja/SpiderOS/SpiderOS = locate() in ninja.actions
+			SpiderOS.action_ready = FALSE
+			SpiderOS.use_action()
 			s_busy = FALSE
 			affecting = null
 

--- a/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_sword_recall.dm
+++ b/code/modules/antagonists/space_ninja/suit/ninja_equipment_actions/ninja_sword_recall.dm
@@ -32,9 +32,8 @@
 		inview = FALSE
 
 	if(!ninjacost(200))	//Статичная цена в 200 энергии
-		for(var/datum/action/item_action/advanced/ninja/ninja_sword_recall/ninja_action in actions)
-			ninja_action.use_action()
-			break
+		var/datum/action/item_action/advanced/ninja/ninja_sword_recall/ninja_sword_recall = locate() in ninja.actions
+		ninja_sword_recall.use_action()
 		if(iscarbon(energyKatana.loc))
 			var/mob/living/carbon/sword_holder = energyKatana.loc
 			sword_holder.drop_item_ground(energyKatana, force = TRUE)

--- a/code/modules/projectiles/projectile/special/johyo.dm
+++ b/code/modules/projectiles/projectile/special/johyo.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/ninjaobjects.dmi'
 	damage = 5
 	armour_penetration = 100
+	ricochet_chance = 0
 	hitsound = 'sound/weapons/whip.ogg'
 	knockdown = 2 SECONDS
 

--- a/code/modules/projectiles/projectile/special/magic.dm
+++ b/code/modules/projectiles/projectile/special/magic.dm
@@ -8,6 +8,7 @@
 	damage_type = OXY
 	nodamage = TRUE
 	armour_penetration = 100
+	ricochet_chance = 0
 	flag = "magic"
 
 /obj/projectile/magic/get_ru_names()


### PR DESCRIPTION

## Что этот ПР делает
Исправляет использование абилок ниндзи после воскрешения через второй шанс, убирает рикошет у его крюка
## Список изменений
:cl:
tweak: Магические снаряды и джохё ниндзи больше не рикошетят.
bugfix: После клонирования с помощью второго шанса ниндзя снова может использовать способности.
/:cl:
