### PR TITLE
Fix: "abstract" circuit board of combat drones

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -26,6 +26,9 @@
 	board_type = "machine"
 	abstract_type = /obj/item/circuitboard/machine
 
+/obj/item/circuitboard/drone
+	board_type = "drone"
+
 /obj/item/circuitboard/Initialize(mapload)
 	. = ..()
 	format_board_name()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -620,7 +620,6 @@
 
 		robot.module.modules += new /obj/item/storage/bag/trash/bluespace/cyborg(robot.module)
 		robot.module.rebuild()
-		return TRUE
 
 	for(var/datum/robot_energy_storage/energy_storage in robot.module.storages)
 		energy_storage.max_energy *= 3

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -644,7 +644,6 @@
 
 		robot.module.modules += new /obj/item/storage/bag/trash/cyborg(robot.module)
 		robot.module.rebuild()
-		return TRUE
 
 	for(var/datum/robot_energy_storage/energy_storage in robot.module.storages)
 		energy_storage.max_energy = initial(energy_storage.max_energy)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -614,6 +614,14 @@
 		robot.module.emag = satchel
 		robot.module.emag.update_icon(UPDATE_ICON_STATE)
 
+	if(istype(robot.module, /obj/item/robot_module/janitor))
+		for(var/obj/item/storage/bag/trash/cyborg/bag in robot.module.modules)
+			qdel(bag)
+
+		robot.module.modules += new /obj/item/storage/bag/trash/bluespace/cyborg(robot.module)
+		robot.module.rebuild()
+		return TRUE
+
 	for(var/datum/robot_energy_storage/energy_storage in robot.module.storages)
 		energy_storage.max_energy *= 3
 		energy_storage.recharge_rate *= 2
@@ -630,6 +638,14 @@
 		satchel.upgraded = FALSE
 		robot.module.emag = satchel
 		robot.module.emag.update_icon(UPDATE_ICON_STATE)
+
+	if(istype(robot.module, /obj/item/robot_module/janitor))
+		for(var/obj/item/storage/bag/trash/bluespace/cyborg/bag in robot.module.modules)
+			qdel(bag)
+
+		robot.module.modules += new /obj/item/storage/bag/trash/cyborg(robot.module)
+		robot.module.rebuild()
+		return TRUE
 
 	for(var/datum/robot_energy_storage/energy_storage in robot.module.storages)
 		energy_storage.max_energy = initial(energy_storage.max_energy)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -77,6 +77,8 @@
 	storage_slots = 60
 	item_flags = NO_MAT_REDEMPTION
 
+/obj/item/storage/bag/trash/bluespace/cyborg
+
 ////////////////////////////////////////
 // MARK:	Plastic bag
 ////////////////////////////////////////

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -130,7 +130,7 @@
 	step_to(K, get_turf(pick(view(7, src))))
 
 	//also drop dummy circuit boards deconstructable for research (loot)
-	var/obj/item/circuitboard/C
+	var/obj/item/circuitboard/drone/C
 
 	//spawn 1-4 boards of a random type
 	var/spawnees = 0


### PR DESCRIPTION

## Что этот ПР делает
Добавлет новый тип платы для комбат дронов, чтобы они не были абстрактными
## Почему это хорошо для игры
В игре не должны появляться абстрактные классы
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
bugfix: Исправлены абстрактные платы у боевых дронов
/:cl:
