### PR TITLE
Баланс приклада

### DIFF
--- a/code/modules/projectiles/accuracy.dm
+++ b/code/modules/projectiles/accuracy.dm
@@ -136,6 +136,7 @@ GLOBAL_DATUM_INIT(gun_accuracy_sniper, /datum/gun_accuracy, GUN_ACCURACY_SNIPER)
 /datum/gun_accuracy/pistol/stechkin
 	min_spread = 2
 	max_spread = 7
+
 /datum/gun_accuracy/rifle
 	head = 90
 	chest = 120

--- a/code/modules/projectiles/gun_modules/stock.dm
+++ b/code/modules/projectiles/gun_modules/stock.dm
@@ -13,12 +13,10 @@
 	custom_price = 2 * PAYCHECK_LOWER
 	/// State flag
 	var/unfolded = FALSE
-	/// How many min spread decrease with unfold stock
-	var/min_spread_compensation = 5
-	/// How many max spread decrease with unfold stock
-	var/max_spread_compensation = 15
+	/// How many spread decrease with unfold stock
+	var/spread_compensation_mod = 0.5
 	/// How many recoil decrease with unfold stock
-	var/recoil_compensation = 0.2
+	var/recoil_compensation_mod = 0.5
 	/// Buffer variable for unfolded stock overlay
 	var/mutable_appearance/buffered_overlay_unfold
 	/// Default gun weight class buffer variable
@@ -52,9 +50,9 @@
 	unfolded = TRUE
 	gun_w_class = gun.w_class
 	gun.w_class = WEIGHT_CLASS_BULKY
-	gun.accuracy.min_spread -= min_spread_compensation
-	gun.accuracy.max_spread -= max_spread_compensation
-	gun.recoil.strength -= recoil_compensation
+	gun.accuracy.min_spread -= initial(gun.accuracy.min_spread) * spread_compensation_mod
+	gun.accuracy.max_spread -= initial(gun.accuracy.max_spread) * spread_compensation_mod
+	gun.recoil.strength -= initial(gun.recoil.strength) * recoil_compensation_mod
 	playsound(gun.loc, 'sound/weapons/gun_interactions/stock_unfold.ogg', 100, TRUE)
 
 /obj/item/gun_module/stock/proc/fold_stock(mob/user)
@@ -62,9 +60,9 @@
 		return
 	unfolded = FALSE
 	gun.w_class = gun_w_class
-	gun.accuracy.min_spread += min_spread_compensation
-	gun.accuracy.max_spread += max_spread_compensation
-	gun.recoil.strength += recoil_compensation
+	gun.accuracy.min_spread += initial(gun.accuracy.min_spread) * spread_compensation_mod
+	gun.accuracy.max_spread += initial(gun.accuracy.max_spread) * spread_compensation_mod
+	gun.recoil.strength += initial(gun.recoil.strength) * recoil_compensation_mod
 	playsound(gun.loc, 'sound/weapons/gun_interactions/stock_fold.ogg', 100, TRUE)
 
 /obj/item/gun_module/stock/create_overlay()

--- a/code/modules/projectiles/guns/ballistic/smg.dm
+++ b/code/modules/projectiles/guns/ballistic/smg.dm
@@ -180,7 +180,6 @@
 	fire_sound = 'sound/weapons/gunshots/1wt.ogg'
 	magin_sound = 'sound/weapons/gun_interactions/batrifle_magin.ogg'
 	magout_sound = 'sound/weapons/gun_interactions/batrifle_magout.ogg'
-	accuracy = GUN_ACCURACY_RIFLE
 	attachable_allowed = GUN_MODULE_CLASS_RIFLE_MUZZLE | GUN_MODULE_CLASS_RIFLE_RAIL | GUN_MODULE_CLASS_RIFLE_UNDER | GUN_MODULE_CLASS_SMG_STOCK
 	attachable_offset = list(
 		ATTACHMENT_SLOT_MUZZLE = list(ATTACHMENT_OFFSET_X = 25, ATTACHMENT_OFFSET_Y = 3), //x+4


### PR DESCRIPTION

## Что этот ПР делает
1. Приклад теперь режет 50% разброса вместо фиксированного значения.
2. Sparkle A12 теперь имеет ткаую же точность как и wt550 и sp91

## Почему это хорошо для игры
1. Баланс без балансеров.
2. Фиксы недоработки прикладов.

## Список изменений
:cl:
balance: Приклад режет разброс на 50% вместо фиксированных 15 градусов.
balance: Sparkle A12 имеет такую же точность как и WT-550 и SP-91
/:cl:
