### PR TITLE
Фикс станционных трейтов для FAST_LOAD

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -848,5 +848,5 @@ SUBSYSTEM_DEF(mapping)
 
 /// Returns true if the map we're playing on is on a planet
 /datum/controller/subsystem/mapping/proc/is_planetary()
-	return SSmapping.map_datum.planetary
+	return map_datum.planetary
 

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -74,6 +74,13 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 		selectable_traits_by_types[trait_typepath.trait_type][trait_typepath] = trait_typepath.weight
 
+// Most of the traits depend on some kind of station feature that FAST_LOAD map lacks, so for now,
+// to avoid inconvenience with runtimes and until we maybe have better map for testing,
+// FAST_LOAD disables random station traits from generation. You still can force them though.
+#ifdef FAST_LOAD
+	return
+#endif
+
 	var/positive_trait_budget = text2num(pick_weight_classic(CONFIG_GET(keyed_list/positive_station_traits)))
 	var/neutral_trait_budget = text2num(pick_weight_classic(CONFIG_GET(keyed_list/neutral_station_traits)))
 	var/negative_trait_budget = text2num(pick_weight_classic(CONFIG_GET(keyed_list/negative_station_traits)))

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -1,6 +1,7 @@
 /datum/station_trait/carp_infestation
 	name = "Миграция космической фауны"
 	trait_type = STATION_TRAIT_NEGATIVE
+	trait_flags = STATION_TRAIT_SPACE_BOUND
 	weight = 5
 	show_in_report = TRUE
 	report_message = "Сканеры дальнего действия регистрируют массивную миграцию космических карпов в вашем секторе. Соблюдайте осторожность при работе в космосе."
@@ -178,6 +179,7 @@
 	name = "Ионная буря"
 	report_message = "Станция была расположена в эпицентре ионизированной туманности. Ожидайте повышенную вероятность ионных штормов, влияющих на работу роботизированных систем."
 	trait_type = STATION_TRAIT_NEGATIVE
+	trait_flags = STATION_TRAIT_SPACE_BOUND
 	weight = 3
 	event_names = list(EVENT_ION_TYPHOON)
 	event_severity = /datum/event_container/moderate
@@ -188,6 +190,7 @@
 	name = "Радиационная буря"
 	report_message = "Звезда системы вошла в цикл повышенной активности. Ожидайте повышенную вероятность радиационных штормов."
 	trait_type = STATION_TRAIT_NEGATIVE
+	trait_flags = STATION_TRAIT_SPACE_BOUND
 	weight = 2
 	event_names = list(EVENT_RADIATION_STORM)
 	event_severity = /datum/event_container/moderate
@@ -198,6 +201,7 @@
 	name = "Метеорный дождь"
 	report_message = "Орбита объекта пересекается с метеоритным потоком. Инженерам рекомендуется проверить системы защиты от метеоритов."
 	trait_type = STATION_TRAIT_NEGATIVE
+	trait_flags = STATION_TRAIT_SPACE_BOUND
 	weight = 2
 	event_names = list(EVENT_METEOR_WAVE)
 	event_severity = /datum/event_container/moderate
@@ -207,6 +211,7 @@
 	name = "Аномальное созвездие"
 	report_message = "Сканеры дальнего действия фиксируют истончение ткани реальности в вашем секторе. Ожидается повышенная аномальная активность."
 	trait_type = STATION_TRAIT_NEGATIVE
+	trait_flags = STATION_TRAIT_SPACE_BOUND
 	weight = 2
 	event_names = list(EVENT_ANOMALY, EVENT_WORMHOLES)
 	event_severity = /datum/event_container/moderate
@@ -216,6 +221,7 @@
 	name = "Вражеская активность"
 	report_message = "Разведка докладывает о присутствии враждебных кораблей в секторе. Экипажу объекта соблюдать полную боевую готовность."
 	trait_type = STATION_TRAIT_NEGATIVE
+	trait_flags = STATION_TRAIT_SPACE_BOUND
 	weight = 2
 	event_names = list(EVENT_SPACE_NINJA, EVENT_LONE_OPERATIVE, EVENT_DRIFTING_CONTRACTOR)
 	event_severity = /datum/event_container/moderate


### PR DESCRIPTION

## Что этот ПР делает
Станционные трейты не генерятся рандомно для быстрогруза, чтобы не рантаймили, но их все еще можно зафорсить для тестов, также указал космический трейт для эксклюзивно космических ивентов
## Почему это хорошо для игры
Вова попросил
