### PR TITLE
Снайперка больше не ваншотит + небольшое изменение стартового набора

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -110,6 +110,11 @@
 
 	// delete these end
 
+	// Give them an get equipment objective if they don't have one already.
+	var/all_objectives = owner.get_all_objectives()
+	if(!(locate(/datum/objective/get_equipment) in all_objectives))
+		add_objective(/datum/objective/get_equipment)
+
 	var/objective_count = hijacker_antag			//Hijacking counts towards number of objectives
 	if(!SSticker.mode.exchange_blue && length(SSticker.mode.traitors) >= EXCHANGE_OBJECTIVE_TRAITORS_REQUIRED)	//Set up an exchange if there are enough traitors
 		if(!SSticker.mode.exchange_red)
@@ -146,12 +151,6 @@
 		if(!(locate(/datum/objective/die) in owner.get_all_objectives()))
 			add_objective(/datum/objective/die)
 			return
-
-	// Give them an get equipment objective if they don't have one already.
-	var/all_objectives = owner.get_all_objectives()
-	if(!(locate(/datum/objective/get_equipment) in all_objectives))
-		if(owner.current?.client?.get_exp_type_num(EXP_TYPE_SPECIAL) < 300 HOURS)
-			add_objective(/datum/objective/get_equipment)
 
 	// Give them an escape objective if they don't have one already.
 	if(!(locate(/datum/objective/escape) in all_objectives) && !(locate(/datum/objective/survive) in all_objectives))

--- a/code/modules/projectiles/projectile/ballistic/rifle.dm
+++ b/code/modules/projectiles/projectile/ballistic/rifle.dm
@@ -46,18 +46,13 @@
 	//range = 100
 	damage = 80
 	weaken = 4 SECONDS
-	dismemberment = 50
 	armour_penetration = 50
 	forced_accuracy = TRUE
 	var/breakthings = TRUE
 
 /obj/projectile/bullet/sniper/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && (!ismob(target) && breakthings))
-		if(hit_zone in list(BODY_ZONE_HEAD, BODY_ZONE_CHEST))
-			return ..()
-
 		target.ex_act(rand(EXPLODE_DEVASTATE, EXPLODE_HEAVY))
-
 	return ..()
 
 /obj/projectile/bullet/sniper/soporific
@@ -79,7 +74,6 @@
 	weaken = 6 SECONDS
 	stun = 6 SECONDS
 	damage = 85
-	dismemberment = 0
 	ricochets_max = 0
 
 /obj/projectile/bullet/sniper/explosive/on_hit(atom/target, blocked = 0, hit_zone)
@@ -91,7 +85,6 @@
 /obj/projectile/bullet/sniper/haemorrhage
 	armour_penetration = 15
 	damage = 15
-	dismemberment = 0
 	weaken = 0
 	breakthings = FALSE
 	var/bleeding = 100
@@ -122,12 +115,9 @@
 	knockdown = 4 SECONDS
 	weaken = 0
 	breakthings = FALSE
-	dismemberment = 0
 
 // MARK: .338 - AXMC
 /obj/projectile/bullet/sniper/a338
-	damage = 80
-	dismemberment = 0
 
 /obj/projectile/bullet/sniper/soporific/a338
 

--- a/code/modules/projectiles/projectile/ballistic/rifle.dm
+++ b/code/modules/projectiles/projectile/ballistic/rifle.dm
@@ -58,7 +58,6 @@
 /obj/projectile/bullet/sniper/soporific
 	armour_penetration = 0
 	nodamage = TRUE
-	dismemberment = 0
 	weaken = 0
 	breakthings = FALSE
 	var/sleep_time = 40 SECONDS
@@ -101,7 +100,6 @@
 	name = "penetrator round"
 	damage = 60
 	forcedodge = -1
-	dismemberment = 0
 	weaken = 0
 	breakthings = FALSE
 	ricochet_chance = 0

--- a/code/modules/projectiles/projectile/ballistic/rifle.dm
+++ b/code/modules/projectiles/projectile/ballistic/rifle.dm
@@ -44,7 +44,7 @@
 /obj/projectile/bullet/sniper
 	//speed = 0.75
 	//range = 100
-	damage = 70
+	damage = 80
 	weaken = 4 SECONDS
 	dismemberment = 50
 	armour_penetration = 50
@@ -53,6 +53,9 @@
 
 /obj/projectile/bullet/sniper/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && (!ismob(target) && breakthings))
+		if(hit_zone in list(BODY_ZONE_HEAD, BODY_ZONE_CHEST))
+			return ..()
+
 		target.ex_act(rand(EXPLODE_DEVASTATE, EXPLODE_HEAVY))
 
 	return ..()

--- a/code/modules/projectiles/projectile/ballistic/rifle.dm
+++ b/code/modules/projectiles/projectile/ballistic/rifle.dm
@@ -44,7 +44,7 @@
 /obj/projectile/bullet/sniper
 	//speed = 0.75
 	//range = 100
-	damage = 80
+	damage = 100
 	weaken = 4 SECONDS
 	armour_penetration = 50
 	forced_accuracy = TRUE

--- a/code/modules/projectiles/projectile/ballistic/shrapnel.dm
+++ b/code/modules/projectiles/projectile/ballistic/shrapnel.dm
@@ -7,6 +7,7 @@
 	range = 20
 	armour_penetration = 30
 	dismemberment = 5
+	dismember_head = TRUE
 	tile_dropoff = 0.5
 	ricochet_chance = 70
 	var/embedded_type = /obj/item/embedded/shrapnel


### PR DESCRIPTION
## Почему это хорошо для игры
1) Стартовый набор ничем не поможет новичку, ибо изначально был сделан не совсем для этого, а для того, чтобы у трейтора всегда было хоть какое-то оружие. С новым пистолетиком, заместо стечкина, это вызывает еще меньше проблем с балансом и имеет еще меньше смысла для новчика. Если кому-то хочется облегчить новичкам жизнь - сделайте отдельный набор с тем, что реально поможет
2) Ваншот гибы от снайперки - одна из самых токсичных вещей в нюке, которые сделали значительный вклад в то, чтобы режим недолюбливали, с небольшим запозданием это исправлено. В замен патрону повышен урон на 10 единиц.
<!-- Опишите, почему, по Вашему, следует добавить эти изменения в кодбазу или почему это хорошо для игры. -->
## Список изменений

<!-- Если Ваш PR изменяет аспекты игры, которые могут быть конкретно замечены игроками, Вы должны добавить это в список изменений. Если Ваши изменения НЕ соответствует этому списку изменений, удалите этот раздел. -->

:cl:
bugfix: Теперь хиджак и каскадный резонанс не блокируют выдачу стартового набора.
balance: Стартовый набор теперь снова выдается всем.
balance: Снайперка больше не может сваншодить куклу базовым патроном.
balance: Базовый патрон 50 бмг теперь наносит 100 урона.
/:cl:

<!-- Оба тега :cl: обязательны для работы списка изменений! Вы можете указать своё имя справа от первого :cl:, если хотите переопределить username пользователя GitHub, как автора в игре. -->
<!-- Вы можете использовать несколько одинаковых префиксов (они используются только для иконки в игре) и удалять ненужные. Несмотря на некоторые теги, списки изменений должны в целом отражать то, как изменения могут повлиять на игрока, а не быть кратким содержанием PR. -->
