### PR TITLE
Балансный патч: нокдауны (ГАП не попросил)

### DIFF
--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -211,7 +211,7 @@
 	/// Duration of the weakening in seconds
 	var/weaken_amt = 0
 	/// Duration of the knockdown in seconds
-	var/knockdown_amt = 0
+	var/knockdown_amt = 4
 	/// Cyclic bola spin sound.
 	var/spin_sound = 'sound/items/bola_spin.ogg'
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -226,6 +226,7 @@
 		var/obj/item/organ/external/O = H.get_organ(user.zone_selected)
 		if(O && O.brute_dam >= 50)
 			O.droplimb()
+		H.Knockdown(1.5 SECONDS)
 
 /***************************************\
 |**************FLESHY MAUL**************|
@@ -316,6 +317,7 @@
 	else if(isliving(target))
 		var/mob/living/M = target
 		M.Slowed(2 SECONDS, 5)
+		M.Knockdown(3 SECONDS)
 		var/atom/throw_target = get_edge_target_turf(M, user.dir)
 		RegisterSignal(M, COMSIG_MOVABLE_IMPACT, PROC_REF(bump_impact))
 		M.throw_at(throw_target, 1, 14, user, callback = CALLBACK(src, PROC_REF(unregister_bump_impact), M))

--- a/code/modules/projectiles/projectile/ballistic/__bullet.dm
+++ b/code/modules/projectiles/projectile/ballistic/__bullet.dm
@@ -7,6 +7,7 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect
 	ricochets_max = 1
 	ricochet_chance = 5
+	stamina = 20
 
 /obj/projectile/bullet/get_ru_names()
 	return list(

--- a/code/modules/projectiles/projectile/ballistic/pistol.dm
+++ b/code/modules/projectiles/projectile/ballistic/pistol.dm
@@ -25,6 +25,7 @@
 /obj/projectile/bullet/midbullet3
 	damage = 33
 	ricochet_chance = 10
+	knockdown = 1 SECONDS
 
 /obj/projectile/bullet/midbullet3/hp
 	damage = 50
@@ -73,6 +74,7 @@
 /obj/projectile/bullet/midbullet
 	damage = 23
 	stamina = 33 //four rounds from the c20r knocks people down
+	knockdown = 1.5 SECONDS
 
 /obj/projectile/bullet/midbullet_AC2S
 	damage = 23
@@ -120,6 +122,7 @@
 /obj/projectile/bullet/desert_eagle
 	stamina = 33
 	ricochet_chance = 10
+	knockdown = 2 SECONDS
 
 // MARK: 7.62x25mm
 /obj/projectile/bullet/ftt762

--- a/code/modules/projectiles/projectile/ballistic/shotgun.dm
+++ b/code/modules/projectiles/projectile/ballistic/shotgun.dm
@@ -2,6 +2,7 @@
 /obj/projectile/bullet/slug
 	armour_penetration = 10
 	damage = 36
+	knockdown = 1 SECONDS
 
 /obj/projectile/bullet/weakbullet //beanbag, heavy stamina damage
 	name = "beanbag slug"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -151,6 +151,7 @@
 	name = "disabler beam"
 	icon_state = "omnilaser"
 	damage = 25
+	knockdown = 0.25 SECONDS
 	shockbull = TRUE
 	damage_type = STAMINA
 	flag = ENERGY

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -6,7 +6,7 @@
 	hitsound = 'sound/weapons/pierce.ogg'
 	damage_type = TOX
 	stamina = 40
-	knockdown = 0.5 SECONDS
+	knockdown = 3 SECONDS
 	stutter = 2 SECONDS
 	shockbull = TRUE
 


### PR DESCRIPTION

## Что этот ПР делает

Обновляем нокдауны в билде под виденье баланса ГАПом. Для большинства предметов антагонистов добавлены/увеличены нокдауны. Арбалет, оружие генокрада, дигл. Также добавлен нокдаун для слагов и дизейблера, а все пули теперь наносят 20 урона выносливости, болы теперь вешают 4 секунды нокдауна

## Почему это хорошо для игры

Гап не попросил

## Список изменений
:cl:
balance: 
Все пули наносят 20 урона выносливости
У бол теперь 4 секунды нокдауна(дальше НК)
Армблейд теперь вешает 1.5с НК
Маул генокрада теперь вешает 3с НК
Пули стечкина вешают 1с НК
Слаги вешают 1с НК
Дигл вешает 2с НК
.45 пули вешают 1.5с НК
Повышен НК арбалета с 0.5 до 3с
Дизейблеры теперь вешают 0.25с НК
