### PR TITLE
Баланс скорострельности

### DIFF
--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -26,7 +26,7 @@
 	/// Variance for inaccuracy fundamental to the casing
 	var/variance = 0
 	/// Delay for energy weapons
-	var/delay = 0.3 SECONDS
+	var/delay = 0.4 SECONDS
 	/// Randomspread for automatics
 	var/randomspread = FALSE
 	/// Override this to make your gun have a faster fire rate, in tenths of a second. 4 is the default gun cooldown.

--- a/code/modules/projectiles/guns/ballistic/_revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/_revolver.dm
@@ -11,7 +11,7 @@
 	fire_sound = 'sound/weapons/gunshots/1rev.ogg'
 	accuracy = GUN_ACCURACY_PISTOL
 	attachable_allowed = GUN_MODULE_CLASS_PISTOL_MUZZLE
-	fire_delay = 0.5 SECONDS
+	fire_delay = 0.45 SECONDS
 	attachable_offset = list(
 		ATTACHMENT_SLOT_MUZZLE = list(ATTACHMENT_OFFSET_X = 19, ATTACHMENT_OFFSET_Y = 4),
 	)

--- a/code/modules/projectiles/guns/ballistic/pistols.dm
+++ b/code/modules/projectiles/guns/ballistic/pistols.dm
@@ -151,6 +151,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	mag_type = /obj/item/ammo_box/magazine/pistolm9mm
 	burst_amount = 3
+	fire_delay = 0.3 SECONDS
 	accuracy = GUN_ACCURACY_PISTOL_UPLINK
 	recoil = GUN_RECOIL_MEDIUM
 	attachable_offset = list(


### PR DESCRIPTION
## Список изменений
:cl:
balance: Задержка между выстрелами у лазерного оружия увеличена на 0.1 секунду.
balance: Задержка между выстрелами у пистолетов увеличена на 0.1 секунду.
balance: Задержка между выстрелами у револьверов уменьшена на 0.05 секунды.
/:cl:
