### PR TITLE
Фикс консоли карго

### DIFF
--- a/code/controllers/subsystem/capitalism.dm
+++ b/code/controllers/subsystem/capitalism.dm
@@ -10,6 +10,9 @@ SUBSYSTEM_DEF(capitalism)
 	dependencies = list(
 		/datum/controller/subsystem/mapping,
 	)
+	dependents = list(
+		/datum/controller/subsystem/shuttle,
+	)
 	runlevels = RUNLEVEL_GAME
 	wait = 5 MINUTES
 	ss_flags = SS_BACKGROUND | SS_KEEP_TIMING

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -8,6 +8,7 @@ SUBSYSTEM_DEF(shuttle)
 		/datum/controller/subsystem/mapping,
 		/datum/controller/subsystem/atoms,
 		/datum/controller/subsystem/air,
+		/datum/controller/subsystem/capitalism,
 	)
 	ss_flags = SS_KEEP_TIMING
 	runlevels = RUNLEVEL_SETUP | RUNLEVEL_GAME

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -8,7 +8,6 @@ SUBSYSTEM_DEF(shuttle)
 		/datum/controller/subsystem/mapping,
 		/datum/controller/subsystem/atoms,
 		/datum/controller/subsystem/air,
-		/datum/controller/subsystem/capitalism,
 	)
 	ss_flags = SS_KEEP_TIMING
 	runlevels = RUNLEVEL_SETUP | RUNLEVEL_GAME


### PR DESCRIPTION

## Что этот ПР делает
Капитализм теперь загружается перед шаттлами, чтобы успели сгенерироваться все аккаунты
## Список изменений
:cl:
bugfix: Исправлен баг с синим экраном у консоли карго.
/:cl:
