### PR TITLE
Singularity act & pull cleanup + fix callback COMSIG_TURF_CHANGE

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_x_act.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_x_act.dm
@@ -22,7 +22,7 @@
 #define COMSIG_ATOM_NARSIE_ACT "atom_narsie_act"
 ///from base of atom/rcd_act(): (/mob, /obj/item/construction/rcd, passed_mode)
 #define COMSIG_ATOM_RCD_ACT "atom_rcd_act"
-///from base of atom/singularity_pull(): (S, current_size)
+///from base of atom/singularity_pull(): (/atom, current_size)
 #define COMSIG_ATOM_SING_PULL "atom_sing_pull"
 ///from obj/machinery/bsa/full/proc/fire(): ()
 #define COMSIG_ATOM_BSA_BEAM "atom_bsa_beam_pass"

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -280,9 +280,12 @@ GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(
 #define ismodcore(A) istype(A, /obj/item/mod/core)
 
 GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
-	/turf/space,
+	/turf/simulated/floor/beach/water,
 	/turf/simulated/floor/chasm,
+	/turf/simulated/floor/lava,
 	/turf/simulated/openspace,
+	/turf/space,
+	/turf/space/openspace,
 )))
 
 #define isgroundlessturf(A) (is_type_in_typecache(A, GLOB.turfs_without_ground))

--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -74,7 +74,7 @@
 /// it calls Entered() on all of its moveable contents, which will invoke on_source_entering(), which will register each elevating
 /// object with the new turf. We need to do this because turfs do not keep their traits when changed, and so the check for
 /// TRAIT_TURF_HAS_ELEVATED_OBJ above will fail and cause override runtimes when we attempt to register the signals again.
-/datum/element/elevation/proc/pre_change_turf(turf/changed, path, list/new_baseturfs, flags, list/post_change_callbacks)
+/datum/element/elevation/proc/pre_change_turf(turf/changed, path, list/post_change_callbacks)
 	SIGNAL_HANDLER
 	for(var/atom/movable/content as anything in changed)
 		if(HAS_TRAIT_FROM(content, TRAIT_ELEVATING_OBJECT, UNIQUE_TRAIT_SOURCE(src)))

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -6,7 +6,7 @@
 /obj/effect/proc_holder/singularity_act()
 	return
 
-/obj/effect/proc_holder/singularity_pull()
+/obj/effect/proc_holder/singularity_pull(atom/singularity, current_size)
 	return
 
 GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell))

--- a/code/datums/spells/spacetime_dist.dm
+++ b/code/datums/spells/spacetime_dist.dm
@@ -95,7 +95,7 @@
 /obj/effect/cross_action/singularity_act()
 	return
 
-/obj/effect/cross_action/singularity_pull()
+/obj/effect/cross_action/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/cross_action/spacetime_dist/proc/walk_link(atom/movable/AM)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1155,7 +1155,7 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
  *
  * Default behaviour is to send [COMSIG_ATOM_SING_PULL] and return
  */
-/atom/proc/singularity_pull(obj/singularity/singularity, current_size)
+/atom/proc/singularity_pull(atom/singularity, current_size)
 	SEND_SIGNAL(src, COMSIG_ATOM_SING_PULL, singularity, current_size)
 
 /**

--- a/code/game/gamemodes/clockwork/clockwork_misc.dm
+++ b/code/game/gamemodes/clockwork/clockwork_misc.dm
@@ -31,16 +31,13 @@
 /obj/effect/clockwork/overlay/singularity_act()
 	return
 
-/obj/effect/clockwork/overlay/singularity_pull()
-	return
-
-/obj/effect/clockwork/overlay/singularity_pull(S, current_size)
+/obj/effect/clockwork/overlay/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/clockwork/overlay/Destroy()
 	if(linked)
 		linked = null
-	. = ..()
+	return ..()
 
 /obj/effect/clockwork/overlay/wall
 	name = "clockwork wall"

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -334,7 +334,7 @@ GLOBAL_LIST_INIT(blacklisted_pylon_turfs, typecacheof(list(
 /obj/effect/gateway/singularity_act()
 	return
 
-/obj/effect/gateway/singularity_pull()
+/obj/effect/gateway/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/gateway/Bumped(atom/movable/moving_atom)

--- a/code/game/gamemodes/miniantags/demons/pulse_demon/pulse_demon.dm
+++ b/code/game/gamemodes/miniantags/demons/pulse_demon/pulse_demon.dm
@@ -849,7 +849,7 @@
 /mob/living/simple_animal/demon/pulse_demon/experience_pressure_difference(flow_x, flow_y)
 	return // Immune to gas flow.
 
-/mob/living/simple_animal/demon/pulse_demon/singularity_pull()
+/mob/living/simple_animal/demon/pulse_demon/singularity_pull(atom/singularity, current_size)
 	return
 
 /mob/living/simple_animal/demon/pulse_demon/mob_negates_gravity()

--- a/code/game/gamemodes/miniantags/guardian/types/ranged.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/ranged.dm
@@ -138,6 +138,6 @@
 /obj/effect/snare/singularity_act()
 	return
 
-/obj/effect/snare/singularity_pull()
+/obj/effect/snare/singularity_pull(atom/singularity, current_size)
 	return
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -119,10 +119,10 @@
 	view_range = num
 	GLOB.cameranet.updateVisibility(src, opacity_check = FALSE)
 
-/obj/machinery/camera/singularity_pull(S, current_size)
+/obj/machinery/camera/singularity_pull(atom/singularity, current_size)
 	if(status && current_size >= STAGE_FIVE) // If the singulo is strong enough to pull anchored objects and the camera is still active, turn off the camera as it gets ripped off the wall.
 		toggle_cam(null, 0)
-	..()
+	return ..()
 
 /obj/machinery/camera/attackby(obj/item/I, mob/living/user, params)
 	if(user.a_intent == INTENT_HARM)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -240,10 +240,10 @@ GLOBAL_LIST_EMPTY(firealarms)
 			if(prob(33))
 				alarm()
 
-/obj/machinery/firealarm/singularity_pull(S, current_size)
+/obj/machinery/firealarm/singularity_pull(atom/singularity, current_size)
 	if(current_size >= STAGE_FIVE) // If the singulo is strong enough to pull anchored objects, the fire alarm experiences integrity failure
 		deconstruct()
-	..()
+	return ..()
 
 /obj/machinery/firealarm/obj_break(damage_flag)
 	if(!(stat & BROKEN) && !(obj_flags & NODECONSTRUCT) && buildstage != 0) //can't break the electronics if there isn't any inside.

--- a/code/game/objects/effects/bump_teleporter.dm
+++ b/code/game/objects/effects/bump_teleporter.dm
@@ -11,7 +11,7 @@ GLOBAL_LIST_EMPTY(bump_teleporters)
 
 /obj/effect/bump_teleporter/Initialize(mapload)
 	. = ..()
-	
+
 	GLOB.bump_teleporters += src
 
 /obj/effect/bump_teleporter/Destroy()
@@ -21,7 +21,7 @@ GLOBAL_LIST_EMPTY(bump_teleporters)
 /obj/effect/bump_teleporter/singularity_act()
 	return
 
-/obj/effect/bump_teleporter/singularity_pull()
+/obj/effect/bump_teleporter/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/bump_teleporter/Bumped(atom/movable/moving_atom)

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -205,9 +205,6 @@
 	color = "#D5820B"
 	scoop_reagents = list("fungus" = 10)
 
-/obj/effect/decal/cleanable/fungus/never_should_have_come_here(turf/here_turf)
-	return FALSE
-
 /obj/effect/decal/cleanable/confetti //PARTY TIME!
 	name = "confetti"
 	desc = "Party time!"

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -19,7 +19,7 @@
 		 * Someday, someone will definitely clean it up to the end.
 		 */
 		//if(mapload)
-		//	stack_trace("[name] spawned in a bad turf ([loc]) at [AREACOORD(src)] in [get_area(src)]. Please remove it or allow it to pass never_should_have_come_here if it's intended.")
+		//	stack_trace("[name] spawned in a bad turf ([loc]) at [AREACOORD(src)] in [get_area(src)]. Please remove it or allow it to pass `never_should_have_come_here` if it's intended.")
 		return INITIALIZE_HINT_QDEL
 
 	var/static/list/loc_connections = list(
@@ -44,7 +44,7 @@
 /obj/effect/decal/proc/never_should_have_come_here(turf/here_turf)
 	return isclosedturf(here_turf) || (isgroundlessturf(here_turf) && !GET_TURF_BELOW(here_turf))
 
-/obj/effect/decal/proc/on_decal_move(turf/changed, path, list/new_baseturfs, flags, list/post_change_callbacks)
+/obj/effect/decal/proc/on_decal_move(turf/changed, path, list/post_change_callbacks)
 	SIGNAL_HANDLER
 	post_change_callbacks += CALLBACK(src, PROC_REF(sanity_check_self))
 

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -42,7 +42,7 @@
 
 /// Checks if we are allowed to be in `here_turf`, and returns that result. Subtypes should override this when necessary.
 /obj/effect/decal/proc/never_should_have_come_here(turf/here_turf)
-	return iswallturf(here_turf) || ismineralturf(here_turf) || (isgroundlessturf(here_turf) && !GET_TURF_BELOW(here_turf))
+	return isclosedturf(here_turf) || (isgroundlessturf(here_turf) && !GET_TURF_BELOW(here_turf))
 
 /obj/effect/decal/proc/on_decal_move(turf/changed, path, list/new_baseturfs, flags, list/post_change_callbacks)
 	SIGNAL_HANDLER

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -4,20 +4,23 @@
 	abstract_type = /obj/effect
 	icon = 'icons/effects/effects.dmi'
 	obj_flags = IGNORE_HITS
-	resistance_flags = INDESTRUCTIBLE|LAVA_PROOF|FIRE_PROOF|UNACIDABLE|ACID_PROOF|FREEZE_PROOF
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	move_resist = INFINITY
 	anchored = TRUE
 
 /obj/effect/add_debris_element()
 	return // They're not hittable, and prevents recursions.
 
+/obj/effect/attack_generic(mob/user, damage_amount, damage_type, damage_flag, sound_effect, armor_penetration)
+	return
+
 /obj/effect/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	return
 
 /obj/effect/singularity_act()
-	if(!QDELETED(src))
-		qdel(src)
-	return FALSE
+	if(QDELETED(src))
+		return
+	qdel(src)
 
 /obj/effect/fire_act(exposed_temperature, exposed_volume)
 	return
@@ -31,7 +34,7 @@
 /obj/effect/mech_melee_attack(obj/mecha/mech, obj/item/mecha_parts/mecha_equipment/selected_module = null)
 	return FALSE
 
-/obj/effect/blob_act(obj/structure/blob/B)
+/obj/effect/blob_act(obj/structure/blob/blob)
 	return
 
 /obj/effect/experience_pressure_difference(flow_x, flow_y)
@@ -61,6 +64,7 @@
  * The object should be immune to all forms of damage, or things that can delete it, such as the singularity, or explosions.
  */
 /obj/effect/abstract
+	abstract_type = /obj/effect/abstract
 	name = "Abstract object"
 	invisibility = INVISIBILITY_ABSTRACT
 	layer = TURF_LAYER
@@ -81,11 +85,14 @@
 /obj/effect/abstract/zap_act()
 	return
 
+/obj/effect/abstract/singularity_pull(atom/singularity, current_size)
+	return
+
 /obj/effect/abstract/singularity_act()
 	return
 
-/obj/effect/abstract/get_gravity()
-	return
+/obj/effect/abstract/get_gravity(turf/gravity_turf)
+	return FALSE
 
 /obj/effect/abstract/narsie_act()
 	return
@@ -104,6 +111,3 @@
 
 /obj/effect/abstract/fire_act(exposed_temperature, exposed_volume)
 	return
-
-/obj/effect/abstract/get_gravity(turf/gravity_turf)
-	return FALSE

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -21,7 +21,7 @@
 /obj/effect/landmark/ex_act()
 	return
 
-/obj/effect/landmark/singularity_pull()
+/obj/effect/landmark/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/landmark/singularity_act()

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -5,7 +5,7 @@
 /obj/effect/overlay/singularity_act()
 	return
 
-/obj/effect/overlay/singularity_pull()
+/obj/effect/overlay/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/overlay/beam//Not actually a projectile, just an effect.

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -86,7 +86,7 @@
 	underlays.Cut()
 	underlays += emissive_appearance(icon, "[base_icon_state]_lightmask", src)
 
-/obj/effect/portal/singularity_pull()
+/obj/effect/portal/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/portal/singularity_act()

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -33,7 +33,7 @@
 /obj/effect/step_trigger/singularity_act()
 	return
 
-/obj/effect/step_trigger/singularity_pull()
+/obj/effect/step_trigger/singularity_pull(atom/singularity, current_size)
 	return
 
 /* Sends a message to mob when triggered*/

--- a/code/game/objects/effects/temporary_visuals/temporary_visual.dm
+++ b/code/game/objects/effects/temporary_visuals/temporary_visual.dm
@@ -24,7 +24,7 @@
 /obj/effect/temp_visual/singularity_act()
 	return
 
-/obj/effect/temp_visual/singularity_pull()
+/obj/effect/temp_visual/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/temp_visual/ex_act()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1040,10 +1040,10 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/g
 	else
 		target.apply_damage(7)
 
-/obj/item/singularity_pull(S, current_size)
+/obj/item/singularity_pull(atom/singularity, current_size)
 	..()
 	if(current_size >= STAGE_FOUR)
-		throw_at(S, 14, 3, spin = 0)
+		throw_at(singularity, 14, 3, spin = 0)
 	else
 		return
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -260,7 +260,7 @@
 	extinguish()
 	acid_level = 0
 
-/obj/singularity_pull(singularity, current_size)
+/obj/singularity_pull(atom/singularity, current_size)
 	..()
 	if(move_resist == INFINITY)
 		return

--- a/code/game/objects/structures/crates_lockers/closet.dm
+++ b/code/game/objects/structures/crates_lockers/closet.dm
@@ -738,7 +738,7 @@ GLOBAL_LIST_EMPTY(closets)
 
 /obj/structure/closet/singularity_act()
 	dump_contents()
-	..()
+	return ..()
 
 /obj/structure/closet/AllowDrop()
 	return TRUE

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -70,7 +70,7 @@
 	else	//wtf make your ladders properly assholes
 		icon_state = "ladder00"
 
-/obj/structure/ladder/singularity_pull()
+/obj/structure/ladder/singularity_pull(atom/singularity, current_size)
 	if(!(resistance_flags & INDESTRUCTIBLE))
 		visible_message(span_danger("[src] is torn to pieces by the gravitational pull!"))
 		qdel(src)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -65,7 +65,7 @@
 /obj/structure/lattice/blob_act(obj/structure/blob/B)
 	return
 
-/obj/structure/lattice/singularity_pull(S, current_size)
+/obj/structure/lattice/singularity_pull(atom/singularity, current_size)
 	if(current_size >= STAGE_FOUR)
 		deconstruct()
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -166,8 +166,10 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 /obj/structure/window/rpd_act(mob/user, obj/item/rpd/our_rpd, mode)
 	return
 
-/obj/structure/window/singularity_pull(S, current_size)
+/obj/structure/window/singularity_pull(atom/singularity, current_size)
 	..()
+	if(anchored && current_size >= STAGE_TWO)
+		set_anchored(FALSE)
 	if(current_size >= STAGE_FIVE)
 		deconstruct(FALSE)
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -113,7 +113,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 		return FALSE
 	return TRUE
 
-/turf/simulated/floor/blob_act(obj/structure/blob/B)
+/turf/simulated/floor/blob_act(obj/structure/blob/blob)
 	return
 
 /turf/simulated/floor/update_overlays()
@@ -144,7 +144,8 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	if(temperature > FIRE_MINIMUM_TEMPERATURE_TO_EXIST && prob(1))
 		burn_tile()
 
-/turf/simulated/floor/proc/make_plating(make_floor_tile, mob/user)	// Set `make_floor_tile` to FALSE, if `floor_tile` have another drop logic before calling this proc.
+/// Set `make_floor_tile` to FALSE, if `floor_tile` have another drop logic before calling this proc.
+/turf/simulated/floor/proc/make_plating(make_floor_tile, mob/user)
 	if(make_floor_tile && floor_tile && !broken && !burnt)
 		var/obj/item/stack/stack_dropped = new floor_tile(src)
 		if(user)
@@ -261,7 +262,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 			to_chat(user, span_danger("You remove the floor tile."))
 	return make_plating(make_tile, user)
 
-/turf/simulated/floor/singularity_pull(S, current_size)
+/turf/simulated/floor/singularity_pull(atom/singularity, current_size)
 	..()
 	if(current_size == STAGE_THREE)
 		if(prob(30))

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -141,7 +141,7 @@
 /turf/simulated/floor/chasm/singularity_act()
 	return
 
-/turf/simulated/floor/chasm/singularity_pull(S, current_size)
+/turf/simulated/floor/chasm/singularity_pull(atom/singularity, current_size)
 	return
 
 /turf/simulated/floor/chasm/crowbar_act()

--- a/code/game/turfs/simulated/floor/indestructible.dm
+++ b/code/game/turfs/simulated/floor/indestructible.dm
@@ -10,7 +10,7 @@
 /turf/simulated/floor/indestructible/singularity_act()
 	return
 
-/turf/simulated/floor/indestructible/singularity_pull(S, current_size)
+/turf/simulated/floor/indestructible/singularity_pull(atom/singularity, current_size)
 	return
 
 /turf/simulated/floor/indestructible/narsie_act()

--- a/code/game/turfs/simulated/floor/lava.dm
+++ b/code/game/turfs/simulated/floor/lava.dm
@@ -75,7 +75,7 @@
 /turf/simulated/floor/lava/singularity_act()
 	return
 
-/turf/simulated/floor/lava/singularity_pull(S, current_size)
+/turf/simulated/floor/lava/singularity_pull(atom/singularity, current_size)
 	return
 
 /turf/simulated/floor/lava/make_plating()

--- a/code/game/turfs/simulated/floor/reinforced_floor.dm
+++ b/code/game/turfs/simulated/floor/reinforced_floor.dm
@@ -162,7 +162,8 @@
 	nitrogen = 0
 	temperature = 716
 
-/turf/simulated/floor/engine/singularity_pull(S, current_size)
+/turf/simulated/floor/engine/singularity_pull(atom/singularity, current_size)
+	..()
 	if(current_size >= STAGE_FIVE)
 		if(floor_tile)
 			if(prob(30))

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -32,7 +32,7 @@
 /turf/simulated/wall/shuttle/singularity_act()
 	return
 
-/turf/simulated/wall/shuttle/singularity_pull(S, current_size)
+/turf/simulated/wall/shuttle/singularity_pull(atom/singularity, current_size)
 	return
 
 /turf/simulated/wall/shuttle/burn_down()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -556,7 +556,7 @@
 		return TRUE
 	return FALSE
 
-/turf/simulated/wall/singularity_pull(S, current_size)
+/turf/simulated/wall/singularity_pull(atom/singularity, current_size)
 	..()
 	wall_singularity_pull(current_size)
 

--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -24,7 +24,7 @@
 /turf/simulated/wall/indestructible/singularity_act()
 	return
 
-/turf/simulated/wall/indestructible/singularity_pull(S, current_size)
+/turf/simulated/wall/indestructible/singularity_pull(atom/singularity, current_size)
 	return
 
 /turf/simulated/wall/indestructible/narsie_act()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -605,11 +605,11 @@
 	faller.drop_from_hands()
 
 /turf/singularity_act()
-	if(intact)
+	if(underfloor_accessibility < UNDERFLOOR_INTERACTABLE)
 		for(var/obj/on_top in contents) //this is for deleting things like wires contained in the turf
 			if(on_top.level != 1)
 				continue
-			if(on_top.invisibility in list(INVISIBILITY_MAXIMUM, INVISIBILITY_ABSTRACT))
+			if(HAS_TRAIT(on_top, TRAIT_UNDERFLOOR))
 				on_top.singularity_act()
 	ChangeTurf(baseturf)
 	return 2
@@ -1113,13 +1113,13 @@
 	// No, I don't think I will.
 	return FALSE
 
-/obj/effect/abstract/pressure_overlay/singularity_pull()
+/obj/effect/abstract/pressure_overlay/singularity_pull(atom/singularity, current_size)
 	// I am not a physical object, you have no control over me!
-	return FALSE
+	return
 
 /obj/effect/abstract/pressure_overlay/singularity_act()
 	// I don't taste good, either!
-	return FALSE
+	return
 
 /turf/proc/ensure_pressure_overlay()
 	if(isnull(pressure_overlay))

--- a/code/modules/antagonists/bingle/bingle_pit.dm
+++ b/code/modules/antagonists/bingle/bingle_pit.dm
@@ -566,13 +566,10 @@
 /obj/structure/bingle_hole/singularity_act()
 	return
 
-/obj/structure/bingle_hole/singularity_pull(obj/singularity/S, current_size)
+/obj/structure/bingle_hole/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/structure/bingle_pit_overlay/singularity_act()
-	return
-
-/obj/structure/bingle_hole/singularity_pull(obj/singularity/S, current_size)
 	return
 
 /area/misc/bingle_pit

--- a/code/modules/atmospherics/enviromental/LINDA_fire.dm
+++ b/code/modules/atmospherics/enviromental/LINDA_fire.dm
@@ -200,7 +200,7 @@
 	if(istype(entered))
 		entered.fire_act()
 
-/obj/effect/hotspot/singularity_pull()
+/obj/effect/hotspot/singularity_pull(atom/singularity, current_size)
 	return
 
 /// Largely for the fireflash procs below
@@ -209,7 +209,7 @@
 
 /obj/effect/hotspot/fake/Initialize(mapload)
 	. = ..()
-	
+
 	if(burn_time)
 		QDEL_IN(src, burn_time)
 

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -421,7 +421,7 @@ Pipelines + Other Objects -> Pipe network
 		else
 			underlays += SSair.icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "retracted" + icon_connect_type)
 
-/obj/machinery/atmospherics/singularity_pull(S, current_size)
+/obj/machinery/atmospherics/singularity_pull(atom/singularity, current_size)
 	if(current_size >= STAGE_FIVE)
 		deconstruct(FALSE)
 	return ..()

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -108,8 +108,10 @@ Thus, the two variables affect pump operation are set in New():
 	var/datum/gas_mixture/removed = air1.remove(transfer_moles)
 	air2.merge(removed)
 
-	parent1.update = TRUE
-	parent2.update = TRUE
+	if(parent1)
+		parent1.update = TRUE
+	if(parent2)
+		parent2.update = TRUE
 
 	return TRUE
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/temperature_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/temperature_gate.dm
@@ -71,8 +71,10 @@
 	if(removed && removed.total_moles() > 0)
 		air2.merge(removed)
 
-	parent1.update = TRUE
-	parent2.update = TRUE
+	if(parent1)
+		parent1.update = TRUE
+	if(parent2)
+		parent2.update = TRUE
 
 	return TRUE
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -95,8 +95,10 @@ Thus, the two variables affect pump operation are set in New():
 
 	air2.merge(removed)
 
-	parent1.update = TRUE
-	parent2.update = TRUE
+	if(parent1)
+		parent1.update = TRUE
+	if(parent2)
+		parent2.update = TRUE
 
 	return FALSE
 

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -140,11 +140,10 @@
 		new /obj/item/pipe_meter(loc)
 	qdel(src)
 
-/obj/machinery/atmospherics/meter/singularity_pull(S, current_size)
+/obj/machinery/atmospherics/meter/singularity_pull(atom/singularity, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)
 		deconstruct()
-
 
 /obj/item/circuit_component/atmos_meter
 	display_name = "Атмосферный измеритель"

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -183,7 +183,7 @@
 /obj/effect/chronos_cam/singularity_act()
 	return
 
-/obj/effect/chronos_cam/singularity_pull()
+/obj/effect/chronos_cam/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/chronos_cam/relaymove(mob/user, direction)

--- a/code/modules/countdown/countdown.dm
+++ b/code/modules/countdown/countdown.dm
@@ -76,7 +76,7 @@
 /obj/effect/countdown/ex_act(severity, target) //immune to explosions
 	return
 
-/obj/effect/countdown/singularity_pull()
+/obj/effect/countdown/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/countdown/singularity_act()

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -221,7 +221,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/singularity_act()
 	return
 
-/obj/effect/immovablerod/singularity_pull()
+/obj/effect/immovablerod/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/immovablerod/Process_Spacemove(movement_dir = NONE, continuous_move = FALSE)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -152,7 +152,7 @@
 	if(prob(20))
 		ChangeTurf(baseturf) //nar sie eats this shit
 
-/turf/simulated/floor/vines/singularity_pull(S, current_size)
+/turf/simulated/floor/vines/singularity_pull(atom/singularity, current_size)
 	if(current_size >= STAGE_FIVE)
 		if(prob(50))
 			ChangeTurf(baseturf)
@@ -632,7 +632,7 @@
 /obj/structure/spacevine_controller/singularity_act()
 	return
 
-/obj/structure/spacevine_controller/singularity_pull()
+/obj/structure/spacevine_controller/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/structure/spacevine_controller/Destroy()

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_INIT(major_hallutinations, list("fake"=20,"death"=10,"xeno"=10,"sing
 	target = null
 	. = ..()
 
-/obj/effect/hallucination/singularity_pull()
+/obj/effect/hallucination/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/hallucination/singularity_act()

--- a/code/modules/hallucination/_hallucination.dm
+++ b/code/modules/hallucination/_hallucination.dm
@@ -115,7 +115,7 @@
 		return
 	regenerate_image()
 
-/obj/effect/client_image_holder/singularity_pull()
+/obj/effect/client_image_holder/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/client_image_holder/singularity_act()

--- a/code/modules/lighting/lighting_emissive_blocker.dm
+++ b/code/modules/lighting/lighting_emissive_blocker.dm
@@ -35,7 +35,7 @@
 /atom/movable/emissive_blocker/singularity_act()
 	return
 
-/atom/movable/emissive_blocker/singularity_pull()
+/atom/movable/emissive_blocker/singularity_pull(atom/singularity, current_size)
 	return
 
 /atom/movable/emissive_blocker/blob_act()

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -118,7 +118,7 @@ GLOBAL_LIST_EMPTY(default_lighting_underlays_by_z)
 /atom/movable/lighting_object/singularity_act()
 	return
 
-/atom/movable/lighting_object/singularity_pull()
+/atom/movable/lighting_object/singularity_pull(atom/singularity, current_size)
 	return
 
 /atom/movable/lighting_object/blob_act(obj/structure/blob/B)

--- a/code/modules/lootpanel/search_object.dm
+++ b/code/modules/lootpanel/search_object.dm
@@ -84,7 +84,7 @@
 	qdel(src)
 
 /// Parent tile has been altered, entire search needs reset
-/datum/search_object/proc/on_turf_change(turf/source, path, list/new_baseturfs, flags, list/post_change_callbacks)
+/datum/search_object/proc/on_turf_change(turf/source, path, list/post_change_callbacks)
 	SIGNAL_HANDLER
 
 	post_change_callbacks += CALLBACK(src, GLOBAL_PROC_REF(qdel), src)

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -244,5 +244,5 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 /obj/effect/extraction_holder/singularity_act()
 	return
 
-/obj/effect/extraction_holder/singularity_pull()
+/obj/effect/extraction_holder/singularity_pull(atom/singularity, current_size)
 	return

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -520,8 +520,8 @@
 /obj/effect/immortality_talisman/singularity_act()
 	return
 
-/obj/effect/immortality_talisman/singularity_pull()
-	return 0
+/obj/effect/immortality_talisman/singularity_pull(atom/singularity, current_size)
+	return
 
 /obj/effect/immortality_talisman/Destroy(force)
 	if(!can_destroy && !force)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -20,7 +20,7 @@
 	. = ..()
 	icon_state = null
 
-/obj/effect/light_emitter/singularity_pull()
+/obj/effect/light_emitter/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/light_emitter/singularity_act()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1525,25 +1525,28 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 	return threatcount
 
+// Overrides the point value that the mob is worth
 /mob/living/carbon/human/singularity_act()
 	. = 20
-	if(mind)
-		if((mind.assigned_role == JOB_TITLE_ENGINEER) || (mind.assigned_role == JOB_TITLE_CHIEF_ENGINEER))
+	switch(mind?.assigned_role)
+		if(JOB_TITLE_ENGINEER, JOB_TITLE_CHIEF_ENGINEER)
 			. = 100
-		if(mind.assigned_role == JOB_TITLE_ENGINEER_TRAINEE)	//Чем глупее, тем вкуснее
+		if(JOB_TITLE_ENGINEER_TRAINEE) // The stupider, the tastier
 			. = 300
-		if(mind.assigned_role == JOB_TITLE_CLOWN)
+		if(JOB_TITLE_CLOWN)
 			. = rand(-1000, 1000)
-	..() //Called afterwards because getting the mind after getting gibbed is sketchy
+	..() // Called afterwards because getting the mind after getting gibbed is sketchy
 
-/mob/living/carbon/human/singularity_pull(S, current_size)
+/mob/living/carbon/human/singularity_pull(atom/singularity, current_size)
 	..()
-	if(current_size >= STAGE_THREE)
-		var/list/handlist = list(l_hand, r_hand)
-		for(var/obj/item/hand_item in handlist)
-			if(prob(current_size * 5) && hand_item.w_class >= ((11-current_size)/2)	&& drop_item_ground(hand_item))
-				step_towards(hand_item, src)
-				to_chat(src, span_warning("[S] вырывает [hand_item.declent_ru(ACCUSATIVE)] из вашей хватки!"))
+	if(current_size < STAGE_THREE)
+		return
+	var/list/handlist = list(l_hand, r_hand)
+	for(var/obj/item/hand_item in handlist)
+		if(!prob(current_size * 5) || hand_item.w_class < ((11 - current_size) / 2) || !drop_item_ground(hand_item))
+			continue
+		step_towards(hand_item, src)
+		to_chat(src, span_warning("[singularity.declent_ru(NOMINATIVE)] вырывает [hand_item.declent_ru(ACCUSATIVE)] из вашей хватки!"))
 
 /mob/living/carbon/human/narsie_act(obj/god/narsie)
 	if(iswizard(src) && iscultist(src)) //Wizard cultists are immune to narsie because it would prematurely end the wiz round that's about to end by the automated shuttle call anyway

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1331,11 +1331,12 @@
 	return HEARING_PROTECTION_NONE
 
 /mob/living/singularity_act()
-	investigate_log("([key_name_log(src)]) has been consumed by the singularity.", INVESTIGATE_ENGINE) //Oh that's where the clown ended up!
+	investigate_log("has been consumed by the singularity.", INVESTIGATE_ENGINE) //Oh that's where the clown ended up!
+	investigate_log("has been gibbed by the singularity.", INVESTIGATE_DEATHS)
 	gib()
 	return 20
 
-/mob/living/singularity_pull(singularity, current_size)
+/mob/living/singularity_pull(atom/singularity, current_size)
 	..()
 	if(move_resist == INFINITY)
 		return

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -222,10 +222,11 @@
 	else
 		return FALSE
 
-/obj/structure/cable/singularity_pull(S, current_size)
+/obj/structure/cable/singularity_pull(atom/singularity, current_size)
 	..()
-	if(current_size >= STAGE_FIVE)
-		deconstruct()
+	if(current_size < STAGE_FIVE)
+		return
+	deconstruct()
 
 /obj/structure/cable/proc/cable_color(colorC)
 	if(!colorC)

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -75,7 +75,7 @@
 /obj/effect/accelerated_particle/ex_act(severity, target)
 	qdel(src)
 
-/obj/effect/accelerated_particle/singularity_pull()
+/obj/effect/accelerated_particle/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/effect/accelerated_particle/proc/propagate()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -283,8 +283,8 @@
 	// Add this to SM psi coefficient on hit for lasers
 	var/psi_change
 
-/obj/projectile/beam/emitter/singularity_pull()
-	return //don't want the emitters to miss
+/obj/projectile/beam/emitter/singularity_pull(atom/singularity, current_size)
+	return // don't want the emitters to miss
 
 /obj/projectile/beam/emitter/hitscan/bluelens
 	name = "electrodisruptive beam"

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -124,10 +124,11 @@
 		trunk = null
 	return ..()
 
-/obj/machinery/disposal/singularity_pull(S, current_size)
+/obj/machinery/disposal/singularity_pull(atom/singularity, current_size)
 	..()
-	if(current_size >= STAGE_FIVE)
-		deconstruct()
+	if(current_size < STAGE_FIVE)
+		return
+	deconstruct()
 
 //This proc returns TRUE if the item can be picked up and FALSE if it can't.
 //Set the stop_messages to stop it from printing messages

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -120,10 +120,11 @@
 	holder.vent_gas(expel_to)
 	qdel(holder)
 
-/obj/structure/disposalpipe/singularity_pull(S, current_size)
+/obj/structure/disposalpipe/singularity_pull(atom/singularity, current_size)
 	..()
-	if(current_size >= STAGE_FIVE)
-		deconstruct()
+	if(current_size < STAGE_FIVE)
+		return
+	deconstruct()
 
 // pipe affected by explosion
 /obj/structure/disposalpipe/ex_act(severity, target)

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -68,8 +68,8 @@
 	else
 		return QDEL_HINT_LETMELIVE
 
-/obj/structure/necropolis_gate/singularity_pull()
-	return 0
+/obj/structure/necropolis_gate/singularity_pull(atom/singularity, current_size)
+	return
 
 /obj/structure/necropolis_gate/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
@@ -102,8 +102,8 @@
 	opacity = TRUE
 	anchored = TRUE
 
-/obj/structure/opacity_blocker/singularity_pull()
-	return 0
+/obj/structure/opacity_blocker/singularity_pull(atom/singularity, current_size)
+	return
 
 /obj/structure/opacity_blocker/Destroy(force)
 	if(force)
@@ -275,8 +275,8 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 	top_overlay.layer = EDGED_TURF_LAYER
 	add_overlay(top_overlay)
 
-/obj/structure/necropolis_arch/singularity_pull()
-	return 0
+/obj/structure/necropolis_arch/singularity_pull(atom/singularity, current_size)
+	return
 
 /obj/structure/necropolis_arch/Destroy(force)
 	if(force)
@@ -341,7 +341,7 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 	else
 		return QDEL_HINT_LETMELIVE
 
-/obj/structure/stone_tile/singularity_pull()
+/obj/structure/stone_tile/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/structure/stone_tile/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -42,7 +42,7 @@
 /obj/docking_port/take_damage()
 	return
 
-/obj/docking_port/singularity_pull()
+/obj/docking_port/singularity_pull(atom/singularity, current_size)
 	return
 
 /obj/docking_port/singularity_act()


### PR DESCRIPTION

## Что этот ПР делает
Копипаст колбэков с ТГ для сигнала COMSIG_TURF_CHANGE вызывал неправильную работу чейндж турфов. 
Помимо удаления декалей вероятно пофиксилась лутпанель и недавно добавленный элевейшон элемент. 
Привёл сингуло пуллы к одному виду, посмотрел все акты. 
Сделал проверки на вечные рантаймы обновления parent1 & parent2.
Расширил список граундлесс турфов.

Некоторые декали всё равно будут оставаться по причине насёра декалями грязи в стены, космос изначально и т.д. Я когда-то чистил, но не дочистил, рантайм на инит этого *** закомменчен.

Теперь сингулярность может летать не вызывая рантаймов 😨 

Багрепорт https://discord.com/channels/617003227182792704/1502700915097079808

## Список изменений
:cl:
bugfix: Грязный космос после синги синги. В некоторых местах декали всё равно будут оставаться.
/:cl:
