### PR TITLE
Удалить деффиб из мэка парамедика.

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -157,14 +157,12 @@
 		/obj/item/mod/module/storage/large_capacity,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/injector,
-		/obj/item/mod/module/defibrillator,
 		/obj/item/mod/module/monitor,
 		/obj/item/mod/module/health_analyzer,
 		/obj/item/mod/module/quick_carry/advanced,
 	)
 	default_pins = list(
 		/obj/item/mod/module/injector,
-		/obj/item/mod/module/defibrillator,
 		/obj/item/mod/module/monitor,
 		/obj/item/mod/module/health_analyzer,
 	)


### PR DESCRIPTION
## Что этот ПР делает
Удаляет у МЭКа парамедика модуль деффиба раундстратом.

## Почему это хорошо для игры
~~ГАП попросил~~ Кисик попросил. Часть предметов из РНД (такие как: перчи инугами, компактный деффиб и т.д) просто становятся бесполезными и мало востребованными, когда под рукой есть такая приколюха раундстартом.

## Список изменений
:cl:
del: Удалён деффиб из МЭКа парамедика раундстартом.
/:cl:
