### PR TITLE
Правки перевода боеприпасов

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -73,3 +73,4 @@ GLOBAL_LIST_EMPTY(pod_styles_by_type)
 GLOBAL_LIST_EMPTY(loot_tiers)
 
 GLOBAL_LIST_EMPTY(design_names_cached)
+GLOBAL_LIST_EMPTY(design_descs_cached)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -137,7 +137,7 @@
 
 			recipes.Add(list(list(
 				"name" = D.build_object_name,
-				"desc" = created_object.desc,
+				"desc" = D.build_object_desc,
 				"category" = categories,
 				"uid" = D.UID(),
 				"requirements" =  matreq,

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -111,7 +111,7 @@
 // MARK: Incendiary slug
 /obj/item/ammo_casing/shotgun/incendiary
 	ammo_marking = "12g \"Зажигательный\""
-	extra_info = "Пуля воспламенятся при попадании в цель."
+	extra_info = "Пуля воспламенится при попадании в цель."
 	icon_state = "incendiaryshell"
 	projectile_type = /obj/projectile/bullet/incendiary/shell
 	muzzle_flash_color = LIGHT_COLOR_FIRE

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -38,7 +38,7 @@
 // MARK: Rubbershot
 /obj/item/ammo_casing/shotgun/rubbershot
 	ammo_marking = "12g \"Резиновая картечь\""
-	extra_info = "Резиновая картечь. Обладает высоким останавливающим действием, не нанося смертельных ранений при попадании."
+	extra_info = "Наполнен резиновыми гранулами. Обладает высоким останавливающим действием, не нанося смертельных ранений при попадании."
 	icon_state = "rubbershotshell"
 	materials = list(MAT_METAL = 1000)
 	projectile_type = /obj/projectile/bullet/pellet/rubber
@@ -48,7 +48,7 @@
 // MARK: Chemical dart
 /obj/item/ammo_casing/shotgun/dart
 	ammo_marking = "12g \"Дротик\""
-	extra_info = "Дротик для использования в гладкоствольных ружьях. Может содержать до 30 единиц вещества."
+	extra_info = "Пуля представляет собой аналог дротика с ёмкостью для химикатов. Вмещает вплоть до 30 единиц вещества."
 	icon_state = "rubbershotshell"
 	container_type = OPENCONTAINER
 	materials = list(MAT_METAL = 500, MAT_GLASS = 200)
@@ -64,7 +64,7 @@
 // MARK: Beanbag
 /obj/item/ammo_casing/shotgun/beanbag
 	ammo_marking = "12g \"Погремушка\""
-	extra_info = "Резиновая пуля. Обладает высоким останавливающим действием, не нанося смертельных ранений при попадании."
+	extra_info = "Цельная пуля из резины. Обладает высоким останавливающим действием, не нанося смертельных ранений при попадании."
 	icon_state = "beanbagshell"
 	materials = list(MAT_METAL = 1000)
 	projectile_type = /obj/projectile/bullet/weakbullet
@@ -111,7 +111,7 @@
 // MARK: Incendiary slug
 /obj/item/ammo_casing/shotgun/incendiary
 	ammo_marking = "12g \"Зажигательный\""
-	extra_info = "Зажигательная пуля с покрытием."
+	extra_info = "Пуля воспламенятся при попадании в цель."
 	icon_state = "incendiaryshell"
 	projectile_type = /obj/projectile/bullet/incendiary/shell
 	muzzle_flash_color = LIGHT_COLOR_FIRE
@@ -203,7 +203,7 @@
 // MARK: Improvised buckshot
 /obj/item/ammo_casing/shotgun/improvised
 	ammo_marking = "12g \"Самодельный\""
-	extra_info = "Самодельный боеприпас, начинённый множеством металлических гранул и малым количеством пороха."
+	extra_info = "Импровизированный боеприпас, начинённый множеством металлических гранул и малым количеством пороха."
 	icon_state = "improvisedshell"
 	materials = list(MAT_METAL = 250)
 	projectile_type = /obj/projectile/bullet/pellet/weak
@@ -214,7 +214,7 @@
 
 /obj/item/ammo_casing/shotgun/improvised/overload
 	ammo_marking = "12g \"Самодельный+\""
-	extra_info = "Самодельный боеприпас, начинённый крупными металлическими гранулами и избыточным количеством пороха. Чрезвычайно нестабильный."
+	extra_info = "Импровизированный боеприпас, начинённый крупными металлическими гранулами и избыточным количеством пороха. Чрезвычайно нестабильный."
 	projectile_type = /obj/projectile/bullet/pellet/overload
 	pellets = 4
 	variance = 40

--- a/code/modules/projectiles/boxes_magazines/magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/magazines/internal/_cylinder.dm
@@ -3,6 +3,21 @@
 	ammo_type = /obj/item/ammo_casing/a357
 	caliber = CALIBER_DOT_357
 
+/obj/item/ammo_box/magazine/internal/cylinder/get_ru_names()
+	return list(
+		NOMINATIVE = "барабан [gun_name] [get_cartridge_marking()]",
+		GENITIVE = "барабана [gun_name] [get_cartridge_marking()]",
+		DATIVE = "барабану [gun_name] [get_cartridge_marking()]",
+		ACCUSATIVE = "барабан [gun_name] [get_cartridge_marking()]",
+		INSTRUMENTAL = "барабаном [gun_name] [get_cartridge_marking()]",
+		PREPOSITIONAL = "барабане [gun_name] [get_cartridge_marking()]",
+	)
+
+/obj/item/ammo_box/magazine/internal/cylinder/update_desc(updates = ALL)
+	. = ..()
+	desc = "Барабан с каморами для [gun_name ? gun_name : "огнестрельного оружия"]. \
+			Предназначен для [get_ammo_descriptor()] [get_cartridge_marking()], вмещает вплоть до [max_ammo].[extra_info ? " " + extra_info : ""]"
+
 /obj/item/ammo_box/magazine/internal/cylinder/Initialize(mapload)
 	. = ..()
 	if(start_empty)

--- a/code/modules/projectiles/boxes_magazines/magazines/internal/_internal.dm
+++ b/code/modules/projectiles/boxes_magazines/magazines/internal/_internal.dm
@@ -2,6 +2,21 @@
 	desc = "Oh god, this shouldn't be here!"
 	can_fast_load = TRUE
 
+/obj/item/ammo_box/magazine/internal/get_ru_names()
+	return list(
+		NOMINATIVE = "внутренний магазин [gun_name] [get_cartridge_marking()]",
+		GENITIVE = "внутреннего магазина [gun_name] [get_cartridge_marking()]",
+		DATIVE = "внутреннему магазину [gun_name] [get_cartridge_marking()]",
+		ACCUSATIVE = "внутренний магазин [gun_name] [get_cartridge_marking()]",
+		INSTRUMENTAL = "внутренним магазином [gun_name] [get_cartridge_marking()]",
+		PREPOSITIONAL = "внутреннем магазине [gun_name] [get_cartridge_marking()]",
+	)
+
+/obj/item/ammo_box/magazine/internal/update_desc(updates = ALL)
+	. = ..()
+	desc = "Несъёмный магазин для [gun_name ? gun_name : "огнестрельного оружия"]. \
+			Предназначен для [get_ammo_descriptor()] [get_cartridge_marking()], вмещает вплоть до [max_ammo].[extra_info ? " " + extra_info : ""]"
+
 //internals magazines are accessible, so replace spent ammo if full when trying to put a live one in
 /obj/item/ammo_box/magazine/internal/give_round(obj/item/ammo_casing/new_casing, replace_spent = TRUE, count_chambered = FALSE, mob/user)
 	. = ..()

--- a/code/modules/projectiles/boxes_magazines/magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/magazines/internal/revolver.dm
@@ -36,28 +36,6 @@
 	caliber = CALIBER_DOT_36
 	max_ammo = 6
 
-/obj/item/ammo_box/magazine/internal/cylinder/improvised
-	name = "improvised bullet cylinder"
-	desc = "A roughly made revolver cylinder."
-	icon = 'icons/obj/improvised.dmi'
-	icon_state = "rev_cylinder"
-	ammo_type = null
-	start_empty = TRUE
-	caliber = list(CALIBER_DOT_257)
-	max_ammo = 4
-
-/obj/item/ammo_box/magazine/internal/cylinder/improvised/ammo_suitability(obj/item/ammo_casing/new_casing)
-	if(!new_casing || !(new_casing.caliber in caliber))
-		return FALSE
-	return TRUE
-
-/obj/item/ammo_box/magazine/internal/cylinder/improvised/steel
-	name = "steel bullet cylinder"
-	desc = "High quality steel revolver cylinder with increased amount of bullets."
-	icon_state = "s_rev_cylinder"
-	caliber = list(CALIBER_DOT_257, CALIBER_DOT_38)
-	max_ammo = 6
-
 /obj/item/ammo_box/magazine/internal/cylinder/cap
 	name = "cap gun revolver cylinder"
 	ammo_type = /obj/item/ammo_casing/cap
@@ -68,6 +46,50 @@
 	ammo_type = /obj/item/ammo_casing/shotgun
 	caliber = CALIBER_12G
 	max_ammo = 3
+
+// MARK: Improvised revolvers
+/obj/item/ammo_box/magazine/internal/cylinder/improvised
+	gun_name = "импровизированного револьвера"
+	icon = 'icons/obj/improvised.dmi'
+	icon_state = "rev_cylinder"
+	ammo_type = null
+	start_empty = TRUE
+	caliber = list(CALIBER_DOT_257)
+	max_ammo = 4
+
+/obj/item/ammo_box/magazine/internal/cylinder/improvised/get_ru_names()
+	return list(
+		NOMINATIVE = "кустарный барабан [gun_name] [get_cartridge_marking()]",
+		GENITIVE = "кустарный барабана [gun_name] [get_cartridge_marking()]",
+		DATIVE = "кустарный барабану [gun_name] [get_cartridge_marking()]",
+		ACCUSATIVE = "кустарный барабан [gun_name] [get_cartridge_marking()]",
+		INSTRUMENTAL = "кустарный барабаном [gun_name] [get_cartridge_marking()]",
+		PREPOSITIONAL = "кустарный барабане [gun_name] [get_cartridge_marking()]",
+	)
+
+/obj/item/ammo_box/magazine/internal/cylinder/improvised/ammo_suitability(obj/item/ammo_casing/new_casing)
+	if(!new_casing || !(new_casing.caliber in caliber))
+		return FALSE
+	return TRUE
+
+/obj/item/ammo_box/magazine/internal/cylinder/improvised/get_cartridge_marking()
+	return jointext(caliber, "\\")
+
+/obj/item/ammo_box/magazine/internal/cylinder/improvised/steel
+	extra_info = "Совместим с патронами калибров .38 и .257."
+	icon_state = "s_rev_cylinder"
+	caliber = list(CALIBER_DOT_257, CALIBER_DOT_38)
+	max_ammo = 6
+
+/obj/item/ammo_box/magazine/internal/cylinder/improvised/steel/get_ru_names()
+	return list(
+		NOMINATIVE = "стальной барабан [gun_name] [get_cartridge_marking()]",
+		GENITIVE = "стальной барабана [gun_name] [get_cartridge_marking()]",
+		DATIVE = "стальной барабану [gun_name] [get_cartridge_marking()]",
+		ACCUSATIVE = "стальной барабан [gun_name] [get_cartridge_marking()]",
+		INSTRUMENTAL = "стальной барабаном [gun_name] [get_cartridge_marking()]",
+		PREPOSITIONAL = "стальной барабане [gun_name] [get_cartridge_marking()]",
+	)
 
 // MARK: Russian roulette .357
 /obj/item/ammo_box/magazine/internal/rus357

--- a/code/modules/projectiles/boxes_magazines/magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/magazines/internal/revolver.dm
@@ -73,10 +73,10 @@
 	return TRUE
 
 /obj/item/ammo_box/magazine/internal/cylinder/improvised/get_cartridge_marking()
-	return jointext(caliber, "\\")
+	return jointext(caliber, "/")
 
 /obj/item/ammo_box/magazine/internal/cylinder/improvised/steel
-	extra_info = "Совместим с патронами калибров .38 и .257."
+	extra_info = "Совместим с патронами обоих калибров."
 	icon_state = "s_rev_cylinder"
 	caliber = list(CALIBER_DOT_257, CALIBER_DOT_38)
 	max_ammo = 6

--- a/code/modules/projectiles/boxes_magazines/magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/magazines/internal/revolver.dm
@@ -60,11 +60,11 @@
 /obj/item/ammo_box/magazine/internal/cylinder/improvised/get_ru_names()
 	return list(
 		NOMINATIVE = "кустарный барабан [gun_name] [get_cartridge_marking()]",
-		GENITIVE = "кустарный барабана [gun_name] [get_cartridge_marking()]",
-		DATIVE = "кустарный барабану [gun_name] [get_cartridge_marking()]",
+		GENITIVE = "кустарного барабана [gun_name] [get_cartridge_marking()]",
+		DATIVE = "кустарному барабану [gun_name] [get_cartridge_marking()]",
 		ACCUSATIVE = "кустарный барабан [gun_name] [get_cartridge_marking()]",
-		INSTRUMENTAL = "кустарный барабаном [gun_name] [get_cartridge_marking()]",
-		PREPOSITIONAL = "кустарный барабане [gun_name] [get_cartridge_marking()]",
+		INSTRUMENTAL = "кустарным барабаном [gun_name] [get_cartridge_marking()]",
+		PREPOSITIONAL = "кустарном барабане [gun_name] [get_cartridge_marking()]",
 	)
 
 /obj/item/ammo_box/magazine/internal/cylinder/improvised/ammo_suitability(obj/item/ammo_casing/new_casing)
@@ -84,11 +84,11 @@
 /obj/item/ammo_box/magazine/internal/cylinder/improvised/steel/get_ru_names()
 	return list(
 		NOMINATIVE = "стальной барабан [gun_name] [get_cartridge_marking()]",
-		GENITIVE = "стальной барабана [gun_name] [get_cartridge_marking()]",
-		DATIVE = "стальной барабану [gun_name] [get_cartridge_marking()]",
+		GENITIVE = "стального барабана [gun_name] [get_cartridge_marking()]",
+		DATIVE = "стальному барабану [gun_name] [get_cartridge_marking()]",
 		ACCUSATIVE = "стальной барабан [gun_name] [get_cartridge_marking()]",
-		INSTRUMENTAL = "стальной барабаном [gun_name] [get_cartridge_marking()]",
-		PREPOSITIONAL = "стальной барабане [gun_name] [get_cartridge_marking()]",
+		INSTRUMENTAL = "стальным барабаном [gun_name] [get_cartridge_marking()]",
+		PREPOSITIONAL = "стальном барабане [gun_name] [get_cartridge_marking()]",
 	)
 
 // MARK: Russian roulette .357

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -62,6 +62,8 @@ other types of metals and chemistry for reagents).
 	var/lathe_time_factor = 1
 	/// Name of the object that gets created.
 	var/build_object_name
+	/// Description of the object that gets created.
+	var/build_object_desc
 
 /datum/design/New()
 	. = ..()
@@ -70,9 +72,12 @@ other types of metals and chemistry for reagents).
 		return
 
 	var/design_name = GLOB.design_names_cached[id]
+	var/design_desc = GLOB.design_descs_cached[id]
 
 	if(design_name)
 		build_object_name = design_name
+		if(design_desc)
+			build_object_desc = design_desc
 		return
 
 	var/list/category_cached = category
@@ -81,6 +86,8 @@ other types of metals and chemistry for reagents).
 
 	var/obj/item/design_item = new build_path
 	design_name = DECLENT_RU_CAP(design_item, NOMINATIVE)
-	qdel(design_item)
 	build_object_name = design_name
+	build_object_desc = design_item.desc
+	qdel(design_item)
 	GLOB.design_names_cached[id] = design_name
+	GLOB.design_descs_cached[id] = build_object_desc

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -76,8 +76,9 @@ other types of metals and chemistry for reagents).
 
 	if(design_name)
 		build_object_name = design_name
-		if(design_desc)
-			build_object_desc = design_desc
+	if(design_desc)
+		build_object_desc = design_desc
+	if(design_name && design_desc)
 		return
 
 	var/list/category_cached = category

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -836,15 +836,14 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 	if(submenu == SUBMENU_LATHE_CATEGORY)
 		for(var/datum/design/D in matching_designs)
-			var/item_name = D.build_object_name
 			var/list/design_list = list()
 			designs_list[++designs_list.len] = design_list
 			var/list/design_materials_list = list()
 			var/obj/item/created_object = D.build_path
 			design_list["materials"] = design_materials_list
 			design_list["id"] = D.id
-			design_list["name"] = item_name
-			design_list["desc"] = created_object.desc
+			design_list["name"] = D.build_object_name
+			design_list["desc"] = D.build_object_desc
 			design_list["icon"] = created_object.icon
 			design_list["icon_state"] = created_object.icon_state
 			var/can_build = is_imprinter ? 1 : 50


### PR DESCRIPTION

## Что этот ПР делает
Т.к. в билде существуют предметы, описания и названия которых задаются динамически при инициализации (патроны, например), требуется эти динамически изменённые переменные подтягивать и обрабатывать. Доработал недоработку — описания теперь тоже кешируются, по аналогии с названиями, для которых это было сделано давно.

Также потыкал немного по локализации там и сям.
## Демонстрация изменений
<img width="902" height="192" alt="изображение" src="https://github.com/user-attachments/assets/3932e26f-e4bd-4432-b9d5-3562b3d560ee" />


<img width="519" height="31" alt="изображение" src="https://github.com/user-attachments/assets/3e74ea0f-24bf-45c2-bd7f-c7edc5c34935" />


<img width="594" height="158" alt="изображение" src="https://github.com/user-attachments/assets/10048478-6010-43f3-8ead-c3ce9192aa35" />

## Список изменений
:cl:
spellcheck: Улучшение описаний некоторых патронов.
bugfix: Правки отображения стального цилиндра в автолате.
refactor: Кеширование описаний шаблонов печати по аналогии с названиями.
/:cl: