### PR TITLE
Убирает медицину с кошельков

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -14,7 +14,6 @@
 		/obj/item/clothing/mask/cigarette,
 		/obj/item/flashlight/pen,
 		/obj/item/seeds,
-		/obj/item/stack/medical,
 		/obj/item/toy/crayon,
 		/obj/item/coin,
 		/obj/item/dice,
@@ -29,7 +28,6 @@
 		/obj/item/stamp,
 		/obj/item/encryptionkey,
 		/obj/item/clothing/gloves/ring,
-		/obj/item/reagent_containers/food/pill/patch,
 		/obj/item/spacepod_equipment/key,
 		/obj/item/key,
 	)


### PR DESCRIPTION

## Что этот ПР делает
Теперь в кошельки нельзя хранить медицину.

## Почему это хорошо для игры
1. Логика: нельзя будет хранить половину наномеда в кошельках.
2. Логика: у вас есть аптечки карманные для медицины с увеличенными слотами.
3. ГАП: гап попросил сделать это.

## Список изменений
:cl:
balance: Удалена возможность хранить медицину в кошельках.
/:cl:
