### PR TITLE
Fix Обход запрета на возрождение через тандердом

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -616,10 +616,10 @@ structure_check() searches for nearby cultist structures required for the invoca
 		set waitfor = FALSE
 		to_chat(user, span_cult("[mob_to_revive] was revived, but their mind is lost! Seeking a lost soul to replace it."))
 		var/list/mob/dead/observer/candidates = SSghost_spawns.poll_candidates("Would you like to play as a revived Cultist?", ROLE_CULTIST, TRUE, poll_time = 20 SECONDS, source = /obj/item/melee/cultblade/dagger)
-		
+
 		if(QDELETED(mob_to_revive))
 			return
-		
+
 		if(length(candidates))
 			var/mob/dead/observer/C = pick(candidates)
 			to_chat(mob_to_revive, span_biggerdanger("Your physical form has been taken over by another soul due to your inactivity! Ahelp if you wish to regain your form."))
@@ -893,7 +893,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	notify_ghosts("Manifest rune created in [get_area(src)].", ghost_sound = 'sound/effects/ghost2.ogg', source = src)
 	var/list/ghosts_on_rune = list()
 	for(var/mob/dead/observer/O in T)
-		if(O.client && !iscultist(O) && !jobban_isbanned(O, ROLE_CULTIST) && !O.has_enabled_antagHUD && !QDELETED(src) && !QDELETED(O))
+		if(O.client && !iscultist(O) && !jobban_isbanned(O, ROLE_CULTIST) && !O.persistent_client?.antaghud_enabled && !QDELETED(src) && !QDELETED(O))
 			ghosts_on_rune += O
 	if(!length(ghosts_on_rune))
 		to_chat(user, span_cultitalic("There are no spirits near [src]!"))

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -262,7 +262,8 @@ ADMIN_VERB(toggle_antaghud_use, R_SERVER, "Toggle antagHUD usage", "Toggles anta
 		for(var/mob/dead/observer/g in user.get_ghosts())
 			if(g.antagHUD)
 				g.antagHUD = FALSE						// Disable it on those that have it enabled
-				g.has_enabled_antagHUD = FALSE				// We'll allow them to respawn
+				if(g.persistent_client)
+					g.persistent_client.antaghud_enabled = FALSE	// We'll allow them to respawn
 				to_chat(g, span_danger("The Administrator has disabled AntagHUD."))
 
 		CONFIG_SET(flag/allow_antag_hud, FALSE)
@@ -292,7 +293,8 @@ ADMIN_VERB(toggle_antaghug_restrictions, R_SERVER, "Toggle antagHUD Restrictions
 			to_chat(ghost, span_danger("The administrator has placed restrictions on joining the round if you use AntagHUD"), confidential = TRUE)
 			to_chat(ghost, span_danger("Your AntagHUD has been disabled, you may choose to re-enabled it but will be under restrictions."), confidential = TRUE)
 			ghost.antagHUD = FALSE
-			ghost.has_enabled_antagHUD = FALSE
+			if(ghost.persistent_client)
+				ghost.persistent_client.antaghud_enabled = FALSE
 		action = "placed restrictions"
 		CONFIG_SET(flag/antag_hud_restricted, TRUE)
 		to_chat(user, span_danger("AntagHUD restrictions have been enabled."), confidential = TRUE)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -262,8 +262,7 @@ ADMIN_VERB(toggle_antaghud_use, R_SERVER, "Toggle antagHUD usage", "Toggles anta
 		for(var/mob/dead/observer/g in user.get_ghosts())
 			if(g.antagHUD)
 				g.antagHUD = FALSE						// Disable it on those that have it enabled
-				if(g.persistent_client)
-					g.persistent_client.antaghud_enabled = FALSE	// We'll allow them to respawn
+				g.persistent_client?.antaghud_enabled = FALSE // We'll allow them to respawn
 				to_chat(g, span_danger("The Administrator has disabled AntagHUD."))
 
 		CONFIG_SET(flag/allow_antag_hud, FALSE)
@@ -293,8 +292,7 @@ ADMIN_VERB(toggle_antaghug_restrictions, R_SERVER, "Toggle antagHUD Restrictions
 			to_chat(ghost, span_danger("The administrator has placed restrictions on joining the round if you use AntagHUD"), confidential = TRUE)
 			to_chat(ghost, span_danger("Your AntagHUD has been disabled, you may choose to re-enabled it but will be under restrictions."), confidential = TRUE)
 			ghost.antagHUD = FALSE
-			if(ghost.persistent_client)
-				ghost.persistent_client.antaghud_enabled = FALSE
+			ghost.persistent_client?.antaghud_enabled = FALSE
 		action = "placed restrictions"
 		CONFIG_SET(flag/antag_hud_restricted, TRUE)
 		to_chat(user, span_danger("AntagHUD restrictions have been enabled."), confidential = TRUE)

--- a/code/modules/client/persistent_client.dm
+++ b/code/modules/client/persistent_client.dm
@@ -36,6 +36,13 @@ GLOBAL_LIST_EMPTY_TYPED(persistent_clients, /datum/persistent_client)
 	/// World.time this player last died
 	var/time_of_death = 0
 
+	/// Has the player ever enabled AntagHUD this round
+	var/antaghud_enabled = FALSE
+	/// Is the player eligible for OOC respawn
+	var/respawn_eligible = TRUE
+	/// The client's ability to respawn is currently blocked by a minigame or event.
+	var/respawn_locked = FALSE
+
 /datum/persistent_client/New(ckey, client)
 	src.client = client
 	achievements = new(ckey)

--- a/code/modules/mini_games/thunderdome/thunderdome_battle.dm
+++ b/code/modules/mini_games/thunderdome/thunderdome_battle.dm
@@ -174,7 +174,8 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 		return
 	for(var/mob/living/mob in zone)
 		if(mob.ckey)
-			addtimer(CALLBACK(src, PROC_REF(restore_ghost_state), mob.ckey), 5 SECONDS)
+			continue
+		addtimer(CALLBACK(src, PROC_REF(restore_ghost_state), mob.ckey), 5 SECONDS)
 		mob.melt()
 
 	for(var/obj/object_in_zone in zone)

--- a/code/modules/mini_games/thunderdome/thunderdome_battle.dm
+++ b/code/modules/mini_games/thunderdome/thunderdome_battle.dm
@@ -51,9 +51,10 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 
 	is_going = TRUE
 	add_game_logs("Thunderdome poll voting in [gamemode.name] mode started.")
-	var/image/I = new('icons/mob/thunderdome_previews.dmi', gamemode.preview_icon)
+
+	var/image/preview_image = new('icons/mob/thunderdome_previews.dmi', gamemode.preview_icon)
 	var/list/candidates = shuffle(SSghost_spawns.poll_candidates("Желаете записаться на Тандердом? (Режим — [gamemode.name])", \
-		role, poll_time = voting_poll_time, ignore_respawnability = TRUE, check_antaghud = FALSE, source = I))
+		role, poll_time = voting_poll_time, ignore_respawnability = TRUE, check_antaghud = FALSE, source = preview_image))
 	var/players_count = clamp(ceil(length(candidates)*spawn_coefficent), 0, maxplayers)
 	if(players_count < spawn_minimum_limit)
 		notify_ghosts("Not enough players to start Thunderdome Battle!")
@@ -77,24 +78,24 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 	random_stuff += get_random_items(item_pool_ref, gamemode.random_items_count)
 
 	if(!gamemode.extended_area)
-		for(var/obj/machinery/door/poddoor/M in GLOB.airlocks)
-			if(M.id_tag != "TD_CloseCombat")
+		for(var/obj/machinery/door/poddoor/pod_door in GLOB.airlocks)
+			if(pod_door.id_tag != "TD_CloseCombat")
 				continue
-			INVOKE_ASYNC(M, TYPE_PROC_REF(/obj/machinery/door, do_animate), "closing")
-			M.set_density(TRUE)
-			M.set_opacity(TRUE)
-			M.layer = M.closingLayer
-			M.update_icon()
+			INVOKE_ASYNC(pod_door, TYPE_PROC_REF(/obj/machinery/door, do_animate), "closing")
+			pod_door.set_density(TRUE)
+			pod_door.set_opacity(TRUE)
+			pod_door.layer = pod_door.closingLayer
+			pod_door.update_icon()
 
 	else
-		for(var/obj/machinery/door/poddoor/M in GLOB.airlocks)
-			if(M.id_tag != "TD_CloseCombat")
+		for(var/obj/machinery/door/poddoor/pod_door in GLOB.airlocks)
+			if(pod_door.id_tag != "TD_CloseCombat")
 				continue
-			if(M.density)
-				INVOKE_ASYNC(M, TYPE_PROC_REF(/obj/machinery/door, do_animate), "opening")
-				M.set_density(FALSE)
-				M.set_opacity(FALSE)
-				M.update_icon()
+			if(pod_door.density)
+				INVOKE_ASYNC(pod_door, TYPE_PROC_REF(/obj/machinery/door, do_animate), "opening")
+				pod_door.set_density(FALSE)
+				pod_door.set_opacity(FALSE)
+				pod_door.update_icon()
 
 	while(currpoint <= points)
 		if(phi > (2 * PI))
@@ -106,6 +107,14 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 		brawler.thunderdome = src
 		brawler.outfit.backpack_contents += random_stuff
 		var/mob/dead/observer/ghost = candidates[currpoint]
+		if(ghost && ghost.client && ghost.client.persistent_client)
+			var/datum/persistent_client/persistent = ghost.client.persistent_client
+			if(persistent)
+				persistent.respawn_locked = TRUE
+				GLOB.respawnable_list -= ghost
+				ghost.can_reenter_corpse = FALSE
+
+		fighters += brawler
 		brawler.attack_ghost(ghost)
 		phi += delta_phi
 		currpoint += 1
@@ -131,8 +140,8 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 	for(var/i in 1 to count)
 		random_items += pick(from)
 
-	for(var/i in random_items)
-		random_items[i] = from[i]
+	for(var/item_key in random_items)
+		random_items[item_key] = from[item_key]
 
 	return random_items
 
@@ -164,18 +173,20 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 	if(!zone)
 		return
 	for(var/mob/living/mob in zone)
+		if(mob.ckey)
+			addtimer(CALLBACK(src, PROC_REF(restore_ghost_state), mob.ckey), 1 SECONDS)
 		mob.melt()
 
-	for(var/obj/A in zone)
-		if(istype(A, /obj/machinery/door/poddoor) || istype(A, /obj/minigame_anchor/thunderdome_poller) || istype(A, /obj/structure/sink/puddle) || istype(A, /obj/structure/table/reinforced))
+	for(var/obj/object_in_zone in zone)
+		if(istype(object_in_zone, /obj/machinery/door/poddoor) || istype(object_in_zone, /obj/minigame_anchor/thunderdome_poller) || istype(object_in_zone, /obj/structure/sink/puddle) || istype(object_in_zone, /obj/structure/table/reinforced))
 			continue
-		qdel(A)
+		qdel(object_in_zone)
 
 /**
  * Gets location with rounded coordinates (needed for precise geometry builder)
  */
-/datum/mini_game/thunderdome_battle/proc/get_rounded_location(curr_x, curr_y, z)
-	return locate(round(curr_x), round(curr_y), z)
+/datum/mini_game/thunderdome_battle/proc/get_rounded_location(curr_x, curr_y, z_level)
+	return locate(round(curr_x), round(curr_y), z_level)
 
 /**
  * Handles thunderdome's participants deaths. Called from /datum/component/death_timer_reset/
@@ -183,6 +194,10 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 /datum/mini_game/thunderdome_battle/proc/handle_participant_death(mob/living/dead_fighter)
 	if(dead_fighter in fighters)
 		fighters -= dead_fighter
+
+	if(dead_fighter.ckey)
+		addtimer(CALLBACK(src, PROC_REF(restore_ghost_state), dead_fighter.ckey), 1 SECONDS)
+
 	if(!length(fighters) && !is_cleansing_going)
 		for(var/datum/timedevent/timer in active_timers)
 			qdel(timer)
@@ -192,6 +207,24 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 		if(last_poller)
 			last_poller.visible_message(span_danger("Thunderdome has ended with death of all participants! Cleansing in 5 seconds..."))
 	return
+
+/**
+ * Restores ghost AntagHUD and respawnability after the battle.
+ */
+/datum/mini_game/thunderdome_battle/proc/restore_ghost_state(target_ckey)
+	var/datum/persistent_client/persistent = GLOB.persistent_clients_by_ckey[target_ckey]
+	if(!persistent)
+		return
+
+	persistent.respawn_locked = FALSE
+
+	var/mob/dead/observer/ghost = persistent.mob
+	if(istype(ghost))
+		ghost.antagHUD = persistent.antaghud_enabled
+
+		if(persistent.respawn_eligible)
+			GLOB.respawnable_list |= ghost
+			ghost.can_reenter_corpse = TRUE
 
 /**
  * Invisible object which is responsible for rolling brawlers for fighting on thunderdome.

--- a/code/modules/mini_games/thunderdome/thunderdome_battle.dm
+++ b/code/modules/mini_games/thunderdome/thunderdome_battle.dm
@@ -218,13 +218,14 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 	persistent.respawn_locked = FALSE
 
 	var/mob/dead/observer/ghost = persistent.mob
-	if(istype(ghost))
+	if(!istype(ghost))
 		return
-		ghost.antagHUD = persistent.antaghud_enabled
 
-		if(persistent.respawn_eligible)
-			GLOB.respawnable_list |= ghost
-			ghost.can_reenter_corpse = TRUE
+	ghost.antagHUD = persistent.antaghud_enabled
+
+	if(persistent.respawn_eligible)
+		GLOB.respawnable_list |= ghost
+		ghost.can_reenter_corpse = TRUE
 
 /**
  * Invisible object which is responsible for rolling brawlers for fighting on thunderdome.

--- a/code/modules/mini_games/thunderdome/thunderdome_battle.dm
+++ b/code/modules/mini_games/thunderdome/thunderdome_battle.dm
@@ -174,7 +174,7 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 		return
 	for(var/mob/living/mob in zone)
 		if(mob.ckey)
-			addtimer(CALLBACK(src, PROC_REF(restore_ghost_state), mob.ckey), 1 SECONDS)
+			addtimer(CALLBACK(src, PROC_REF(restore_ghost_state), mob.ckey), 5 SECONDS)
 		mob.melt()
 
 	for(var/obj/object_in_zone in zone)
@@ -196,7 +196,7 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 		fighters -= dead_fighter
 
 	if(dead_fighter.ckey)
-		addtimer(CALLBACK(src, PROC_REF(restore_ghost_state), dead_fighter.ckey), 1 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(restore_ghost_state), dead_fighter.ckey), 5 SECONDS)
 
 	if(!length(fighters) && !is_cleansing_going)
 		for(var/datum/timedevent/timer in active_timers)

--- a/code/modules/mini_games/thunderdome/thunderdome_battle.dm
+++ b/code/modules/mini_games/thunderdome/thunderdome_battle.dm
@@ -173,7 +173,7 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 	if(!zone)
 		return
 	for(var/mob/living/mob in zone)
-		if(mob.ckey)
+		if(!mob.ckey)
 			continue
 		addtimer(CALLBACK(src, PROC_REF(restore_ghost_state), mob.ckey), 5 SECONDS)
 		mob.melt()

--- a/code/modules/mini_games/thunderdome/thunderdome_battle.dm
+++ b/code/modules/mini_games/thunderdome/thunderdome_battle.dm
@@ -107,12 +107,11 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 		brawler.thunderdome = src
 		brawler.outfit.backpack_contents += random_stuff
 		var/mob/dead/observer/ghost = candidates[currpoint]
-		if(ghost && ghost.client && ghost.client.persistent_client)
+		if(ghost?.client?.persistent_client)
 			var/datum/persistent_client/persistent = ghost.client.persistent_client
-			if(persistent)
-				persistent.respawn_locked = TRUE
-				GLOB.respawnable_list -= ghost
-				ghost.can_reenter_corpse = FALSE
+			persistent.respawn_locked = TRUE
+			GLOB.respawnable_list -= ghost
+			ghost.can_reenter_corpse = FALSE
 
 		fighters += brawler
 		brawler.attack_ghost(ghost)
@@ -220,6 +219,7 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 
 	var/mob/dead/observer/ghost = persistent.mob
 	if(istype(ghost))
+		return
 		ghost.antagHUD = persistent.antaghud_enabled
 
 		if(persistent.respawn_eligible)

--- a/code/modules/mini_games/thunderdome/thunderdome_battle.dm
+++ b/code/modules/mini_games/thunderdome/thunderdome_battle.dm
@@ -91,11 +91,12 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/tdome/newtdome/CQC))
 		for(var/obj/machinery/door/poddoor/pod_door in GLOB.airlocks)
 			if(pod_door.id_tag != "TD_CloseCombat")
 				continue
-			if(pod_door.density)
-				INVOKE_ASYNC(pod_door, TYPE_PROC_REF(/obj/machinery/door, do_animate), "opening")
-				pod_door.set_density(FALSE)
-				pod_door.set_opacity(FALSE)
-				pod_door.update_icon()
+			if(!pod_door.density)
+				continue
+			INVOKE_ASYNC(pod_door, TYPE_PROC_REF(/obj/machinery/door, do_animate), "opening")
+			pod_door.set_density(FALSE)
+			pod_door.set_opacity(FALSE)
+			pod_door.update_icon()
 
 	while(currpoint <= points)
 		if(phi > (2 * PI))

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -194,8 +194,6 @@
 	/// Can move on the shuttle.
 	var/move_on_shuttle = 1
 
-	/// Whether antagHUD has been enabled previously.
-	var/has_enabled_antagHUD = FALSE
 	/// Whether AntagHUD is active right now
 	var/antagHUD = FALSE
 	/// Just a handler for permanent/temporary THOUGHTS_HUD changing.

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -66,9 +66,8 @@
 
 	return 1
 
-/proc/cannotPossess(A)
-	var/mob/dead/observer/ghost = A
-	return istype(ghost) && ghost.persistent_client?.antaghud_enabled && CONFIG_GET(flag/antag_hud_restricted)
+/proc/cannotPossess(mob/dead/observer/ghost)
+    return istype(ghost) && ghost.persistent_client?.antaghud_enabled && CONFIG_GET(flag/antag_hud_restricted)
 
 /proc/iscuffed(A)
 	if(iscarbon(A))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -67,7 +67,7 @@
 	return 1
 
 /proc/cannotPossess(mob/dead/observer/ghost)
-    return istype(ghost) && ghost.persistent_client?.antaghud_enabled && CONFIG_GET(flag/antag_hud_restricted)
+	return istype(ghost) && ghost.persistent_client?.antaghud_enabled && CONFIG_GET(flag/antag_hud_restricted)
 
 /proc/iscuffed(A)
 	if(iscarbon(A))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -67,10 +67,8 @@
 	return 1
 
 /proc/cannotPossess(A)
-	var/mob/dead/observer/G = A
-	if(G.persistent_client?.antaghud_enabled && CONFIG_GET(flag/antag_hud_restricted))
-		return 1
-	return 0
+	var/mob/dead/observer/ghost = A
+	return istype(ghost) && ghost.persistent_client?.antaghud_enabled && CONFIG_GET(flag/antag_hud_restricted)
 
 /proc/iscuffed(A)
 	if(iscarbon(A))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -68,7 +68,7 @@
 
 /proc/cannotPossess(A)
 	var/mob/dead/observer/G = A
-	if(G.has_enabled_antagHUD && CONFIG_GET(flag/antag_hud_restricted))
+	if(G.persistent_client?.antaghud_enabled && CONFIG_GET(flag/antag_hud_restricted))
 		return 1
 	return 0
 

--- a/code/modules/tgui/modules/ghost_hud_panel.dm
+++ b/code/modules/tgui/modules/ghost_hud_panel.dm
@@ -58,7 +58,7 @@ GLOBAL_DATUM_INIT(ghost_hud_panel, /datum/ui_module/ghost_hud_panel, new)
 				to_chat(ghost, span_warning("Администраторы отключили это для данного раунда."))
 				return FALSE
 
-			var/datum/persistent_client/persistent = ghost.client.persistent_client
+			var/datum/persistent_client/persistent = ghost.client?.persistent_client
 			if(!persistent)
 				return FALSE
 			// Check if this is the first time they're turning on Antag HUD.

--- a/code/modules/tgui/modules/ghost_hud_panel.dm
+++ b/code/modules/tgui/modules/ghost_hud_panel.dm
@@ -57,13 +57,19 @@ GLOBAL_DATUM_INIT(ghost_hud_panel, /datum/ui_module/ghost_hud_panel, new)
 			if(!CONFIG_GET(flag/allow_antag_hud) && !ghost.client.holder)
 				to_chat(ghost, span_warning("Администраторы отключили это для данного раунда."))
 				return FALSE
+
+			var/datum/persistent_client/persistent = ghost.client.persistent_client
+			if(!persistent)
+				return FALSE
 			// Check if this is the first time they're turning on Antag HUD.
-			if(check_rights(R_MENTOR, FALSE) && !check_rights(R_ADMIN | R_MOD, FALSE) && !ghost.has_enabled_antagHUD && CONFIG_GET(flag/antag_hud_restricted))
+			if(check_rights(R_MENTOR, FALSE) && !check_rights(R_ADMIN | R_MOD, FALSE) && !persistent.antaghud_enabled && CONFIG_GET(flag/antag_hud_restricted))
 				var/response = tgui_alert(ghost, "Если вы включите эту функцию, вы не сможете принять участие в раунде.", "Вы уверены, что хотите включить антаг HUD?", list("Да", "Нет"))
 				if(response != "Да")
 					return FALSE
 
-				ghost.has_enabled_antagHUD = TRUE
+				persistent.antaghud_enabled = TRUE
+				persistent.respawn_eligible = FALSE
+
 				ghost.can_reenter_corpse = FALSE
 				GLOB.respawnable_list -= ghost
 


### PR DESCRIPTION
# Что этот ПР делает
Данные о состоянии игрока (включен ли antaghud и находится ли он в списке respawnable_list) теперь сохраняются в persistent_client (также заменены однобуквенные переменные).
>баг репорт: https://discord.com/channels/617003227182792704/1265265597462216776
## Список изменений
:cl:
bugfix: Теперь точно не даёт возможность респавна если был включён антаг худ
refactor: Замена однобуквенных переменных
/:cl: