### PR TITLE
Куча колод карт в лодаут и в merch computer.

### DIFF
--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -242,14 +242,14 @@ GLOBAL_VAR(scoreboard) // Variable to save the scoreboard string once it's been 
 		richest_cash = cash_score
 		richest_name = human.real_name
 		richest_job = human.job
-		richest_key = human.key
+		richest_key = (human.client && (human.client.prefs.toggles2 & PREFTOGGLE_2_ANON)) ? "Anon" : human.key
 
 	var/damage_score = human.getBruteLoss() + human.getFireLoss() + human.getToxLoss() + human.getOxyLoss()
 	if(damage_score > damaged_health)
 		damaged_health = damage_score
 		damaged_name = human.real_name
 		damaged_job = human.job
-		damaged_key = human.key
+		damaged_key = (human.client && (human.client.prefs.toggles2 & PREFTOGGLE_2_ANON)) ? "Anon" : human.key
 
 /datum/scoreboard/proc/check_apc_power()
 	for(var/A in GLOB.apcs)

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -242,14 +242,14 @@ GLOBAL_VAR(scoreboard) // Variable to save the scoreboard string once it's been 
 		richest_cash = cash_score
 		richest_name = human.real_name
 		richest_job = human.job
-		richest_key = (human.client && (human.client.prefs.toggles2 & PREFTOGGLE_2_ANON)) ? "Anon" : human.key
+		richest_key = human.key
 
 	var/damage_score = human.getBruteLoss() + human.getFireLoss() + human.getToxLoss() + human.getOxyLoss()
 	if(damage_score > damaged_health)
 		damaged_health = damage_score
 		damaged_name = human.real_name
 		damaged_job = human.job
-		damaged_key = (human.client && (human.client.prefs.toggles2 & PREFTOGGLE_2_ANON)) ? "Anon" : human.key
+		damaged_key = human.key
 
 /datum/scoreboard/proc/check_apc_power()
 	for(var/A in GLOB.apcs)

--- a/code/modules/client/preference/loadout/loadout_general.dm
+++ b/code/modules/client/preference/loadout/loadout_general.dm
@@ -94,7 +94,7 @@
 	path = /obj/item/deck/tarot
 
 /datum/gear/unum
-	index_name = "a deck of UNUM! cards"
+	index_name = "a deck of UNUM cards"
 	path = /obj/item/deck/unum
 
 /datum/gear/headphones

--- a/code/modules/client/preference/loadout/loadout_general.dm
+++ b/code/modules/client/preference/loadout/loadout_general.dm
@@ -83,19 +83,33 @@
 
 /datum/gear/cards
 	index_name = "a deck of standard cards"
+	display_name = "Колода карт"
 	path = /obj/item/deck/cards
 
 /datum/gear/doublecards
 	index_name = "a double deck of standard cards"
+	display_name = "Двойная колода карт"
 	path = /obj/item/deck/cards/doublecards
 
 /datum/gear/tarot
 	index_name = "a deck of tarot cards"
+	display_name = "Колода карт таро"
 	path = /obj/item/deck/tarot
 
 /datum/gear/unum
 	index_name = "a deck of UNUM cards"
+	display_name = "Колода карт UNUM"
 	path = /obj/item/deck/unum
+
+/datum/gear/cards_tiny
+	index_name = "a deck of tiny cards"
+	display_name = "Колода миниатюрных карт"
+	path = /obj/item/deck/cards/tiny
+
+/datum/gear/doublecards_tiny
+	index_name = "a double deck of tiny cards"
+	display_name = "Двойная колода миниатюрных карт"
+	path = /obj/item/deck/cards/tiny/doublecards
 
 /datum/gear/headphones
 	index_name = "a pair of headphones"

--- a/code/modules/client/preference/loadout/loadout_general.dm
+++ b/code/modules/client/preference/loadout/loadout_general.dm
@@ -93,6 +93,10 @@
 	index_name = "a deck of tarot cards"
 	path = /obj/item/deck/tarot
 
+/datum/gear/tarot
+	index_name = "a deck of UNUM! cards"
+	path = /obj/item/deck/unum
+
 /datum/gear/headphones
 	index_name = "a pair of headphones"
 	path = /obj/item/clothing/ears/headphones

--- a/code/modules/client/preference/loadout/loadout_general.dm
+++ b/code/modules/client/preference/loadout/loadout_general.dm
@@ -93,7 +93,7 @@
 	index_name = "a deck of tarot cards"
 	path = /obj/item/deck/tarot
 
-/datum/gear/tarot
+/datum/gear/unum
 	index_name = "a deck of UNUM! cards"
 	path = /obj/item/deck/unum
 

--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -70,20 +70,20 @@
 
 /datum/storeitem/tarot
 	name = "Колода карт таро"
-	desc = "Простая колода игральных карт."
+	desc = "Для всех ваших оккультных нужд!"
 	typepath = /obj/item/deck/tarot
 	cost = 100
 
 /datum/storeitem/unum
 	name = "Колода карт UNUM!"
 	desc = "Колода карт UNUM! Правила для домашних ссор не входят в комплект."
-	typepath = /obj/item/deck/cards/tiny
+	typepath = /obj/item/deck/unum
 	cost = 100
 
 /datum/storeitem/cards_tiny
 	name = "Колода миниатюрных карт"
 	desc = "Простая колода миниатюрных игральных карт."
-	typepath = /obj/item/deck/unum
+	typepath = /obj/item/deck/cards/tiny
 	cost = 100
 
 /datum/storeitem/candle

--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -49,6 +49,7 @@
 	desc = "Chips for playing poker"
 	typepath = /obj/item/stack/spacechips/c2000
 	cost = 100
+
 /datum/storeitem/dnd
 	name = "Dungeons & Dragons Set"
 	desc = "A box containing minifigures suitable for a good game of D&D."
@@ -61,11 +62,47 @@
 	typepath = /obj/item/storage/box/dice
 	cost = 100
 
+/datum/storeitem/cards
+	name = "Колода карт"
+	desc = "Простая колода игральных карт."
+	typepath = /obj/item/deck/cards
+	cost = 100
+
+/datum/storeitem/tarot
+	name = "Колода карт таро"
+	desc = "Простая колода игральных карт."
+	typepath = /obj/item/deck/tarot
+	cost = 100
+
+/datum/storeitem/unum
+	name = "Колода карт UNUM!"
+	desc = "Колода карт UNUM! Правила для домашних ссор не входят в комплект."
+	typepath = /obj/item/deck/cards/tiny
+	cost = 100
+
+/datum/storeitem/cards_tiny
+	name = "Колода миниатюрных карт"
+	desc = "Простая колода миниатюрных игральных карт."
+	typepath = /obj/item/deck/unum
+	cost = 100
+
 /datum/storeitem/candle
 	name = "Candles"
 	desc = "A box of candles. Use them to fool others into thinking you're out for a romantic dinner...or something."
 	typepath = /obj/item/storage/fancy/candle_box/full
 	cost = 100
+
+/datum/storeitem/doublecards
+	name = "Двойная колода карт"
+	desc = "Простая колода игральных карт. Удвоенная. Может быть, играть с такой будет в два раза интереснее?"
+	typepath = /obj/item/deck/cards/doublecards
+	cost = 175
+
+/datum/storeitem/doublecards_tiny
+	name = "Двойная колода миниатюрных карт"
+	desc = "Простая колода миниатюрных игральных карт. Удвоенная. Может быть, играть с такой будет в два раза интереснее?"
+	typepath = /obj/item/deck/cards/tiny/doublecards
+	cost = 175
 
 /datum/storeitem/crayons
 	name = "Crayons"


### PR DESCRIPTION

## Что этот ПР делает
Добавляет в лодаут карты UNUM, миниатюрные карты(которые даже нигде не достать?)+двойные, также в merch computer все колоды карт(кроме заточеных) для покупки. Также выполняет частично [предложение](https://discord.com/channels/617003227182792704/1417197057520832643). 
## Почему это хорошо для игры
Возможность достать карты сразу с лодаута и купить не за игровые тикеты и не идти в перму за УНО. Также вытащены из щитспавна колода миниатюрных карт.
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
<img width="585" height="237" alt="loadout" src="https://github.com/user-attachments/assets/8c1da900-5c6e-4b39-b302-808d470b5103" />
<img width="437" height="354" alt="merch computer" src="https://github.com/user-attachments/assets/0d36156d-0701-4cec-8707-143d56018016" />

</p>
</details>

## Список изменений
:cl:
tweak: Большая часть колод карт есть в лодауте и в merch computer(зеленая консоль у карго)
/:cl:
