### PR TITLE
get logs improve and acces to devs

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -112,5 +112,9 @@
 #define BLACKBOX_LOG_ADMIN_VERB(the_verb) SSblackbox.record_feedback("tally", "admin_verb", 1, the_verb)
 #define BLACKBOX_LOG_VUAP(the_verb) SSblackbox.record_feedback("tally", "VUAP", 1, the_verb)
 
-//How many things you can spawn at once with spawn verb/create panel
+/// How many things you can spawn at once with spawn verb/create panel
 #define ADMIN_SPAWN_CAP 100
+
+// LOG BROWSE TYPES
+#define BROWSE_ROOT_ALL_LOGS 1
+#define BROWSE_ROOT_CURRENT_LOGS 2

--- a/code/__DEFINES/files.dm
+++ b/code/__DEFINES/files.dm
@@ -1,6 +1,11 @@
 // None of these should be trusted for the purpose of user input
 // They do not check the actual type of the file, a user could just rename it
 
+/// Loads a file from disk. Prevent loading files via Advanced ProcCall.
+#define WRAP_FILE(filepath) file(filepath)
+/// Reads a file from disk into a string. Prevent reading files via Advanced ProcCall.
+#define WRAP_FILE2TEXT(filepath) file2text(filepath)
+
 /// File types we can sniff the duration from using rustg.
 #define IS_SOUND_FILE_SAFE(file) is_file_type_in_list(##file, SSsounds.safe_formats)
 

--- a/code/__HELPERS/_string_lists.dm
+++ b/code/__HELPERS/_string_lists.dm
@@ -5,7 +5,7 @@
 /// Pick a string with @pick(SOME_KEY) replacements for nested random selection
 #define pick_list_replacements(FILE, KEY) (strings_replacement(FILE, KEY))
 /// Load and parse a JSON file
-#define json_load(FILE) (json_decode(wrap_file2text(FILE)))
+#define json_load(FILE) (json_decode(WRAP_FILE2TEXT(FILE)))
 
 /// Global cache for loaded string files
 GLOBAL_LIST(string_cache)

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -1,60 +1,23 @@
-/// Security helpers to ensure you cant arbitrarily load stuff from disk
-/proc/wrap_file(filepath)
-	if(IsAdminAdvancedProcCall())
-		// Admins shouldnt fuck with this
-		to_chat(usr, span_boldannounceooc("File load blocked: Advanced ProcCall detected."))
-		log_and_message_admins("attempted to load files via advanced proc-call")
-		return
-
-	return file(filepath)
-
-/proc/wrap_file2text(filepath)
-	if(IsAdminAdvancedProcCall())
-		// Admins shouldnt fuck with this
-		to_chat(usr, span_boldannounceooc("File load blocked: Advanced ProcCall detected."))
-		log_and_message_admins("attempted to load files via advanced proc-call")
-		return
-
-	return file2text(filepath)
-
-///checks if a file exists and contains text
-///returns text as a string if these conditions are met
-/proc/return_file_text(filename)
-	if(fexists(filename) == 0)
-		error("File not found ([filename])")
-		return
-
-	var/text = wrap_file2text(filename)
-	if(!text)
-		error("File empty ([filename])")
-		return
-
-	return text
-
-///Sends resource files to client cache
-/client/proc/getFiles()
-	if(IsAdminAdvancedProcCall())
-		to_chat(usr, span_boldannounceooc("Shelleo blocked: Advanced ProcCall detected."))
-		log_and_message_admins("attempted to call Shelleo via advanced proc-call")
-		return
-
-	for(var/file in args)
-		src << browse_rsc(file)
-
-/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm"))
+/client/proc/browse_files(root_type = BROWSE_ROOT_ALL_LOGS, max_iterations = 10, list/valid_extensions=list("txt", "log", "htm", "html", "gz", "json"))
 	if(IsAdminAdvancedProcCall())
 		to_chat(usr, span_boldannounceooc("Shelleo blocked: Advanced ProcCall detected."))
 		log_and_message_admins("attempted to call Shelleo via advanced proc-call")
 		return
 
 	// wow why was this ever a parameter
-	root = "data/logs/"
+	var/root = "data/logs/"
+	switch(root_type)
+		if(BROWSE_ROOT_ALL_LOGS)
+			root = "data/logs/"
+		if(BROWSE_ROOT_CURRENT_LOGS)
+			root = "[GLOB.log_directory]/"
 	var/path = root
 
-	for(var/i=0, i<max_iterations, i++)
+	for(var/i in 1 to max_iterations)
 		var/list/choices = flist(path)
 		if(path != root)
-			choices.Insert(1,"/")
+			choices.Insert(1, "/")
+		choices = sort_list(choices) + "Download Folder"
 
 		var/choice = tgui_input_list(src, "Choose a file to access:", "Download", choices, null)
 		switch(choice)
@@ -63,20 +26,34 @@
 			if("/")
 				path = root
 				continue
+			if("Download Folder")
+				var/list/comp_flist = flist(path)
+				var/confirmation = tgui_input_list(src, "Are you SURE you want to download all the files in this folder? (This will open [length(comp_flist)] prompt[length(comp_flist) == 1 ? "" : "s"])", "Confirmation", list("Да", "Нет"))
+				if(confirmation != "Да")
+					continue
+				for(var/file in comp_flist)
+					src << ftp(path + file)
+				return
 		path += choice
 
-		if(copytext(path,-1,0) != "/") //didn't choose a directory, no need to iterate again
+		if(copytext_char(path, -1) != "/") // didn't choose a directory, no need to iterate again
 			break
-
-	var/extension = copytext(path,-4,0)
-	if(!fexists(path) || !(extension in valid_extensions))
+	var/extensions
+	for(var/i in valid_extensions)
+		if(extensions)
+			extensions += "|"
+		extensions += "[i]"
+	var/regex/valid_ext = new("\\.([extensions])$", "i")
+	if(!fexists(path) || !(valid_ext.Find(path)))
 		to_chat(src, span_red("Error: browse_files(): File not found/Invalid file([path])."))
 		return
 
 	return path
 
-#define FTPDELAY 200 // 200 tick delay to discourage spam
-#define ADMIN_FTPDELAY_MODIFIER 0.5 // Admins get to spam files faster since we ~trust~ them!
+/// 200 tick delay to discourage spam
+#define FTPDELAY 200
+/// Admins get to spam files faster since we ~trust~ them!
+#define ADMIN_FTPDELAY_MODIFIER 0.5
 
 /**
  * This proc is a failsafe to prevent spamming of file requests.

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -1,4 +1,5 @@
 // Everything in this file should be protected
+/// The directory in which ALL log files should be stored
 GLOBAL_VAR(log_directory)
 GLOBAL_PROTECT(log_directory)
 GLOBAL_VAR(world_game_log)

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -42,8 +42,11 @@ GLOBAL_VAR_INIT(recall_time_limit, 72000) //apparently used for the comm console
 
 GLOBAL_VAR_INIT(timezoneOffset, 0) // The difference betwen midnight (of the host computer) and 0 world.ticks.
 
-// For FTP requests. (i.e. downloading runtime logs.)
-// However it'd be ok to use for accessing attack logs and such too, which are even laggier.
+/**
+ * For FTP requests. (i.e. downloading runtime logs.)
+ *
+ * However it'd be ok to use for accessing attack logs and such too, which are even laggier.
+ */
 GLOBAL_VAR_INIT(fileaccess_timer, 0)
 
 GLOBAL_VAR_INIT(gametime_offset, 432000) // 12:00 in seconds

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -403,7 +403,7 @@ SUBSYSTEM_DEF(mapping)
 	else
 		var/s_traits = map_datum.traits ? map_datum.traits : DEFAULT_STATION_TRATS
 		map_z_level = GLOB.space_manager.add_new_zlevel(MAIN_STATION, linkage = map_datum.linkage, traits = s_traits)
-	GLOB.maploader.load_map(wrap_file(map_datum.map_path), z_offset = map_z_level)
+	GLOB.maploader.load_map(WRAP_FILE(map_datum.map_path), z_offset = map_z_level)
 
 	if(map_datum?.forced_mode)
 		GLOB.master_mode = map_datum.forced_mode.name

--- a/code/datums/helper_datums/map_template.dm
+++ b/code/datums/helper_datums/map_template.dm
@@ -17,7 +17,7 @@
 		name = rename
 
 /datum/map_template/proc/preload_size(path)
-	var/bounds = GLOB.maploader.load_map(wrap_file(path), 1, 1, 1, shouldCropMap = FALSE, measureOnly = TRUE)
+	var/bounds = GLOB.maploader.load_map(WRAP_FILE(path), 1, 1, 1, shouldCropMap = FALSE, measureOnly = TRUE)
 	if(bounds)
 		width = bounds[MAP_MAXX] // Assumes all templates are rectangular, have a single Z level, and begin at 1,1,1
 		height = bounds[MAP_MAXY]
@@ -81,7 +81,7 @@
 	if(mapfile)
 		. = mapfile
 	else if(mappath)
-		. = wrap_file(mappath)
+		. = WRAP_FILE(mappath)
 
 	if(!.)
 		stack_trace("  The file of [src] appears to be empty/non-existent.")

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -5,7 +5,7 @@
 	if(!subject)
 		CRASH("No subject provided for investigate_log")
 
-	var/file = wrap_file("[GLOB.log_directory]/[subject].html")
+	var/file = WRAP_FILE("[GLOB.log_directory]/[subject].html")
 	var/source = "[src]"
 	if(isliving(src))
 		var/mob/living/source_mob = src
@@ -63,7 +63,7 @@ ADMIN_VERB(investigate_show, R_ADMIN, "Investigate", "Browse various detailed lo
 			if(config && CONFIG_GET(flag/log_hrefs))
 				if(GLOB.world_href_log)
 					var/datum/browser/popup = new(user, "investigate[selected]", capitalize("investigate[selected]"), 800, 300)
-					popup.set_content(wrap_file(GLOB.world_href_log))
+					popup.set_content(WRAP_FILE(GLOB.world_href_log))
 					popup.open(FALSE)
 				else
 					to_chat(user, span_red("Error: admin_investigate: No href logfile found."))
@@ -78,7 +78,7 @@ ADMIN_VERB(investigate_show, R_ADMIN, "Investigate", "Browse various detailed lo
 				to_chat(user, span_danger("No [selected] logfile was found."), confidential = TRUE)
 				return
 
-			file = wrap_file2text(file)
+			file = WRAP_FILE2TEXT(file)
 			var/datum/browser/popup = new(user, "investigate[selected]", capitalize("investigate[selected]"), 800, 300)
 			popup.set_content(file)
 			popup.open(FALSE)

--- a/code/modules/admin/outfits.dm
+++ b/code/modules/admin/outfits.dm
@@ -32,7 +32,7 @@ ADMIN_VERB(outfit_manager, R_EVENT, "Outfit Manager", "View and edit outfits.", 
 	var/outfit_file = input(usr, "Pick outfit json file:", "File") as null|file
 	if(!outfit_file)
 		return
-	var/filedata = wrap_file2text(outfit_file)
+	var/filedata = WRAP_FILE2TEXT(outfit_file)
 	var/json = json_decode(filedata)
 	if(!json)
 		to_chat(admin,span_warning("JSON decode error."))

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -1,40 +1,29 @@
-/*
-	HOW DO I LOG RUNTIMES?
-	Firstly, start dreamdeamon if it isn't already running. Then select "world>Log Session" (or press the F3 key)
-	navigate the popup window to the data/logs/runtime/ folder from where your tgstation .dmb is located.
-	(you may have to make this folder yourself)
-
-	OPTIONAL:	you can select the little checkbox down the bottom to make dreamdeamon save the log everytime you
-				start a world. Just remember to repeat these steps with a new name when you update to a new revision!
-
-	Save it with the name of the revision your server uses (e.g. r3459.txt).
-	Game Masters will now be able to grant access any runtime logs you have archived this way!
-	This will allow us to gather information on bugs across multiple servers and make maintaining the TG
-	codebase for the entire /TG/station commuity a TONNE easier :3 Thanks for your help!
-*/
-
-ADMIN_VERB(get_server_logs, R_ADMIN, "Get Server Logs", "View or retrieve logfiles.", ADMIN_CATEGORY_DEBUG)
+ADMIN_VERB(get_server_logs, R_ADMIN|R_DEBUG, "Get Server Logs", "View or retrieve logfiles.", ADMIN_CATEGORY_MAIN)
 	user.browseserverlogs()
 
-//This proc allows download of past server logs saved within the data/logs/ folder.
-/client/proc/browseserverlogs()
-	var/path = browse_files("data/logs/")
+ADMIN_VERB(get_current_logs, R_ADMIN|R_DEBUG, "Get Current Logs", "View or retrieve logfiles for the current round.", ADMIN_CATEGORY_MAIN)
+	user.browseserverlogs(current = TRUE)
+
+/// This proc allows download of past server logs saved within the data/logs/ folder.
+/client/proc/browseserverlogs(current = FALSE)
+	var/path = browse_files(current ? BROWSE_ROOT_CURRENT_LOGS : BROWSE_ROOT_ALL_LOGS)
 	if(!path)
 		return
 
 	if(file_spam_check())
 		return
 
-	message_admins("[key_name_admin(src)] accessed file: [path]")
+	message_admins(span_adminnotice("[key_name_admin(src)] accessed file: [path]"))
+	log_admin("[key_name(src)] accessed file: [path]")
 	switch(tgui_alert(usr, "View (in game), Open (in your system's text editor), or Download?", path, list("View", "Open", "Download")))
 		if("View")
 			var/datum/browser/popup = new(src, "viewfile.[path]", "Server Logs")
-			popup.set_content("<pre style='word-wrap: break-word;'>[html_encode(wrap_file2text(wrap_file(path)))]</pre>")
+			popup.set_content("<pre style='word-wrap: break-word;'>[html_encode(WRAP_FILE2TEXT(WRAP_FILE(path)))]</pre>")
 			popup.open(FALSE)
 		if("Open")
-			src << run(wrap_file(path))
+			src << run(WRAP_FILE(path))
 		if("Download")
-			src << ftp(wrap_file(path))
+			src << ftp(WRAP_FILE(path))
 		else
 			return
 	to_chat(src, "Attempting to send [path], this may take a fair few minutes if the file is very large.", confidential = TRUE)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -43,7 +43,7 @@ GLOBAL_DATUM_INIT(_preloader, /datum/dmm_suite/preloader, new())
 		// if rustlib for whatever reason fails and returns null
 		// try to load it the old dm way instead
 		if(!map_data)
-			map_data = wrap_file2text(dmm_file)
+			map_data = WRAP_FILE2TEXT(dmm_file)
 
 		if(!LAZYLEN(map_data))
 			CRASH("Map path '[fname]' does not exist!")
@@ -430,7 +430,7 @@ GLOBAL_DATUM_INIT(_preloader, /datum/dmm_suite/preloader, new())
 
 	// Check for file
 	else if(copytext(value_text, 1, 2) == "'")
-		. = wrap_file(copytext(value_text, 2, LAZYLEN(value_text)))
+		. = WRAP_FILE(copytext(value_text, 2, LAZYLEN(value_text)))
 
 	// Check for path
 	else if(ispath(text2path(value_text)))

--- a/code/modules/awaymissions/maploader/writer.dm
+++ b/code/modules/awaymissions/maploader/writer.dm
@@ -18,7 +18,7 @@
 	var/map_path = "[map_prefix][map_name].dmm"
 	if(fexists(map_path))
 		fdel(map_path)
-	var/saved_map = wrap_file(map_path)
+	var/saved_map = WRAP_FILE(map_path)
 	var/map_text = write_map(t1, t2, flags, saved_map)
 	saved_map << map_text
 	return saved_map

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_INIT(potentialRandomZlevels, generateMapList(filename = "config/away
 	if(CONFIG_GET(string/override_away_mission))
 		log_startup_progress_global("Mapping", "Away mission overridden by configuration to [CONFIG_GET(string/override_away_mission)].")
 
-	var/file = wrap_file(map)
+	var/file = WRAP_FILE(map)
 	var/bounds = GLOB.maploader.load_map(file, 1, 1, 1, shouldCropMap = FALSE, measureOnly = TRUE)
 	var/total_z = bounds[MAP_MAXZ] - bounds[MAP_MINZ] + 1
 	var/map_z_level

--- a/code/modules/instruments/songs/play_legacy.dm
+++ b/code/modules/instruments/songs/play_legacy.dm
@@ -71,7 +71,7 @@
 
 	// now generate name
 	var/filename = "sound/instruments/[cached_legacy_dir]/[ascii2text(note + 64)][acc][oct].[cached_legacy_ext]"
-	var/soundfile = wrap_file(filename)
+	var/soundfile = WRAP_FILE(filename)
 	// make sure the note exists
 	var/cached_fexists = valid_files[filename]
 	if(!isnull(cached_fexists))

--- a/code/modules/karma/karma.dm
+++ b/code/modules/karma/karma.dm
@@ -169,7 +169,7 @@ GLOBAL_LIST_EMPTY(karma_spenders)
 
 	var/special_role = "None"
 	var/assigned_role = "None"
-	var/karma_diary = wrap_file("[GLOB.log_directory]/karma.log")
+	var/karma_diary = WRAP_FILE("[GLOB.log_directory]/karma.log")
 	if(M.mind)
 		if(M.mind.special_role)
 			special_role = M.mind.special_role

--- a/code/modules/tgs/v3210/api.dm
+++ b/code/modules/tgs/v3210/api.dm
@@ -152,7 +152,7 @@
 	. = list()
 	if(!fexists(SERVICE_PR_TEST_JSON))
 		return
-	var/list/json = json_decode(wrap_file2text(SERVICE_PR_TEST_JSON))
+	var/list/json = json_decode(WRAP_FILE2TEXT(SERVICE_PR_TEST_JSON))
 	if(!json)
 		return
 	for(var/I in json)

--- a/code/modules/tgs/v4/api.dm
+++ b/code/modules/tgs/v4/api.dm
@@ -58,7 +58,7 @@
 	if(!json_path)
 		TGS_ERROR_LOG("Missing [TGS4_PARAM_INFO_JSON] world parameter!")
 		return
-	var/json_file = wrap_file2text(json_path)
+	var/json_file = WRAP_FILE2TEXT(json_path)
 	if(!json_file)
 		TGS_ERROR_LOG("Missing specified json file: [json_path]")
 		return
@@ -291,7 +291,7 @@
 /datum/tgs_api/v4/ChatChannelInfo()
 	. = list()
 	//no caching cause tgs may change this
-	var/list/json = json_decode(wrap_file2text(chat_channels_json_path))
+	var/list/json = json_decode(WRAP_FILE2TEXT(chat_channels_json_path))
 	for(var/I in json)
 		. += DecodeChannel(I)
 

--- a/code/modules/tgs/v5/api.dm
+++ b/code/modules/tgs/v5/api.dm
@@ -241,7 +241,7 @@
 		TGS_ERROR_LOG("Failed export request: [json]")
 		return
 
-	var/response_json = wrap_file2text(export_response["CONTENT"])
+	var/response_json = WRAP_FILE2TEXT(export_response["CONTENT"])
 	if(!response_json)
 		TGS_ERROR_LOG("Failed export request, missing content!")
 		return

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -42,7 +42,7 @@ Notes:
 /datum/tooltip/New(client/C)
 	if(C)
 		owner = C
-		owner << browse(wrap_file2text(file), "window=[control]")
+		owner << browse(WRAP_FILE2TEXT(file), "window=[control]")
 
 	..()
 


### PR DESCRIPTION

## Что этот ПР делает
Невозможность договориться о правах для доступа ко многим логам в логисе с Азизом (игнор), невозможность посмотреть логи рекурсий, невозможность просмотра логов кудела, невозможность адекватно воспринимать некоторые баги из рантаймов. R_DEBUG выдаётся самым здравым с самыми надроченными + добавлено логирование на конкретные файлы, что открывает человек. Факт того, что в педалях регулярно сидят трапы, друзья друзей, инфобезы доксящие людей, извращенцы и т.д. и т.п. с инструментариев GeoIP и логированием CID и IP, полностью невелирует любые претензии к доступу к этой информации у людей, что поддерживают/разрабатывают хагбокс для этих самых выше перечисленных.

Также проки защиты от проккола заменены на обычные макросы обертки, что уже позволяет защититься от проккола. Добавлена поддержка `json` и `gz` логов.

## Почему это хорошо для игры
Логи для разработчиков.

## Список изменений
:cl:
admin: Добавлен верб, позволяющий смотреть файлы логов текущего раунда. Добавлена возможность скачивать всю папку с логами.
admin: Позволяет смотреть логи обладателям флага R_DEBUG.
admin: Добавлено логирование тех, кто взаимодействовал с файлами логов. Добавлена поддержка json логов.
/:cl:
