### PR TITLE
VV edit Обработчки для gun + фикс подствола для m90

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -247,7 +247,7 @@
 	var/image/overlay = module.create_overlay()
 	if(!overlay)
 		return
-	if(overlay && attachable_offset)
+	if(attachable_offset)
 		apply_attachment_offset(module.slot, overlay, module)
 	attachment_overlays[module.slot] = overlay
 	update_icon(UPDATE_OVERLAYS)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -245,6 +245,8 @@
 
 /obj/item/gun/proc/add_attachment_overlay(obj/item/gun_module/module)
 	var/image/overlay = module.create_overlay()
+	if(!overlay)
+		return
 	if(overlay && attachable_offset)
 		apply_attachment_offset(module.slot, overlay, module)
 	attachment_overlays[module.slot] = overlay
@@ -345,6 +347,7 @@
 /obj/item/gun/proc/clean_gun_user()
 	SIGNAL_HANDLER
 	set_gun_user(null)
+
 ///Check if the gun can fire and add it to bucket auto_fire system if needed, or just fire the gun if not
 /obj/item/gun/proc/start_fire(datum/source, atom/object, turf/location, control, params, bypass_checks = FALSE)
 	SIGNAL_HANDLER
@@ -1133,3 +1136,21 @@
 	if(gun_firemode == removed_firemode)
 		gun_firemode = gun_firemode_list[1]
 		toggle_firemode(gun_firemode)
+
+/obj/item/gun/vv_edit_var(var_name, var_value)
+	if(var_name == NAMEOF(src, fire_delay))
+		modify_fire_delay(-fire_delay + var_value, usr)
+		return TRUE
+	if(var_name == NAMEOF(src, burst_delay))
+		modify_burst_delay(-burst_delay + var_value, usr)
+		return TRUE
+	if(var_name == NAMEOF(src, autoburst_delay))
+		modify_auto_burst_delay(-autoburst_delay + var_value , usr)
+		return TRUE
+	if(var_name == NAMEOF(src, burst_amount))
+		modify_burst_amount(-burst_amount + var_value, usr)
+		return TRUE
+	if(var_name == NAMEOF(src, gun_firemode))
+		toggle_firemode(var_value)
+		return TRUE
+	. = ..()

--- a/code/modules/projectiles/gun_modules/_gun_module.dm
+++ b/code/modules/projectiles/gun_modules/_gun_module.dm
@@ -72,6 +72,8 @@
 	return TRUE
 
 /obj/item/gun_module/proc/create_overlay()
+	if(!overlay_state)
+		return
 	if(!buffered_overlay)
 		buffered_overlay = mutable_appearance(icon, overlay_state, layer = FLOAT_LAYER - 1)
 	return buffered_overlay

--- a/code/modules/projectiles/gun_modules/underbarrel.dm
+++ b/code/modules/projectiles/gun_modules/underbarrel.dm
@@ -414,6 +414,10 @@
 	can_detach = FALSE
 	overlay_state = null
 
+/obj/item/gun_module/under/gun/grenade_launcher/integrated/unloaded/Initialize(mapload)
+	. = ..()
+	QDEL_NULL(internal_gun.chambered)
+
 // MARK: Shotgun
 /obj/item/gun_module/under/gun/shotgun
 	name = "underbarrel shotgun"

--- a/code/modules/projectiles/gun_modules/underbarrel.dm
+++ b/code/modules/projectiles/gun_modules/underbarrel.dm
@@ -410,6 +410,10 @@
 		launcher.unload_act(user)
 	return ..()
 
+/obj/item/gun_module/under/gun/grenade_launcher/integrated
+	can_detach = FALSE
+	overlay_state = null
+
 // MARK: Shotgun
 /obj/item/gun_module/under/gun/shotgun
 	name = "underbarrel shotgun"

--- a/code/modules/projectiles/guns/ballistic/auto_rifles.dm
+++ b/code/modules/projectiles/guns/ballistic/auto_rifles.dm
@@ -40,6 +40,7 @@
 	name = "M-90gl Carbine (Rusted)"
 	desc = "A three-round burst 5.56 toploading carbine, designated 'M-90gl'. Has an attached underbarrel grenade launcher which can be toggled on and off. Looks rusty."
 	damage_mod = 0.85
+	starting_attachment_types = list(/obj/item/gun_module/under/gun/grenade_launcher/integrated/unloaded)
 
 /obj/item/gun/projectile/automatic/m90/rusted/ComponentInitialize()
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/auto_rifles.dm
+++ b/code/modules/projectiles/guns/ballistic/auto_rifles.dm
@@ -9,8 +9,7 @@
 	fire_sound = 'sound/weapons/gunshots/1m90.ogg'
 	magin_sound = 'sound/weapons/gun_interactions/batrifle_magin.ogg'
 	magout_sound = 'sound/weapons/gun_interactions/batrifle_magout.ogg'
-	can_suppress = 1
-	var/obj/item/gun/projectile/revolver/grenadelauncher/underbarrel
+	can_suppress = TRUE
 	accuracy = GUN_ACCURACY_RIFLE_UPLINK
 	attachable_allowed = GUN_MODULE_CLASS_RIFLE_MUZZLE | GUN_MODULE_CLASS_RIFLE_RAIL
 	attachable_offset = list(
@@ -18,26 +17,7 @@
 		ATTACHMENT_SLOT_RAIL = list(ATTACHMENT_OFFSET_X = 12, ATTACHMENT_OFFSET_Y = 7),
 	)
 	recoil = GUN_RECOIL_MEDIUM
-
-/obj/item/gun/projectile/automatic/m90/Initialize(mapload)
-	. = ..()
-	underbarrel = new /obj/item/gun/projectile/revolver/grenadelauncher(src)
-	update_icon()
-
-/obj/item/gun/projectile/automatic/m90/Destroy()
-	QDEL_NULL(underbarrel)
-	return ..()
-
-/obj/item/gun/projectile/automatic/m90/attackby(obj/item/I, mob/user, params)
-	if(istype(I, underbarrel.magazine.ammo_type))
-		add_fingerprint(user)
-		var/reload = underbarrel.magazine.reload(I, user, replace_spent = TRUE)
-		if(reload)
-			underbarrel.chamber_round(FALSE)
-			return ATTACK_CHAIN_BLOCKED_ALL
-		return ATTACK_CHAIN_PROCEED
-
-	return ..()
+	starting_attachment_types = list(/obj/item/gun_module/under/gun/grenade_launcher/integrated)
 
 /obj/item/gun/projectile/automatic/m90/update_icon_state()
 	icon_state = "[initial(icon_state)][magazine ? "" : "-e"]"
@@ -60,10 +40,6 @@
 	name = "M-90gl Carbine (Rusted)"
 	desc = "A three-round burst 5.56 toploading carbine, designated 'M-90gl'. Has an attached underbarrel grenade launcher which can be toggled on and off. Looks rusty."
 	damage_mod = 0.85
-
-/obj/item/gun/projectile/automatic/m90/rusted/Initialize(mapload)
-	. = ..()
-	QDEL_NULL(underbarrel.chambered)
 
 /obj/item/gun/projectile/automatic/m90/rusted/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
## Список изменений
:cl:
tweak: Теперь при изменении дилеев, файрмода и размеров очередей у оружия они корректно обновляются в компоненте автоогня.
refactor: Теперь m90 имеет интегрированный модуль подствольного гранатомета, заместо костыля. Модуль работает как и обычный подствол.
/:cl:
