### PR TITLE
Фикс проксимити монитора и рантайма игрушки фейсхаггера

### DIFF
--- a/code/datums/components/connect_range.dm
+++ b/code/datums/components/connect_range.dm
@@ -88,13 +88,11 @@
 	// when switching locs in the same turf so i commented it out
 	// - Ksaikok
 
-	// I didn't find any issues.
-	// - LittleBoobs
-
 	// Only register/unregister turf signals if it's moved to a new turf.
-	if(current_turf == get_turf(old_loc))
+	/*if(current_turf == get_turf(old_loc))
 		unregister_signals(old_loc, null)
-		return
+		return*/
+
 	var/list/old_turfs = turfs
 	turfs = RANGE_TURFS(range, current_turf)
 	unregister_signals(old_loc, old_turfs - turfs)

--- a/code/datums/proximity_monitor/field.dm
+++ b/code/datums/proximity_monitor/field.dm
@@ -87,7 +87,7 @@
 
 /datum/proximity_monitor/advanced/on_moved(atom/movable/movable, atom/old_loc)
 	. = ..()
-	if(ignore_if_not_on_turf)
+	if(!works_when_not_on_turf)
 		//Early return if it's not the host that has moved.
 		if(movable != host)
 			return
@@ -127,7 +127,7 @@
 		cleanup_field_turf(target)
 
 /datum/proximity_monitor/advanced/proc/update_new_turfs()
-	if(ignore_if_not_on_turf && !isturf(host.loc))
+	if(!works_when_not_on_turf && !isturf(host.loc))
 		return list(FIELD_TURFS_KEY = list(), EDGE_TURFS_KEY = list())
 
 	var/list/local_field_turfs = list()

--- a/code/datums/proximity_monitor/fields/gravity.dm
+++ b/code/datums/proximity_monitor/fields/gravity.dm
@@ -5,7 +5,7 @@
 	var/list/modified_turfs = list()
 	var/mob_ref_key
 
-/datum/proximity_monitor/advanced/gravity/New(atom/_host, range, _ignore_if_not_on_turf = TRUE, gravity)
+/datum/proximity_monitor/advanced/gravity/New(atom/_host, range, works_when_not_on_turf = FALSE, gravity)
 	. = ..()
 	gravity_value = gravity
 	recalculate_field(full_recalc = TRUE)

--- a/code/datums/proximity_monitor/fields/timestop.dm
+++ b/code/datums/proximity_monitor/fields/timestop.dm
@@ -104,7 +104,7 @@
 
 	var/static/list/global_frozen_atoms = list()
 
-/datum/proximity_monitor/advanced/timestop/New(atom/_host, range, _ignore_if_not_on_turf = TRUE, list/immune, antimagic_flags, channelled, timefreeze, color_matrix)
+/datum/proximity_monitor/advanced/timestop/New(atom/_host, range, works_when_not_on_turf = FALSE, list/immune, antimagic_flags, channelled, timefreeze, color_matrix)
 	..()
 	src.immune = immune.Copy()
 	src.antimagic_flags = antimagic_flags

--- a/code/datums/proximity_monitor/proximity_monitor.dm
+++ b/code/datums/proximity_monitor/proximity_monitor.dm
@@ -8,8 +8,8 @@
 	var/atom/hasprox_receiver
 	/// The range of the proximity monitor. Things moving wihin it will trigger HasProximity calls.
 	var/current_range = 1
-	/// If we don't check turfs in range if the host's loc isn't a turf
-	var/ignore_if_not_on_turf
+	/// Whether this monitor checks turfs in range when it's loc isn't a turf (inside closet for example)
+	var/works_when_not_on_turf
 	/// The signals of the connect range component, needed to monitor the turfs in range.
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
@@ -17,8 +17,8 @@
 		COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON = PROC_REF(on_initialized),
 	)
 
-/datum/proximity_monitor/New(atom/_host, range, _ignore_if_not_on_turf = TRUE)
-	ignore_if_not_on_turf = _ignore_if_not_on_turf
+/datum/proximity_monitor/New(atom/_host, range, works_when_not_on_turf = FALSE)
+	src.works_when_not_on_turf = works_when_not_on_turf
 	if(range)
 		current_range = range
 	set_host(_host)
@@ -65,7 +65,7 @@
 	current_range = range
 
 	// If the connect_range component exists already, this will just update its range. No errors or duplicates.
-	AddComponent(/datum/component/connect_range, host, loc_connections, range, !ignore_if_not_on_turf)
+	AddComponent(/datum/component/connect_range, host, loc_connections, range, works_when_not_on_turf)
 
 /datum/proximity_monitor/proc/on_moved(atom/movable/source, atom/old_loc)
 	SIGNAL_HANDLER
@@ -78,12 +78,12 @@
 
 	return
 
-/datum/proximity_monitor/proc/set_ignore_if_not_on_turf(does_ignore = TRUE)
-	if(ignore_if_not_on_turf == does_ignore)
+/datum/proximity_monitor/proc/set_works_when_not_on_turf(does_work = FALSE)
+	if(works_when_not_on_turf == does_work)
 		return
-	ignore_if_not_on_turf = does_ignore
-	// Update the ignore_if_not_on_turf
-	AddComponent(/datum/component/connect_range, host, loc_connections, current_range, ignore_if_not_on_turf)
+	works_when_not_on_turf = does_work
+	// Update the works_when_not_on_turf
+	AddComponent(/datum/component/connect_range, host, loc_connections, current_range, works_when_not_on_turf)
 
 /datum/proximity_monitor/proc/on_uncrossed()
 	SIGNAL_HANDLER

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -13,7 +13,7 @@
 
 /obj/item/assembly/prox_sensor/Initialize(mapload)
 	. = ..()
-	proximity_monitor = new(src, _ignore_if_not_on_turf = FALSE)
+	proximity_monitor = new(src, works_when_not_on_turf = TRUE)
 
 /obj/item/assembly/prox_sensor/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/mining/equipment/vendor_items.dm
+++ b/code/modules/mining/equipment/vendor_items.dm
@@ -16,15 +16,14 @@
 
 /obj/item/clothing/mask/facehugger/toy/Initialize(mapload)
 	. = ..()
-	proximity_monitor = new(src)
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/item/clothing/mask/facehugger/toy/Destroy()
-	. = ..()
 	QDEL_NULL(proximity_monitor)
+	return ..()
 
 /obj/item/clothing/mask/facehugger/toy/Die()
 	return


### PR DESCRIPTION

## Что этот ПР делает
Удаляет проксимити монитор у игрушки фейсхаггера, оставляет коннект_лок чтобы она просто цеплялась на того кто встанет на тайл с ней/в кого она прилетит/того кто откроет контейнер с ней, также переименовывает параметр у проксимити монитора чтобы он был интуитивно понятен

<details><summary>Дополнительные технические детали</summary>
<p>
Также исправляет название переменной у проксимити монитора с ignore_if_not_on_turf на works_when_not_on_turf и соответственно изменяет всю логику, чтобы не нужно было инвертировать этот аргумент для connect_range. Connect_range принимал параметр works_in_containers, который позволял сканировать турфы если владелец находится например в шкафу или коробке, этот параметр передавался из проксимити монитора инвертированным как !ignore_if_not_on_turf, потому что он означал "игнорировать[изменение позиции]если не на турфе", и такое использование звучит и выглядит максимально тупо и даже оригинальный автор на ТГ в этом запутался и пропустил инвертирование в одном из мест, так что я заменил название на вполне понятный works_when_not_on_turf который не нужно инвертировать.

Также комментирует назад багующие строки которые маленькая сиська раскомментировала, решил их не удалять в назидание будущим потомкам и мало ли вдруг что
</p>
</details>

<details><summary>Видео с багом для маленьких бубс</summary>
<p>

https://github.com/user-attachments/assets/064b2ac0-8d44-4204-bde5-bb79c5642a9d


</p>
</details>
## Список изменений
:cl:

tweak: Игрушка фейсхаггера теперь реагирует только на того кто наступит на нее, откроет контейнер с ней или того в кого её кинут.
bugfix: Исправлен баг в проксимити мониторе.
/:cl:
