### PR TITLE
Flashbang now flashes everyone

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -104,20 +104,20 @@
 			M.Weaken(10 SECONDS)
 
 		if(ear_safety)
-			return
+			continue
 
 		M.apply_damage(15, STAMINA)
 		M.Weaken(status_duration * pressure_factor)
 		M.Deaf(30 SECONDS * pressure_factor)
 
 		if(!iscarbon(M))
-			return
+			continue
 
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
 
 		if(!istype(ears))
-			return
+			continue
 
 		if(HAS_TRAIT(M, TRAIT_WEAK_EARS))
 			ears.internal_receive_damage(10)
@@ -127,7 +127,7 @@
 			to_chat(M, span_warning("У вас начинает очень сильно звенеть в ушах!"))
 			if(prob(ears.damage - 5))
 				to_chat(M, span_warning("Вы ничего не слышите!"))
-			return
+			continue
 
 		if(ears.damage >= 5)
 			to_chat(M, span_warning("У вас начинает звенеть в ушах."))


### PR DESCRIPTION

## Что этот ПР делает

Меняет return в цикле флешки на continue.
Это изменение делает так, что все мобы в радиусе получали эффект флешки, а не зависело от рандома, попался ли офицер в начале списка или нет.

## Почему это хорошо для игры

Выглядит глупо, что офицеры должны снимать с себя одежду, чтобы их граната работала.

## Список изменений
:cl:
bugfix: Эффект флеш гранат не зависит от пристутствия офицеров
/:cl:
