### PR TITLE
Замена пустого сундука в некрополисе на сундук с лутом

### DIFF
--- a/_maps/map_files/Delta/Lavaland.dmm
+++ b/_maps/map_files/Delta/Lavaland.dmm
@@ -5788,7 +5788,7 @@
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/obj/structure/closet/crate/necropolis,
+/obj/structure/closet/crate/necropolis/tendril,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
 "Fe" = (

--- a/_maps/map_files/coldcolony/Lavaland.dmm
+++ b/_maps/map_files/coldcolony/Lavaland.dmm
@@ -1155,7 +1155,7 @@
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/obj/structure/closet/crate/necropolis,
+/obj/structure/closet/crate/necropolis/tendril,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
 "kp" = (

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -4181,7 +4181,7 @@
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/obj/structure/closet/crate/necropolis,
+/obj/structure/closet/crate/necropolis/tendril,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
 "qw" = (

--- a/_maps/map_files/nova/Lavaland.dmm
+++ b/_maps/map_files/nova/Lavaland.dmm
@@ -7394,7 +7394,7 @@
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/obj/structure/closet/crate/necropolis,
+/obj/structure/closet/crate/necropolis/tendril,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/necropolis)
 "QE" = (


### PR DESCRIPTION
## Что этот ПР делает
>баг репорт: https://discord.com/channels/617003227182792704/1108039755939184641

## Демонстрация изменений

<details><summary>Изображение</summary>

  Сундук теперь с рандом лутом✅

<p>
<img width="891" height="511" alt="image" src="https://github.com/user-attachments/assets/d270bbfa-db24-49d8-a9fe-7bfbde5abc62" />
</p>
</details>

## Список изменений
:cl:
bugfix: Исправлен баг со спавном пустого сундука вместо сундука с лутом в некрополисе (на всех картах)
map: Замена пустого сундука в некрополисе на сундук с рандом лутом (на всех картах)
/:cl: