### PR TITLE
Изменение механики попадания снарядов по лежачим мобам

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -493,8 +493,11 @@
 	original_angle = Angle
 	if(spread)
 		Angle += (rand() - 0.5) * spread
-	if(firer && ismob(firer) && firer.a_intent != INTENT_HELP)
-		hit_crawling_mobs_chance =  100
+	if(firer && ismob(firer))
+		if(firer.a_intent != INTENT_HELP || firer.IsLying())
+			hit_crawling_mobs_chance =  100
+		else
+			hit_crawling_mobs_chance = 0
 	// Turn right away
 	var/matrix/M = new
 	M.Turn(Angle)


### PR DESCRIPTION

## Что этот ПР делает
Стоя и в хелп интенте ваши снаряды всегда игнорируют лежачих
Стоя в любом интенте кроме хелпа всегда попадают по лежачим
Лёжа в любом интенте всегда попадают по лежачим
## Почему это хорошо для игры
ГАП решил что это хорошо
## Список изменений
:cl:
balance: Снаряды выпущенные в хелп интенте всегда игнорируют лежачих, снаряды выпущенные лежа или в любом другом интенте всегда попадают по лежачим.
/:cl:
