### PR TITLE
Fix глушилка Z-уровни

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -472,11 +472,14 @@ GLOBAL_LIST_INIT(default_pirate_channels, list(
 
 	var/jammed = FALSE
 	var/turf/position = get_turf(src)
-	for(var/obj/item/jammer/jammer as anything in GLOB.active_jammers)
-		var/turf/jammer_turf = get_turf(jammer)
-		if(position && jammer_turf && position.z == jammer_turf.z && get_dist(position, jammer_turf) < jammer.range)
-			jammed = TRUE
-			break
+	if(position)
+		for(var/obj/item/jammer/jammer as anything in GLOB.active_jammers)
+			if(!position)
+				break
+			var/turf/jammer_turf = get_turf(jammer)
+			if(jammer_turf && position.z == jammer_turf.z && get_dist(position, jammer_turf) < jammer.range)
+				jammed = TRUE
+				break
 
 	var/message_mode = handle_message_mode(M, message_pieces, channel)
 	switch(message_mode) //special cases

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -472,14 +472,13 @@ GLOBAL_LIST_INIT(default_pirate_channels, list(
 
 	var/jammed = FALSE
 	var/turf/position = get_turf(src)
-	if(position)
-		for(var/obj/item/jammer/jammer as anything in GLOB.active_jammers)
-			if(!position)
-				break
-			var/turf/jammer_turf = get_turf(jammer)
-			if(jammer_turf && position.z == jammer_turf.z && get_dist(position, jammer_turf) < jammer.range)
-				jammed = TRUE
-				break
+	if(!position)
+		return FALSE
+	for(var/obj/item/jammer/jammer as anything in GLOB.active_jammers)
+		var/turf/jammer_turf = get_turf(jammer)
+		if(jammer_turf && position.z == jammer_turf.z && get_dist(position, jammer_turf) < jammer.range)
+			jammed = TRUE
+			break
 
 	var/message_mode = handle_message_mode(M, message_pieces, channel)
 	switch(message_mode) //special cases

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -472,13 +472,14 @@ GLOBAL_LIST_INIT(default_pirate_channels, list(
 
 	var/jammed = FALSE
 	var/turf/position = get_turf(src)
-	if(!position)
-		return FALSE
-	for(var/obj/item/jammer/jammer as anything in GLOB.active_jammers)
-		var/turf/jammer_turf = get_turf(jammer)
-		if(jammer_turf && position.z == jammer_turf.z && get_dist(position, jammer_turf) < jammer.range)
-			jammed = TRUE
-			break
+	if(position && GLOB.active_jammers && length(GLOB.active_jammers))
+		for(var/obj/item/jammer/jammer as anything in GLOB.active_jammers)
+			if(!jammer || QDELETED(jammer))
+				continue
+			var/turf/jammer_turf = get_turf(jammer)
+			if(jammer_turf && position.z == jammer_turf.z && get_dist(position, jammer_turf) < jammer.range)
+				jammed = TRUE
+				break
 
 	var/message_mode = handle_message_mode(M, message_pieces, channel)
 	switch(message_mode) //special cases

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -472,10 +472,11 @@ GLOBAL_LIST_INIT(default_pirate_channels, list(
 
 	var/jammed = FALSE
 	var/turf/position = get_turf(src)
-	if(position && GLOB.active_jammers && length(GLOB.active_jammers))
-		for(var/obj/item/jammer/jammer as anything in GLOB.active_jammers)
-			if(!jammer || QDELETED(jammer))
+	if(position && islist(GLOB.active_jammers) && length(GLOB.active_jammers))
+		for(var/datum/D in GLOB.active_jammers)
+			if(!D || QDELETED(D))
 				continue
+			var/obj/item/jammer/jammer = D
 			var/turf/jammer_turf = get_turf(jammer)
 			if(jammer_turf && position.z == jammer_turf.z && get_dist(position, jammer_turf) < jammer.range)
 				jammed = TRUE

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -473,7 +473,8 @@ GLOBAL_LIST_INIT(default_pirate_channels, list(
 	var/jammed = FALSE
 	var/turf/position = get_turf(src)
 	for(var/obj/item/jammer/jammer as anything in GLOB.active_jammers)
-		if(get_dist(position, get_turf(jammer)) < jammer.range)
+		var/turf/jammer_turf = get_turf(jammer)
+		if(position && jammer_turf && position.z == jammer_turf.z && get_dist(position, jammer_turf) < jammer.range)
 			jammed = TRUE
 			break
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -472,11 +472,10 @@ GLOBAL_LIST_INIT(default_pirate_channels, list(
 
 	var/jammed = FALSE
 	var/turf/position = get_turf(src)
-	if(position && islist(GLOB.active_jammers) && length(GLOB.active_jammers))
-		for(var/datum/D in GLOB.active_jammers)
-			if(!D || QDELETED(D))
-				continue
-			var/obj/item/jammer/jammer = D
+	if(position)
+		for(var/obj/item/jammer/jammer as anything in GLOB.active_jammers)
+			if(!position)
+				break
 			var/turf/jammer_turf = get_turf(jammer)
 			if(jammer_turf && position.z == jammer_turf.z && get_dist(position, jammer_turf) < jammer.range)
 				jammed = TRUE


### PR DESCRIPTION
## Что этот ПР делает
Добавляет в цикл проверки условие благодаря которому глушилка будет подавлять сигнал только на том Z-уровне, на котором она физически находится
>баг репорт: https://discord.com/channels/617003227182792704/1488503663650668585

## Список изменений

:cl:
bugfix: глушилки радиосвязи (jammer) теперь работают только на своем Z-уровне
/:cl: