### PR TITLE
Изменение разгрузок и подсумок

### DIFF
--- a/code/datums/elements/screentips/contextual_screentip_bare_hands.dm
+++ b/code/datums/elements/screentips/contextual_screentip_bare_hands.dm
@@ -17,6 +17,12 @@
 	/// If set, the text to show for RMB when in combat mode. Otherwise, defaults to rmb_text.
 	var/rmb_text_combat_mode
 
+	/// If set, the text to show for Alt+LMB
+	var/alt_lmb_text
+
+	/// If set, the text to show for Ctrl+LMB
+	var/ctrl_lmb_text
+
 // If you're curious about `use_named_parameters`, it's because you should use named parameters!
 // AddElement(/datum/element/contextual_screentip_bare_hands, lmb_text = "Do the thing")
 /datum/element/contextual_screentip_bare_hands/Attach(
@@ -26,6 +32,8 @@
 	rmb_text,
 	lmb_text_combat_mode,
 	rmb_text_combat_mode,
+	alt_lmb_text,
+	ctrl_lmb_text,
 )
 	. = ..()
 	if(!isatom(target))
@@ -38,6 +46,8 @@
 	src.rmb_text = rmb_text
 	src.lmb_text_combat_mode = lmb_text_combat_mode || lmb_text
 	src.rmb_text_combat_mode = rmb_text_combat_mode || rmb_text
+	src.alt_lmb_text = alt_lmb_text
+	src.ctrl_lmb_text = ctrl_lmb_text
 
 	var/atom/atom_target = target
 	atom_target.flags |= HAS_CONTEXTUAL_SCREENTIPS
@@ -74,5 +84,11 @@
 
 	if(!isnull(rmb_text))
 		context[SCREENTIP_CONTEXT_RMB] = living_user.a_intent == INTENT_HARM ? lmb_text_combat_mode : rmb_text
+
+	if(!isnull(alt_lmb_text))
+		context[SCREENTIP_CONTEXT_ALT_LMB] = alt_lmb_text
+
+	if(!isnull(ctrl_lmb_text))
+		context[SCREENTIP_CONTEXT_CTRL_LMB] = ctrl_lmb_text
 
 	return CONTEXTUAL_SCREENTIP_SET

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -988,8 +988,8 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/security/armory/fastpouch
 	name = "Подсумки для магазинов"
 	contains = list(
-		/obj/item/storage/pouch/fast,
-		/obj/item/storage/pouch/fast,
+		/obj/item/storage/belt/security/webbing/pouch/fast,
+		/obj/item/storage/belt/security/webbing/pouch/fast,
 	)
 	cost = 100
 	containername = "ящик подсумков для магазинов"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -2455,6 +2455,12 @@
 	item = /obj/item/stack/medical/bruise_pack/military
 	cost = 1
 
+/datum/uplink_item/badass/fast_pouch
+	name = "Подсумок на два магазина"
+	desc = "Подсумок на два магазина, модифицированный для быстрой перезарядки."
+	item = /obj/item/storage/belt/security/webbing/pouch/fast
+	cost = 2
+
 /**
  * MARK: Bundles & TC
  */

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -475,11 +475,80 @@
 	item_state = "securitywebbing"
 	storage_slots = 6
 	use_item_overlays = FALSE
-	custom_price = PAYCHECK_MAX // 1 extra slot, so lil bit more expensive
+	custom_price = 2 * PAYCHECK_MAX
+	can_hold = list( // can not hold batons, knifes and ammo_boxes
+		/obj/item/grenade/flashbang,
+		/obj/item/grenade/chem_grenade/teargas,
+		/obj/item/reagent_containers/spray/pepper,
+		/obj/item/restraints/handcuffs,
+		/obj/item/flash,
+		/obj/item/clothing/glasses,
+		/obj/item/ammo_casing/shotgun,
+		/obj/item/ammo_box/magazine,
+		/obj/item/flashlight/seclite,
+		/obj/item/holosign_creator/security,
+		/obj/item/melee/baton/telescopic,
+		/obj/item/restraints/legcuffs/bola,
+		/obj/item/eftpos/sec,
+		/obj/item/weapon_cell,
+		/obj/item/radio,
+	)
+	/// Fast reload duration
+	var/fast_reload_delay = 1 SECONDS
+
+/obj/item/storage/belt/security/webbing/attackby(obj/item/attack_item, mob/user, params)
+	if(istype(attack_item, /obj/item/gun/projectile/automatic))
+		add_fingerprint(user)
+		var/obj/item/gun/projectile/automatic/gun = attack_item
+		for(var/obj/item/ammo_box/magazine/magazine in contents)
+			if(!istype(magazine, gun.mag_type))
+				continue
+			INVOKE_ASYNC(src, PROC_REF(do_fast_reload), user, gun, magazine, params)
+			break
+		return ATTACK_CHAIN_PROCEED_SUCCESS
+
+	return ..()
+
+/obj/item/storage/belt/security/webbing/proc/do_fast_reload(mob/user, obj/item/gun/projectile/automatic/gun, obj/item/ammo_box/magazine/magazine, params)
+	if(!do_after(user, fast_reload_delay, src, DA_IGNORE_USER_LOC_CHANGE | DA_IGNORE_LYING))
+		return
+	var/obj/item/ammo_box/magazine/gun_magazine = gun.magazine
+	gun.attackby(magazine, user, params)
+	var/mag_changed = (gun_magazine && gun_magazine.loc != gun)
+	if(!mag_changed || !can_be_inserted(gun_magazine))
+		return
+	handle_item_insertion(gun_magazine)
+	gun_magazine.update_appearance()
+
 
 /obj/item/storage/belt/security/webbing/srt
 	name = "SRT webbing"
 	desc = "Unique and versatile chest rig, can hold SRT gear."
+	can_hold = list(
+		/obj/item/grenade/flashbang,
+		/obj/item/grenade/chem_grenade/teargas,
+		/obj/item/reagent_containers/spray/pepper,
+		/obj/item/restraints/handcuffs,
+		/obj/item/flash,
+		/obj/item/clothing/glasses,
+		/obj/item/ammo_casing/shotgun,
+		/obj/item/ammo_box,
+		/obj/item/reagent_containers/food/snacks/donut,
+		/obj/item/reagent_containers/food/snacks/candy/confectionery/toffee,
+		/obj/item/kitchen/knife/combat,
+		/obj/item/melee/baton/security,
+		/obj/item/melee/baton,
+		/obj/item/flashlight/seclite,
+		/obj/item/holosign_creator/security,
+		/obj/item/melee/baton/telescopic,
+		/obj/item/restraints/legcuffs/bola,
+		/obj/item/forensics/sample_kit/powder,
+		/obj/item/forensics/sample_kit,
+		/obj/item/eftpos/sec,
+		/obj/item/weapon_cell,
+		/obj/item/radio,
+		/obj/item/gun/projectile/automatic/pistol
+	)
 
 /obj/item/storage/belt/security/webbing/srt/full/populate_contents()
 	new /obj/item/flashlight/seclite(src)
@@ -489,6 +558,27 @@
 	new /obj/item/grenade/flashbang(src)
 	new /obj/item/grenade/flashbang(src)
 	update_icon()
+
+
+/obj/item/storage/belt/security/webbing/pouch
+	name = "pouch"
+	desc = "Подсумок на два магазина."
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "pouch"
+	item_state = "pouch"
+	storage_slots = 2
+	w_class = WEIGHT_CLASS_TINY
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
+	can_hold = list(/obj/item/ammo_box/magazine)
+	custom_price = PAYCHECK_MAX
+
+/obj/item/storage/belt/security/webbing/pouch/fast
+	name = "fast pouch"
+	desc = "Подсумок на два магазина, модифицированный для быстрой перезарядки."
+	icon_state = "pouch_fast"
+	item_state = "pouch_fast"
+	custom_price = 4 * PAYCHECK_MAX
+	fast_reload_delay = 0.2 SECONDS
 
 /obj/item/storage/belt/soulstone
 	name = "soul stone belt"
@@ -694,9 +784,9 @@
 	new /obj/item/storage/pill_bottle/sovietstimulants(src)
 
 /obj/item/storage/belt/military/assault/gammaert/full/populate_contents()
-	new /obj/item/storage/pouch/fast(src)
-	new /obj/item/storage/pouch/fast(src)
-	new /obj/item/storage/pouch/fast(src)
+	new /obj/item/storage/belt/security/webbing/pouch/fast(src)
+	new /obj/item/storage/belt/security/webbing/pouch/fast(src)
+	new /obj/item/storage/belt/security/webbing/pouch/fast(src)
 	new /obj/item/melee/baton/telescopic(src)
 
 /obj/item/storage/belt/military/assault/rsh_12/full/populate_contents()

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -471,7 +471,7 @@
 
 /obj/item/storage/belt/security/webbing
 	name = "security webbing"
-	desc = "Unique and versatile chest rig, can hold security gear."
+	desc = "Универсальная разгрузка, вмещающая снаряжение службы безопасности."
 	icon_state = "securitywebbing"
 	item_state = "securitywebbing"
 	storage_slots = 6
@@ -541,16 +541,16 @@
 
 /obj/item/storage/belt/security/webbing/srt
 	name = "SRT webbing"
-	desc = "Unique and versatile chest rig, can hold SRT gear."
+	desc = "Уникальная и универсальная нагрудная разгрузочная система, вмещающая снаряжение отряда специального назначения."
 
 /obj/item/storage/belt/security/webbing/srt/get_ru_names()
 	return list(
-		NOMINATIVE = "разгрузка ГСН",
-		GENITIVE = "разгрузки ГСН",
-		DATIVE = "разгрузке ГСН",
-		ACCUSATIVE = "разгрузку ГСН",
-		INSTRUMENTAL = "разгрузкой ГСН",
-		PREPOSITIONAL = "разгрузке ГСН",
+		NOMINATIVE = "разгрузка ОСН",
+		GENITIVE = "разгрузки ОСН",
+		DATIVE = "разгрузке ОСН",
+		ACCUSATIVE = "разгрузку ОСН",
+		INSTRUMENTAL = "разгрузкой ОСН",
+		PREPOSITIONAL = "разгрузке ОСН",
 	)
 
 /obj/item/storage/belt/security/webbing/srt/full/populate_contents()

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -506,6 +506,16 @@
 		PREPOSITIONAL = "разгрузке СБ",
 	)
 
+/obj/item/storage/belt/security/webbing/ComponentInitialize()
+	. = ..()
+	var/static/list/hovering_item_typechecks = list(
+		/obj/item/gun/projectile/automatic = list(
+			SCREENTIP_CONTEXT_LMB = "Быстрая перезарядка",
+		),
+	)
+	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
+	AddElement(/datum/element/contextual_screentip_bare_hands, ctrl_lmb_text = "Достать магазин")
+
 /obj/item/storage/belt/security/webbing/attackby(obj/item/attack_item, mob/user, params)
 	if(istype(attack_item, /obj/item/gun/projectile/automatic))
 		add_fingerprint(user)
@@ -515,6 +525,13 @@
 				continue
 			INVOKE_ASYNC(src, PROC_REF(do_fast_reload), user, gun, magazine, params)
 			break
+		return ATTACK_CHAIN_PROCEED_SUCCESS
+
+	return ..()
+
+/obj/item/storage/belt/security/webbing/CtrlClick(mob/user)
+	for(var/obj/item/ammo_box/magazine/magazine in contents)
+		user.put_in_active_hand(magazine)
 		return ATTACK_CHAIN_PROCEED_SUCCESS
 
 	return ..()
@@ -562,12 +579,12 @@
 
 /obj/item/storage/belt/security/webbing/srt/get_ru_names()
 	return list(
-		NOMINATIVE = "разгрузка ОБР",
-		GENITIVE = "разгрузки ОБР",
-		DATIVE = "разгрузке ОБР",
-		ACCUSATIVE = "разгрузку ОБР",
-		INSTRUMENTAL = "разгрузкой ОБР",
-		PREPOSITIONAL = "разгрузке ОБР",
+		NOMINATIVE = "разгрузка ГСН",
+		GENITIVE = "разгрузки ГСН",
+		DATIVE = "разгрузке ГСН",
+		ACCUSATIVE = "разгрузку ГСН",
+		INSTRUMENTAL = "разгрузкой ГСН",
+		PREPOSITIONAL = "разгрузке ГСН",
 	)
 
 /obj/item/storage/belt/security/webbing/srt/full/populate_contents()

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -478,7 +478,7 @@
 	use_item_overlays = FALSE
 	custom_price = 2 * PAYCHECK_MAX
 	/// Fast reload duration
-	var/fast_reload_delay = 1 SECONDS
+	var/fast_reload_delay = 1.5 SECONDS
 
 /obj/item/storage/belt/security/webbing/get_ru_names()
 	return list(
@@ -573,6 +573,7 @@
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
 	can_hold = list(/obj/item/ammo_box/magazine)
 	custom_price = PAYCHECK_MAX
+	fast_reload_delay = 2 SECONDS
 
 /obj/item/storage/belt/security/webbing/pouch/get_ru_names()
 	return list(

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -496,6 +496,16 @@
 	/// Fast reload duration
 	var/fast_reload_delay = 1 SECONDS
 
+/obj/item/storage/belt/security/webbing/get_ru_names()
+	return list(
+		NOMINATIVE = "разгрузка СБ",
+		GENITIVE = "разгрузки СБ",
+		DATIVE = "разгрузке СБ",
+		ACCUSATIVE = "разгрузку СБ",
+		INSTRUMENTAL = "разгрузкой СБ",
+		PREPOSITIONAL = "разгрузке СБ",
+	)
+
 /obj/item/storage/belt/security/webbing/attackby(obj/item/attack_item, mob/user, params)
 	if(istype(attack_item, /obj/item/gun/projectile/automatic))
 		add_fingerprint(user)
@@ -550,6 +560,16 @@
 		/obj/item/gun/projectile/automatic/pistol
 	)
 
+/obj/item/storage/belt/security/webbing/srt/get_ru_names()
+	return list(
+		NOMINATIVE = "разгрузка ОБР",
+		GENITIVE = "разгрузки ОБР",
+		DATIVE = "разгрузке ОБР",
+		ACCUSATIVE = "разгрузку ОБР",
+		INSTRUMENTAL = "разгрузкой ОБР",
+		PREPOSITIONAL = "разгрузке ОБР",
+	)
+
 /obj/item/storage/belt/security/webbing/srt/full/populate_contents()
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/kitchen/knife/combat(src)
@@ -558,7 +578,6 @@
 	new /obj/item/grenade/flashbang(src)
 	new /obj/item/grenade/flashbang(src)
 	update_icon()
-
 
 /obj/item/storage/belt/security/webbing/pouch
 	name = "pouch"
@@ -572,6 +591,16 @@
 	can_hold = list(/obj/item/ammo_box/magazine)
 	custom_price = PAYCHECK_MAX
 
+/obj/item/storage/belt/security/webbing/pouch/get_ru_names()
+	return list(
+		NOMINATIVE = "подсумок",
+		GENITIVE = "подсумка",
+		DATIVE = "подсумку",
+		ACCUSATIVE = "подсумок",
+		INSTRUMENTAL = "подсумком",
+		PREPOSITIONAL = "подсумке",
+	)
+
 /obj/item/storage/belt/security/webbing/pouch/fast
 	name = "fast pouch"
 	desc = "Подсумок на два магазина, модифицированный для быстрой перезарядки."
@@ -579,6 +608,17 @@
 	item_state = "pouch_fast"
 	custom_price = 4 * PAYCHECK_MAX
 	fast_reload_delay = 0.2 SECONDS
+
+/obj/item/storage/belt/security/webbing/pouch/fast/get_ru_names()
+	return list(
+		NOMINATIVE = "продвинутый подсумок",
+		GENITIVE = "продвинутого подсумка",
+		DATIVE = "продвинутому подсумку",
+		ACCUSATIVE = "продвинутый подсумок",
+		INSTRUMENTAL = "продвинутым подсумком",
+		PREPOSITIONAL = "продвинутом подсумке",
+	)
+
 
 /obj/item/storage/belt/soulstone
 	name = "soul stone belt"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -414,7 +414,8 @@
 		/obj/item/flash,
 		/obj/item/clothing/glasses,
 		/obj/item/ammo_casing/shotgun,
-		/obj/item/ammo_box,
+		/obj/item/ammo_box/magazine,
+		/obj/item/ammo_box/speedloader,
 		/obj/item/reagent_containers/food/snacks/donut,
 		/obj/item/reagent_containers/food/snacks/candy/confectionery/toffee,
 		/obj/item/kitchen/knife/combat,
@@ -476,23 +477,6 @@
 	storage_slots = 6
 	use_item_overlays = FALSE
 	custom_price = 2 * PAYCHECK_MAX
-	can_hold = list( // can not hold batons, knifes and ammo_boxes
-		/obj/item/grenade/flashbang,
-		/obj/item/grenade/chem_grenade/teargas,
-		/obj/item/reagent_containers/spray/pepper,
-		/obj/item/restraints/handcuffs,
-		/obj/item/flash,
-		/obj/item/clothing/glasses,
-		/obj/item/ammo_casing/shotgun,
-		/obj/item/ammo_box/magazine,
-		/obj/item/flashlight/seclite,
-		/obj/item/holosign_creator/security,
-		/obj/item/melee/baton/telescopic,
-		/obj/item/restraints/legcuffs/bola,
-		/obj/item/eftpos/sec,
-		/obj/item/weapon_cell,
-		/obj/item/radio,
-	)
 	/// Fast reload duration
 	var/fast_reload_delay = 1 SECONDS
 
@@ -516,21 +500,22 @@
 	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
 	AddElement(/datum/element/contextual_screentip_bare_hands, ctrl_lmb_text = "Достать магазин")
 
-/obj/item/storage/belt/security/webbing/attackby(obj/item/attack_item, mob/user, params)
-	if(istype(attack_item, /obj/item/gun/projectile/automatic))
-		add_fingerprint(user)
-		var/obj/item/gun/projectile/automatic/gun = attack_item
-		for(var/obj/item/ammo_box/magazine/magazine in contents)
-			if(!istype(magazine, gun.mag_type))
-				continue
-			INVOKE_ASYNC(src, PROC_REF(do_fast_reload), user, gun, magazine, params)
-			break
-		return ATTACK_CHAIN_PROCEED_SUCCESS
+/obj/item/storage/belt/security/webbing/attackby(obj/item/attack_item, mob/user, list/modifiers)
+	if(!istype(attack_item, /obj/item/gun/projectile/automatic))
+		return ..()
 
-	return ..()
+	add_fingerprint(user)
+	var/obj/item/gun/projectile/automatic/gun = attack_item
+	for(var/obj/item/ammo_box/magazine/magazine in contents)
+		if(!istype(magazine, gun.mag_type))
+			continue
+		INVOKE_ASYNC(src, PROC_REF(do_fast_reload), user, gun, magazine, modifiers)
+		break
+	return ATTACK_CHAIN_PROCEED_SUCCESS
+
 
 /obj/item/storage/belt/security/webbing/CtrlClick(mob/user)
-	if(!user.Adjacent(src) || user.incapacitated())
+	if(!IsReachableBy(user) || user.incapacitated())
 		return ..()
 	for(var/obj/item/ammo_box/magazine/magazine in contents)
 		user.put_in_active_hand(magazine)
@@ -541,7 +526,7 @@
 /obj/item/storage/belt/security/webbing/proc/do_fast_reload(mob/user, obj/item/gun/projectile/automatic/gun, obj/item/ammo_box/magazine/magazine, params)
 	if(!do_after(user, fast_reload_delay, src, DA_IGNORE_USER_LOC_CHANGE | DA_IGNORE_LYING, max_interact_count = 1))
 		return
-	if(QDELETED(src) || QDELETED(user) || QDELETED(gun) || QDELETED(magazine) || magazine.loc != src || !user.is_in_hands(gun) || !user.Adjacent(src))
+	if(QDELETED(src) || QDELETED(user) || QDELETED(gun) || QDELETED(magazine) || magazine.loc != src || !user.is_in_hands(gun) || !IsReachableBy(user))
 		return
 
 	var/obj/item/ammo_box/magazine/gun_magazine = gun.magazine
@@ -557,31 +542,6 @@
 /obj/item/storage/belt/security/webbing/srt
 	name = "SRT webbing"
 	desc = "Unique and versatile chest rig, can hold SRT gear."
-	can_hold = list(
-		/obj/item/grenade/flashbang,
-		/obj/item/grenade/chem_grenade/teargas,
-		/obj/item/reagent_containers/spray/pepper,
-		/obj/item/restraints/handcuffs,
-		/obj/item/flash,
-		/obj/item/clothing/glasses,
-		/obj/item/ammo_casing/shotgun,
-		/obj/item/ammo_box,
-		/obj/item/reagent_containers/food/snacks/donut,
-		/obj/item/reagent_containers/food/snacks/candy/confectionery/toffee,
-		/obj/item/kitchen/knife/combat,
-		/obj/item/melee/baton/security,
-		/obj/item/melee/baton,
-		/obj/item/flashlight/seclite,
-		/obj/item/holosign_creator/security,
-		/obj/item/melee/baton/telescopic,
-		/obj/item/restraints/legcuffs/bola,
-		/obj/item/forensics/sample_kit/powder,
-		/obj/item/forensics/sample_kit,
-		/obj/item/eftpos/sec,
-		/obj/item/weapon_cell,
-		/obj/item/radio,
-		/obj/item/gun/projectile/automatic/pistol,
-	)
 
 /obj/item/storage/belt/security/webbing/srt/get_ru_names()
 	return list(

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -530,6 +530,8 @@
 	return ..()
 
 /obj/item/storage/belt/security/webbing/CtrlClick(mob/user)
+	if(!user.Adjacent(src) || user.incapacitated())
+		return ..()
 	for(var/obj/item/ammo_box/magazine/magazine in contents)
 		user.put_in_active_hand(magazine)
 		return ATTACK_CHAIN_PROCEED_SUCCESS
@@ -537,13 +539,17 @@
 	return ..()
 
 /obj/item/storage/belt/security/webbing/proc/do_fast_reload(mob/user, obj/item/gun/projectile/automatic/gun, obj/item/ammo_box/magazine/magazine, params)
-	if(!do_after(user, fast_reload_delay, src, DA_IGNORE_USER_LOC_CHANGE | DA_IGNORE_LYING))
+	if(!do_after(user, fast_reload_delay, src, DA_IGNORE_USER_LOC_CHANGE | DA_IGNORE_LYING, max_interact_count = 1))
 		return
+	if(QDELETED(src) || QDELETED(user) || QDELETED(gun) || QDELETED(magazine) || magazine.loc != src || !user.is_in_hands(gun) || !user.Adjacent(src))
+		return
+
 	var/obj/item/ammo_box/magazine/gun_magazine = gun.magazine
 	gun.attackby(magazine, user, params)
 	var/mag_changed = (gun_magazine && gun_magazine.loc != gun)
 	if(!mag_changed || !can_be_inserted(gun_magazine))
 		return
+
 	handle_item_insertion(gun_magazine)
 	gun_magazine.update_appearance()
 
@@ -574,7 +580,7 @@
 		/obj/item/eftpos/sec,
 		/obj/item/weapon_cell,
 		/obj/item/radio,
-		/obj/item/gun/projectile/automatic/pistol
+		/obj/item/gun/projectile/automatic/pistol,
 	)
 
 /obj/item/storage/belt/security/webbing/srt/get_ru_names()

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1187,42 +1187,6 @@
 		new /obj/item/reagent_containers/food/snacks/candy/jellybean/wtf(src)
 	new /obj/item/reagent_containers/food/snacks/candy/sucker(src)
 
-/obj/item/storage/pouch
-	name = "pouch"
-	desc = "Подсумок на два магазина."
-	icon_state = "pouch"
-	item_state = "pouch"
-	storage_slots = 2
-	w_class = WEIGHT_CLASS_TINY
-	slot_flags = ITEM_SLOT_BELT
-	can_hold = list(/obj/item/ammo_box/magazine)
-
-/obj/item/storage/pouch/fast
-	name = "fast pouch"
-	desc = "Подсумок на два магазина, модифицированный для быстрой перезарядки."
-	icon_state = "pouch_fast"
-	item_state = "pouch_fast"
-
-/obj/item/storage/pouch/fast/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/gun/projectile/automatic))
-		add_fingerprint(user)
-		var/obj/item/gun/projectile/automatic/gun = I
-		for(var/obj/item/ammo_box/magazine/magazine in contents)
-			if(!istype(magazine, gun.mag_type))
-				continue
-			var/obj/item/ammo_box/magazine/gun_magazine = gun.magazine
-			gun.attackby(magazine, user, params)
-			var/mag_changed = (gun_magazine && gun_magazine.loc != gun)
-			var/success = mag_changed || (!gun_magazine && gun.magazine)
-			if(mag_changed && can_be_inserted(gun_magazine))
-				handle_item_insertion(gun_magazine)
-				gun_magazine.update_appearance()
-			if(success)
-				break
-		return ATTACK_CHAIN_PROCEED_SUCCESS
-
-	return ..()
-
 /obj/item/storage/box/sec
 	name = "officer starter kit"
 	desc = "Коробка, что вмещает в себе все нужное дабы стать офицером! Мелким шрифтом вы можете разобрать: Не включает действительно все."

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -50,6 +50,7 @@
 			"icon" = "vest-patches",
 			"products" = list(
 				/obj/item/storage/belt/security/webbing = 2,
+				/obj/item/storage/belt/security/webbing/pouch = 2,
 				/obj/item/clothing/mask/gas/sechailer/tactical = 5,
 				/obj/item/storage/belt/security/judobelt = 3,
 				/obj/item/eftpos/sec = 4,


### PR DESCRIPTION

## Что этот ПР делает

1. Добавлен механ быстрой перезарядки кликом оружия по разгрузке через прогрессбар в 1 секунду.
2. Повышена цена разгрузок сб, добавлен в продажу подсумок на два магазина.
3. Добавлен продвинутый подсумок (_почти мгновенная перезарядка_) на 2 магаза в аплинк за 2 тк.
4. Добавлены подсказки при наведении.
5. В разгрузку теперь нельзя сувать нож, батоны и коробки с патронами.
6. Возможность достать любой магаз с подсумка/разгрузки через Ctrl+клик.
7. Чутка локализации подсумок и разгрузок.

## Почему это хорошо для игры

1. Нормальный механ перезарядки баллстики без выбрасывания магазина на пол.
2. Возвращаем в игру подсумки.

## Список изменений
:cl:
add: механ быстрой перезарядки для разгрузки сб.
qol: возможность достать магаз из разгрузки/подсумка с помощью сtrl+клик.
balance: Повышена цена на подсумок и разгрузку сб.
add: продвинутый подсумок в аплинк за 2 тк.
/:cl:
