### PR TITLE
add: storage increaser for janitor borgs

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -620,7 +620,6 @@
 
 		robot.module.modules += new /obj/item/storage/bag/trash/bluespace/cyborg(robot.module)
 		robot.module.rebuild()
-		return TRUE
 
 	for(var/datum/robot_energy_storage/energy_storage in robot.module.storages)
 		energy_storage.max_energy *= 3

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -644,7 +644,6 @@
 
 		robot.module.modules += new /obj/item/storage/bag/trash/cyborg(robot.module)
 		robot.module.rebuild()
-		return TRUE
 
 	for(var/datum/robot_energy_storage/energy_storage in robot.module.storages)
 		energy_storage.max_energy = initial(energy_storage.max_energy)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -614,6 +614,14 @@
 		robot.module.emag = satchel
 		robot.module.emag.update_icon(UPDATE_ICON_STATE)
 
+	if(istype(robot.module, /obj/item/robot_module/janitor))
+		for(var/obj/item/storage/bag/trash/cyborg/bag in robot.module.modules)
+			qdel(bag)
+
+		robot.module.modules += new /obj/item/storage/bag/trash/bluespace/cyborg(robot.module)
+		robot.module.rebuild()
+		return TRUE
+
 	for(var/datum/robot_energy_storage/energy_storage in robot.module.storages)
 		energy_storage.max_energy *= 3
 		energy_storage.recharge_rate *= 2
@@ -630,6 +638,14 @@
 		satchel.upgraded = FALSE
 		robot.module.emag = satchel
 		robot.module.emag.update_icon(UPDATE_ICON_STATE)
+
+	if(istype(robot.module, /obj/item/robot_module/janitor))
+		for(var/obj/item/storage/bag/trash/bluespace/cyborg/bag in robot.module.modules)
+			qdel(bag)
+
+		robot.module.modules += new /obj/item/storage/bag/trash/cyborg(robot.module)
+		robot.module.rebuild()
+		return TRUE
 
 	for(var/datum/robot_energy_storage/energy_storage in robot.module.storages)
 		energy_storage.max_energy = initial(energy_storage.max_energy)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -77,6 +77,8 @@
 	storage_slots = 60
 	item_flags = NO_MAT_REDEMPTION
 
+/obj/item/storage/bag/trash/bluespace/cyborg
+
 ////////////////////////////////////////
 // MARK:	Plastic bag
 ////////////////////////////////////////


### PR DESCRIPTION

## Что этот ПР делает
Теперь у боргов уборщиков появится улучшения хранилища в виде БС мешка для мусора. Как и другие БС вещи, данный мешок всё ещё вызывает помехи при телепортации.
## Почему это хорошо для игры
Теперь борги уборщики, что встречаются раз в тысячу лет, смогу поставить себе улучшение хранилища и увеличить себе хранилище. Теперь они смогут собирать вдвое больше мусора, но не смогут телепортироваться, хотя им это зачем - их задача ездить по станции и прибирать её, дак пусть и прибирают.
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
add: Добавлено улучшения хранилища для борга уборщика
/:cl:
