### PR TITLE
Теперь пути передаются в раст в строковом виде

### DIFF
--- a/code/controllers/subsystem/non-firing/sounds.dm
+++ b/code/controllers/subsystem/non-firing/sounds.dm
@@ -93,7 +93,7 @@ SUBSYSTEM_DEF(sounds)
 
 	// Precache ambience sounds
 	for(var/key, value in GLOB.ambience_assoc)
-		sounds_to_precache |= value
+		sounds_to_precache |= "[value]"
 
 	precache_sounds()
 


### PR DESCRIPTION
## Список изменений
:cl:
bugfix: Исправление ошибки "Invalid path: String is not utf8".
/:cl:
