### PR TITLE
alerts refactor and tweaks

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
@@ -8,7 +8,6 @@
 #define COMSIG_CLICK "atom_click"
 ///from base of atom/ShiftClick(): (/mob)
 #define COMSIG_CLICK_SHIFT "shift_click"
-	#define COMPONENT_ALLOW_EXAMINATE (1<<0)							//Allows the user to examinate regardless of client.eye.
 ///from base of atom/CtrlClickOn(): (/mob)
 #define COMSIG_CLICK_CTRL "ctrl_click"
 ///from base of atom/base_click_alt(): (/mob)
@@ -24,6 +23,7 @@
 ///from base of atom/handle_mouse_drop_receive: (/atom/from, /mob/user)
 #define COMSIG_MOUSEDROPPED_ONTO "mousedropped_onto"
 	#define COMPONENT_CANCEL_MOUSEDROPPED_ONTO (1<<0)
-
 /// signal sent when a mouse is hovering over us, sent by atom/proc/on_mouse_entered
 #define COMSIG_ATOM_MOUSE_ENTERED "mouse_entered"
+/// From /atom/movable/screen/click(): (atom/target, atom/location, control, params, mob/user)
+#define COMSIG_SCREEN_ELEMENT_CLICK "screen_element_click"

--- a/code/__DEFINES/ghost.dm
+++ b/code/__DEFINES/ghost.dm
@@ -1,4 +1,5 @@
 #define GHOST_CAN_REENTER 1
 #define GHOST_IS_OBSERVER 2
 
+/// Aghosting AND APPERANTLY STEALTHMINNING sets your ckey/key == "@[old_key]" because it hates me. this detects that
 #define IS_FAKE_KEY(key) (key && key[1] == "@")

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1102,6 +1102,17 @@ GLOBAL_LIST_EMPTY(bicon_cache)
 
 	return alert_overlay
 
+/// Strips all underlays on a different plane from an appearance.
+/// Returns the stripped appearance.
+/proc/strip_appearance_underlays(mutable_appearance/appearance) as /mutable_appearance
+	var/base_plane = PLANE_TO_TRUE(appearance.plane)
+	for(var/mutable_appearance/underlay as anything in appearance.underlays)
+		if(isnull(underlay))
+			continue
+		if(PLANE_TO_TRUE(underlay.plane) != base_plane)
+			appearance.underlays -= underlay
+	return appearance
+
 /// Perform a shake on an atom, resets its position afterwards
 /atom/proc/Shake(pixelshiftx = 2, pixelshifty = 2, duration = 2.5 SECONDS, shake_interval = 0.02 SECONDS)
 	var/initialpixelx = pixel_x

--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -1,5 +1,6 @@
 /atom/movable/screen/ai
 	icon = 'icons/mob/screen_ai.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/ai/aicore
 	name = "Ядро ИИ"

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -1,42 +1,52 @@
-//A system to manage and display alerts on screen without needing you to do it yourself
-
-//PUBLIC -  call these wherever you want
+//! A system to manage and display alerts on screen without needing you to do it yourself
 
 /**
- * Proc to create or update an alert. Returns the alert if the alert is new or updated, 0 if it was thrown already.
+ * Proc to create or update an alert. Returns the alert.
  * Each mob may only have one alert per category.
  *
  * Arguments:
- * * category - a text string corresponding to what type of alert it is
- * * type - a type path of the actual alert type to throw
- * * severity - is an optional number that will be placed at the end of the icon_state for this alert
+ * * `category` - a text string corresponding to what type of alert it is
+ * * `type` - a type path of the actual alert type to throw
+ * * `severity` - is an optional number that will be placed at the end of the icon_state for this alert
  *   For example, high pressure's icon_state is "highpressure" and can be serverity 1 or 2 to get "highpressure1" or "highpressure2"
- * * obj/new_master - optional argument. Sets the alert's icon state to "template" in the ui_style icons with the master as an overlay. Clicks are forwarded to master
- * * no_anim - whether the alert should play a small sliding animation when created on the player's screen
- * * icon_override - makes it so the alert is not replaced until cleared by a clear_alert with clear_override, and it's used for hallucinations.
- * * list/alert_args - a list of arguments to pass to the alert when creating it
+ * * `atom/new_master` - optional argument. Sets the alert's icon state to "template" in the ui_style icons with the master as an overlay. Clicks are forwarded to master
+ * * `no_anim` - whether the alert should play a small sliding animation when created on the player's screen
+ * * `icon_override` - makes it so the alert is not replaced until cleared by a clear_alert with clear_override, and it's used for hallucinations.
+ * * `list/alert_args` - a list of arguments to pass to the alert when creating it
  */
-/mob/proc/throw_alert(category, type, severity, obj/new_master, override = FALSE, timeout_override, no_anim, icon_override, list/alert_args)
-	if(!category)
+/mob/proc/throw_alert(category, type, severity, atom/new_master, override = FALSE, timeout_override, no_anim = FALSE, icon_override, list/alert_args)
+	if(!category || QDELETED(src))
 		return
+
+	var/datum/weakref/master_ref
+	if(isatom(new_master))
+		master_ref = WEAKREF(new_master)
 
 	var/atom/movable/screen/alert/alert = LAZYACCESS(alerts, category)
 	if(alert)
 		if(alert.override_alerts)
-			return 0
-		if(new_master && new_master != alert.master)
-			WARNING("[src] threw alert [category] with new_master [new_master] while already having that alert with master [alert.master]")
+			return alert
+
+		if(master_ref && alert.master_ref && master_ref != alert.master_ref)
+			var/datum/current_master = alert.master_ref.resolve()
+			WARNING("[src] threw alert [category] with new_master [new_master] while already having that alert with master [current_master]")
 			clear_alert(category)
 			return .()
+
 		else if(alert.type != type)
 			clear_alert(category)
 			return .()
+
 		else if(!severity || severity == alert.severity)
-			if(alert.timeout)
-				clear_alert(category)
-				return .()
-			else //no need to update
-				return 0
+			if(!alert.timeout)
+				// No need to update existing alert
+				return alert
+			// Reset timeout of existing alert
+			var/timeout = timeout_override || initial(alert.timeout)
+			addtimer(CALLBACK(src, PROC_REF(alert_timeout), alert, category), timeout)
+			alert.timeout = world.time + timeout - world.tick_lag
+			return alert
+
 	else
 		if(alert_args)
 			alert_args.Insert(1, null) // So it's still created in nullspace.
@@ -47,20 +57,16 @@
 		if(override)
 			alert.timeout = null
 
+	alert.owner = src
+
 	if(icon_override)
 		alert.icon = icon_override
 
 	if(new_master)
-		var/old_layer = new_master.layer
-		var/old_plane = new_master.plane
-		new_master.layer = FLOAT_LAYER
-		new_master.plane = FLOAT_PLANE
-		alert.add_overlay(new_master)
-		new_master.layer = old_layer
-		new_master.plane = old_plane
-		alert.icon_state = "template" // We'll set the icon to the client's ui pref in reorganize_alerts()
-		alert.master = new_master
-	else
+		alert.master_ref = master_ref
+		alert.RegisterSignal(new_master, COMSIG_ATOM_UPDATE_APPEARANCE, TYPE_PROC_REF(/atom/movable/screen/alert, on_master_update_appearance))
+		alert.update_appearance()
+	else if(severity)
 		alert.icon_state = "[initial(alert.icon_state)][severity]"
 		alert.severity = severity
 
@@ -69,23 +75,31 @@
 		hud_used.reorganize_alerts()
 
 	if(!no_anim)
-		alert.transform = matrix(32, 6, MATRIX_TRANSLATE)
-		animate(alert, transform = matrix(), time = 2.5, easing = CUBIC_EASING)
+		alert.transform = matrix(32, 0, MATRIX_TRANSLATE)
+		animate(alert, transform = matrix(), time = 1 SECONDS, easing = ELASTIC_EASING)
 
-	var/timeout = timeout_override || alert.timeout
-	if(timeout)
-		addtimer(CALLBACK(alert, TYPE_PROC_REF(/atom/movable/screen/alert, do_timeout), src, category), timeout)
-		alert.timeout = world.time + timeout - world.tick_lag
+	if(timeout_override)
+		alert.timeout = timeout_override
+
+	if(alert.timeout)
+		addtimer(CALLBACK(src, PROC_REF(alert_timeout), alert, category), alert.timeout)
+		alert.timeout = world.time + alert.timeout - world.tick_lag
 
 	return alert
 
-// Proc to clear an existing alert.
+/mob/proc/alert_timeout(atom/movable/screen/alert/alert, category)
+	var/atom/movable/screen/alert/our_alert = LAZYACCESS(alerts, category)
+	if(!alert.timeout || our_alert != alert || world.time < alert.timeout)
+		return
+	clear_alert(category)
+
+/// Proc to clear an existing alert.
 /mob/proc/clear_alert(category, clear_override = FALSE)
 	var/atom/movable/screen/alert/alert = LAZYACCESS(alerts, category)
 	if(!alert)
-		return 0
+		return FALSE
 	if(alert.override_alerts && !clear_override)
-		return 0
+		return FALSE
 
 	alerts -= category
 	if(client && hud_used)
@@ -97,30 +111,105 @@
 				LAZYREMOVE(inventory_observers, observe)
 				continue
 			observe.client.screen -= alert
+
 	qdel(alert)
+
+/// Proc to check for an alert.
+/mob/proc/has_alert(category)
+	var/atom/movable/screen/alert/alert = LAZYACCESS(alerts, category)
+	return !isnull(alert)
 
 /atom/movable/screen/alert
 	icon = 'icons/mob/screen_alert.dmi'
-	icon_state = "default"
+	icon_state = "template"
 	name = "Alert"
-	desc = "Something seems to have gone wrong with this alert, so report this bug please"
-	var/timeout = 0 //If set to a number, this alert will clear itself after that many deciseconds
+	desc = "Something seems to have gone wrong with this alert, so report this bug please."
+	/// Do we glow to represent we do stuff when clicked
+	var/clickable_glow = FALSE
+	/// If set to a number, this alert will clear itself after that many deciseconds
+	var/timeout = 0
 	var/severity = 0
 	var/alerttooltipstyle = ""
-	var/override_alerts = FALSE //If it is overriding other alerts of the same type
+	/// If it is overriding other alerts of the same type
+	var/override_alerts = FALSE
+	/// Alert owner
+	var/mob/owner
+	/// Boolean. If TRUE, the Click() proc will attempt to Click() on the master first if there is a master.
+	var/click_master = TRUE
+
+/atom/movable/screen/alert/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	if(clickable_glow)
+		add_filter("clickglow", 2, outline_filter(color = COLOR_GOLD, size = 1))
+		mouse_over_pointer = MOUSE_HAND_POINTER
+
+/atom/movable/screen/alert/Destroy()
+	severity = 0
+	master_ref = null
+	owner = null
+	screen_loc = ""
+	return ..()
+
+/atom/movable/screen/alert/examine(mob/user)
+	return list(
+		span_boldnotice(name),
+		span_notice(desc),
+	)
 
 /atom/movable/screen/alert/MouseEntered(location,control,params)
-	openToolTip(usr, src, params, title = name, content = desc, theme = alerttooltipstyle)
+	. = ..()
+	if(!QDELETED(src))
+		openToolTip(usr, src, params, title = name, content = desc, theme = alerttooltipstyle)
 
 /atom/movable/screen/alert/MouseExited()
 	closeToolTip(usr)
 
-/atom/movable/screen/alert/proc/do_timeout(mob/M, category)
-	if(!M || !M.alerts)
-		return
+/atom/movable/screen/alert/proc/on_master_update_appearance(datum/source)
+	SIGNAL_HANDLER
+	update_appearance()
 
-	if(timeout && M.alerts[category] == src && world.time >= timeout)
-		M.clear_alert(category)
+/atom/movable/screen/alert/update_overlays()
+	. = ..()
+	var/atom/our_master = master_ref?.resolve()
+	if(istype(our_master) && !QDELETED(our_master))
+		. += add_atom_icon(our_master)
+
+/// Returns a copy of the appearance of the atom, with its base pixel coordinates. Useful for overlays
+/atom/movable/screen/alert/proc/add_atom_icon(atom/atom)
+	var/mutable_appearance/atom_appearance = new(atom)
+	atom_appearance.appearance_flags = KEEP_TOGETHER
+	atom_appearance.layer = FLOAT_LAYER
+	atom_appearance.plane = FLOAT_PLANE
+	atom_appearance.dir = SOUTH
+	atom_appearance.pixel_x = atom.base_pixel_x
+	atom_appearance.pixel_y = atom.base_pixel_y
+	atom_appearance.pixel_w = atom.base_pixel_w
+	atom_appearance.pixel_z = atom.base_pixel_z
+	return strip_appearance_underlays(atom_appearance)
+
+/atom/movable/screen/alert/Click(location, control, params)
+	SHOULD_CALL_PARENT(TRUE)
+	..()
+
+	if(!usr || !GET_CLIENT(usr) || usr != owner)
+		return FALSE
+
+	if(HAS_TRAIT(usr, TRAIT_OBSERVING_INVENTORY))
+		return FALSE
+
+	var/list/modifiers = params2list(params)
+	if(LAZYACCESS(modifiers, SHIFT_CLICK)) // screen objects don't do the normal Click() stuff so we'll cheat
+		to_chat(usr, chat_box_regular(jointext(examine(usr), "\n")))
+		return FALSE
+
+	if(!click_master)
+		return TRUE
+
+	var/datum/our_master = master_ref?.resolve()
+	if(our_master)
+		return usr.client.Click(our_master, location, control, params)
+
+	return TRUE
 
 //Gas alerts
 /atom/movable/screen/alert/not_enough_oxy
@@ -243,13 +332,15 @@
 	name = "Застрявший предмет"
 	desc = "В вашем теле застрял инородный предмет, вызывающий кровотечение. Он может выпасть сам, но операция безопаснее.<br>Если рискнёте, кликните на себя в режиме помощи, чтобы вытащить его."
 	icon_state = "embeddedobject"
+	clickable_glow = TRUE
 
-/atom/movable/screen/alert/embeddedobject/Click()
-	if(!..())
+/atom/movable/screen/alert/embeddedobject/Click(location, control, params)
+	. = ..()
+	if(!.)
 		return
-	if(isliving(usr))
-		var/mob/living/carbon/human/M = usr
-		return M.help_shake_act(M)
+
+	var/mob/living/carbon/carbon_owner = owner
+	return carbon_owner.help_shake_act(carbon_owner)
 
 /atom/movable/screen/alert/asleep
 	name = "Сон"
@@ -280,37 +371,39 @@
 	name = "В огне"
 	desc = "Вы горите!<br>Падайте, катайтесь или бегите в зону без кислорода, чтобы потушить пламя."
 	icon_state = "fire"
+	clickable_glow = TRUE
 
-/atom/movable/screen/alert/fire/Click()
-	if(!..())
-		return
-
-	if(!isliving(usr))
+/atom/movable/screen/alert/fire/Click(location, control, params)
+	. = ..()
+	if(!.)
 		return FALSE
 
-	var/mob/living/living_user = usr
-	if(!living_user.can_resist())
+	var/mob/living/living_owner = owner
+	if(!living_owner.can_resist())
 		return FALSE
 
-	living_user.changeNext_move(CLICK_CD_RESIST)
-
-	if(!(living_user.mobility_flags & MOBILITY_MOVE))
+	living_owner.changeNext_move(CLICK_CD_RESIST)
+	if(!(living_owner.mobility_flags & MOBILITY_MOVE))
 		return FALSE
 
-	return living_user.resist_fire()
+	return handle_stop_drop_roll(owner)
+
+/atom/movable/screen/alert/fire/proc/handle_stop_drop_roll(mob/living/roller)
+	return roller.resist_fire()
 
 /atom/movable/screen/alert/direction_lock
 	name = "Блокировка поворота"
 	desc = "Вы можете смотреть только в одну сторону, что замедляет движение.<br>Кликните сюда, чтобы разблокировать поворот."
 	icon_state = "direction_lock"
+	clickable_glow = TRUE
 
-/atom/movable/screen/alert/direction_lock/Click()
-	if(!..())
-		return
+/atom/movable/screen/alert/direction_lock/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
 
-	if(isliving(usr))
-		var/mob/living/L = usr
-		return L.clear_forced_look()
+	var/mob/living/living_owner = owner
+	return living_owner.clear_forced_look()
 
 //ALIENS
 
@@ -362,13 +455,15 @@
 /atom/movable/screen/alert/nymph
 	name = "Слияние с гештальтом"
 	desc = "Вы слились с дионическим гештальтом и стали частью его биомассы.<br>Но ещё можете попытаться выбраться."
+	clickable_glow = TRUE
 
-/atom/movable/screen/alert/nymph/Click()
-	if(!usr || !usr.client || !..())
-		return
-	if(isnymph(usr))
-		var/mob/living/simple_animal/diona/D = usr
-		return D.resist()
+/atom/movable/screen/alert/nymph/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/mob/living/simple_animal/diona/nymph_owner = owner
+	return nymph_owner.resist()
 
 //Need to cover all use cases - emag, illegal upgrade module, malf AI hack, traitor cyborg
 /atom/movable/screen/alert/hacked
@@ -385,28 +480,29 @@
 	name = "Обновление законов"
 	desc = "Законы этого юнита могли быть изменены.<br>Убедитесь, что ваши действия соответствуют актуальным законам."
 	icon_state = "newlaw"
-	timeout = 300
+	timeout = 30 SECONDS
 
 /atom/movable/screen/alert/hackingapc
 	name = "Взлом ЛКП"
 	desc = "Идёт взлом контроллера питания. После завершения вы получите над ним полный контроль и дополнительные возможности."
 	icon_state = "hackingapc"
-	timeout = 600
+	timeout = 60 SECONDS
+	clickable_glow = TRUE
 	var/atom/target = null
 
 /atom/movable/screen/alert/hackingapc/Destroy()
 	target = null
 	return ..()
 
-/atom/movable/screen/alert/hackingapc/Click()
-	if(!usr || !usr.client || !..())
-		return
-	if(!target)
-		return
-	var/mob/living/silicon/ai/AI = usr
-	var/turf/T = get_turf(target)
-	if(T)
-		AI.eyeobj.setLoc(T)
+/atom/movable/screen/alert/hackingapc/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/mob/living/silicon/ai/ai_owner = owner
+	var/turf/target_turf = get_turf(target)
+	if(target_turf)
+		ai_owner.eyeobj.setLoc(target_turf)
 
 //MECHS
 /atom/movable/screen/alert/low_mech_integrity
@@ -418,38 +514,40 @@
 	name = "Подключиться к порту"
 	desc = "Нажмите, чтобы подключиться к воздушному порту и пополнить запас кислорода!"
 	icon_state = "mech_port"
+	clickable_glow = TRUE
 	var/obj/machinery/atmospherics/unary/portables_connector/target = null
 
 /atom/movable/screen/alert/mech_port_available/Destroy()
 	target = null
 	return ..()
 
-/atom/movable/screen/alert/mech_port_available/Click()
-	if(!usr || !usr.client || !..())
-		return
-	if(!ismecha(usr.loc) || !target)
-		return
-	var/obj/mecha/M = usr.loc
-	if(M.connect(target))
-		balloon_alert(usr, "подключение к порту")
+/atom/movable/screen/alert/mech_port_available/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/obj/mecha/mecha_owner = owner.loc
+	if(mecha_owner.connect(target))
+		balloon_alert(owner, "подключение к порту")
 	else
-		balloon_alert(usr, "ошибка подключения")
+		balloon_alert(owner, "ошибка подключения")
 
 /atom/movable/screen/alert/mech_port_disconnect
 	name = "Отключиться от порта"
 	desc = "Нажмите, чтобы отключиться от воздушного порта."
 	icon_state = "mech_port_x"
+	clickable_glow = TRUE
 
-/atom/movable/screen/alert/mech_port_disconnect/Click()
-	if(!usr || !usr.client || !..())
-		return
-	if(!ismecha(usr.loc))
-		return
-	var/obj/mecha/M = usr.loc
-	if(M.disconnect())
-		balloon_alert(usr, "отключение от порта")
+/atom/movable/screen/alert/mech_port_disconnect/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/obj/mecha/mecha_owner = owner.loc
+	if(mecha_owner.disconnect())
+		balloon_alert(owner, "отключение от порта")
 	else
-		balloon_alert(usr, "не подключен")
+		balloon_alert(owner, "не подключен")
 
 /atom/movable/screen/alert/mech_nocell
 	name = "Нет батареи"
@@ -533,37 +631,46 @@
 	name = "Реанимация"
 	desc = "Кто-то пытается вас реанимировать. Вернитесь в своё тело, если хотите возродиться!"
 	icon_state = "template"
-	timeout = 300
+	timeout = 30 SECONDS
+	clickable_glow = TRUE
 
-/atom/movable/screen/alert/notify_cloning/Click()
-	if(!usr || !usr.client)
-		return
-	var/mob/dead/observer/G = usr
-	G.reenter_corpse()
+/atom/movable/screen/alert/notify_cloning/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/mob/dead/observer/dead_owner = owner
+	dead_owner.reenter_corpse()
 
 /atom/movable/screen/alert/ghost
 	name = "Призрак"
 	desc = "Хотите стать призраком? Вы получите уведомление, когда ваше тело извлекут из гнезда."
 	icon_state = "template"
 	timeout = 5 MINUTES // longer than any infection should be
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/ghost/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
-	var/image/I = image('icons/mob/mob.dmi', icon_state = "ghost", layer = FLOAT_LAYER, dir = SOUTH)
-	I.layer = FLOAT_LAYER
-	I.plane = FLOAT_PLANE
-	add_overlay(I)
+	var/mutable_appearance/ghost_overlay = mutable_appearance('icons/mob/mob.dmi', "ghost", FLOAT_LAYER)
+	ghost_overlay.plane = FLOAT_PLANE
+	ghost_overlay.dir = SOUTH
+	add_overlay(ghost_overlay)
 
-/atom/movable/screen/alert/ghost/Click()
-	var/mob/living/carbon/human/infected_user = usr
-	if(!istype(infected_user) || infected_user.stat == DEAD)
-		infected_user.clear_alert("ghost_nest")
-		return
-	var/obj/item/clothing/mask/facehugger/hugger_mask = infected_user.wear_mask
-	if(!istype(hugger_mask) || !(locate(/obj/item/organ/internal/body_egg/alien_embryo) in infected_user.internal_organs) || hugger_mask.sterile)
-		infected_user.clear_alert("ghost_nest")
-		return
-	infected_user.ghostize(TRUE)
+/atom/movable/screen/alert/ghost/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/mob/living/carbon/human/human_owner = owner
+	if(!istype(human_owner) || human_owner.stat == DEAD)
+		human_owner?.clear_alert(ALERT_GHOST_NEST)
+		return FALSE
+
+	var/obj/item/clothing/mask/facehugger/hugger_mask = human_owner.wear_mask
+	if(!istype(hugger_mask) || hugger_mask.sterile || !(locate(/obj/item/organ/internal/body_egg/alien_embryo) in human_owner.internal_organs))
+		human_owner.clear_alert(ALERT_GHOST_NEST)
+		return FALSE
+
+	human_owner.ghostize(TRUE)
 
 #define FLOAT_LAYER_TIME -1
 #define FLOAT_LAYER_STACKS -2
@@ -574,8 +681,9 @@
 	desc = "Вы можете в него вселиться."
 	icon_state = "template"
 	timeout = 30 SECONDS
-	/// Target atom of this alert
-	var/atom/target
+	clickable_glow = TRUE
+	/// Weakref to the target atom to use the action on
+	var/datum/weakref/target_ref
 	/// Action type we got from clicking on this alert
 	var/action = NOTIFY_JUMP
 	/// If true you need to call START_PROCESSING manually
@@ -593,10 +701,10 @@
 
 /atom/movable/screen/alert/notify_action/Initialize(mapload)
 	. = ..()
-	signed_up_overlay = mutable_appearance('icons/mob/screen_gen.dmi', "selector", FLOAT_LAYER_SELECTOR)
+	signed_up_overlay = mutable_appearance(icon = 'icons/mob/screen_gen.dmi', icon_state = "selector", layer = FLOAT_LAYER_SELECTOR)
 
 /atom/movable/screen/alert/notify_action/Destroy()
-	target = null
+	target_ref = null
 	QDEL_NULL(time_left_overlay)
 	QDEL_NULL(signed_up_overlay)
 	QDEL_NULL(stacks_overlay)
@@ -618,33 +726,36 @@
 		time_left_overlay.layer = FLOAT_LAYER_TIME
 		add_overlay(time_left_overlay)
 
-/atom/movable/screen/alert/notify_action/Click()
-	if(!usr || !usr.client)
-		return
-	var/mob/dead/observer/observer = usr
-	if(!istype(observer))
-		return
+/atom/movable/screen/alert/notify_action/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
 
+	if(!isobserver(owner))
+		return FALSE
+
+	var/mob/dead/observer/observer = owner
 	if(poll)
-		var/success = FALSE
-		if(observer in poll.signed_up)
-			success = poll.remove_candidate(observer)
-		else
-			success = poll.sign_up(observer)
+		var/success = (observer in poll.signed_up) ? poll.remove_candidate(observer) : poll.sign_up(observer)
 		if(success)
-			// Add a small overlay to indicate we've signed up
 			update_signed_up_alert(observer)
+		return TRUE
 
-	else if(target)
-		switch(action)
-			if(NOTIFY_ATTACK)
-				target.attack_ghost(observer)
-			if(NOTIFY_JUMP)
-				var/turf/target_turf = get_turf(target)
-				if(target_turf)
-					observer.abstract_move(target_turf)
-			if(NOTIFY_FOLLOW)
-				observer.ManualFollow(target)
+	var/atom/target = target_ref?.resolve()
+	if(isnull(target) || target == observer)
+		return FALSE
+
+	switch(action)
+		if(NOTIFY_ATTACK)
+			target.attack_ghost(observer)
+		if(NOTIFY_JUMP)
+			var/turf/target_turf = get_turf(target)
+			if(target_turf)
+				observer.abstract_move(target_turf)
+		if(NOTIFY_FOLLOW)
+			observer.ManualFollow(target)
+
+	return TRUE
 
 /atom/movable/screen/alert/notify_action/Topic(href, href_list)
 	var/mob/dead/observer/observer = usr
@@ -692,148 +803,184 @@
 	desc = "Кто-то пытается заключить вашу душу в камень. Нажмите, чтобы согласиться."
 	icon_state = "template"
 	timeout = 10 SECONDS
+	clickable_glow = TRUE
 	var/obj/item/soulstone/stone = null
 	var/stoner = null
-
-/atom/movable/screen/alert/notify_soulstone/Click()
-	if(!usr || !usr.client)
-		return
-	if(stone)
-		if(tgui_alert(usr, "[stoner] пытается заключить вашу душу в камень. \
-							Это уничтожит ваше тело и не позволит вернуться в игру как прежний персонаж. Согласны?", "Воскрешение", list("Нет", "Да")) ==  "Да")
-			stone?.opt_in = TRUE
 
 /atom/movable/screen/alert/notify_soulstone/Destroy()
 	stone = null
 	return ..()
 
+/atom/movable/screen/alert/notify_soulstone/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	if(QDELETED(stone))
+		return FALSE
+
+	var/choice = tgui_alert(owner, "[stoner] пытается заключить вашу душу в камень. \
+		Это уничтожит ваше тело и не позволит вернуться в игру как прежний персонаж. Согласны?", "Воскрешение", list("Нет", "Да"))
+	if(choice != "Да" || QDELETED(stone))
+		return FALSE
+
+	stone.opt_in = TRUE
+	return TRUE
+
 /atom/movable/screen/alert/notify_mapvote
 	name = "Голосование за карту"
 	desc = "Проголосуйте за следующую карту для игры!"
 	icon_state = "map_vote"
+	clickable_glow = TRUE
 
-/atom/movable/screen/alert/notify_mapvote/Click()
-	usr.client.vote()
+/atom/movable/screen/alert/notify_mapvote/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	owner.client.vote()
+	return TRUE
 
 //OBJECT-BASED
 
-/atom/movable/screen/alert/restrained/buckled
+/atom/movable/screen/alert/buckled
 	name = "Пристёгнут"
 	desc = "Вас пристегнули. Нажмите на уведомление, чтобы отстегнуться."
 	icon_state = "buckled"
+	click_master = FALSE
+	clickable_glow = TRUE
+
+/atom/movable/screen/alert/buckled/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/mob/living/living_owner = owner
+	if(!living_owner.can_resist())
+		return FALSE
+
+	living_owner.changeNext_move(CLICK_CD_RESIST)
+	if(living_owner.last_special > world.time)
+		return FALSE
+
+	return living_owner.resist_buckle()
+
+/atom/movable/screen/alert/restrained
+	icon_state = "template"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/restrained/handcuffed
 	name = "В наручниках"
 	desc = "Вы в наручниках и не можете ни с чем взаимодействовать. Если вас потащат, вы не сможете сопротивляться.<br>Нажмите на уведомление, чтобы освободиться."
+	click_master = FALSE
 
 /atom/movable/screen/alert/restrained/legcuffed
 	name = "Ноги скованы"
 	desc = "Ваши ноги скованы и это вас замедляет.<br>Нажмите на уведомление, чтобы освободиться."
+	click_master = FALSE
 
-/atom/movable/screen/alert/restrained/Click()
-	if(isliving(usr))
-		var/mob/living/L = usr
-		return L.resist()
+/atom/movable/screen/alert/restrained/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
 
-/atom/movable/screen/alert/restrained/buckled/Click()
-	if(!..())
-		return
-
-	var/mob/living/L = usr
-	if(!istype(L) || !L.can_resist())
-		return
-	L.changeNext_move(CLICK_CD_RESIST)
-	if(L.last_special <= world.time)
-		return L.resist_buckle()
+	var/mob/living/living_owner = owner
+	return living_owner.resist()
 
 // PRIVATE = only edit, use, or override these if you're editing the system as a whole
 
+/// Gets the placement for the alert based on its index
+/datum/hud/proc/get_ui_alert_placement(index)
+	// Only has support for 5 slots currently
+	if(index > 5)
+		return ""
+
+	return "EAST-1:28,CENTER+[6 - index]:[29 - (index * 2)]"
+
 // Re-render all alerts - also called in /datum/hud/show_hud() because it's needed there
-/datum/hud/proc/reorganize_alerts()
+/datum/hud/proc/reorganize_alerts(mob/viewmob)
+	var/mob/screenmob = viewmob || mymob
+	if(!screenmob.client)
+		return FALSE
 	var/list/alerts = mymob?.alerts
 	if(!alerts)
 		return FALSE
-	var/icon_pref
+
 	if(!hud_shown)
 		for(var/i in 1 to length(alerts))
-			mymob.client.screen -= alerts[alerts[i]]
+			screenmob.client.screen -= alerts[alerts[i]]
+
 			for(var/mob/dead/observer/observe in mymob.inventory_observers)
 				if(!observe.client)
 					LAZYREMOVE(mymob.inventory_observers, observe)
 					continue
 				observe.client.screen -= alerts[alerts[i]]
+
 		return TRUE
+
+	var/icon_pref
 	for(var/i in 1 to length(alerts))
 		var/atom/movable/screen/alert/alert = alerts[alerts[i]]
 		if(alert.icon_state == "template")
 			if(!icon_pref)
-				icon_pref = ui_style2icon(mymob.client.prefs.UI_style)
+				icon_pref = ui_style2icon(mymob.client?.prefs?.UI_style)
 			alert.icon = icon_pref
-		switch(i)
-			if(1)
-				. = ui_alert1
-			if(2)
-				. = ui_alert2
-			if(3)
-				. = ui_alert3
-			if(4)
-				. = ui_alert4
-			if(5)
-				. = ui_alert5 // Right now there's 5 slots
-			else
-				. = ""
-		alert.screen_loc = .
-		mymob.client.screen |= alert
+		alert.screen_loc = get_ui_alert_placement(i)
+		screenmob.client.screen |= alert
+
 		for(var/mob/dead/observer/observe in mymob.inventory_observers)
 			if(!observe.client)
 				LAZYREMOVE(mymob.inventory_observers, observe)
 				continue
 			observe.client.screen |= alert
-	return TRUE
-
-/atom/movable/screen/alert/Click(location, control, params)
-	if(!usr || !usr.client || HAS_TRAIT(usr, TRAIT_OBSERVING_INVENTORY))
-		return FALSE
-
-	var/list/modifiers = params2list(params)
-	if(LAZYACCESS(modifiers, SHIFT_CLICK)) // screen objects don't do the normal Click() stuff so we'll cheat
-		to_chat(usr, "[span_boldnotice(name)] – [span_notice(desc)]")
-		return FALSE
-
-	if(master)
-		return usr.client.Click(master, location, control, params)
 
 	return TRUE
-
-/atom/movable/screen/alert/Destroy()
-	severity = 0
-	master = null
-	screen_loc = ""
-	return ..()
 
 /// Gives the player the option to succumb while in critical condition
 /atom/movable/screen/alert/succumb
 	name = "Сдаться"
 	desc = "Покинуть этот бренный мир."
 	icon_state = "succumb"
+	clickable_glow = TRUE
 
-/atom/movable/screen/alert/succumb/Click()
-	if(!usr || !usr.client || !..())
-		return
-	var/mob/living/living_owner = usr
-	if(!istype(usr))
-		return
+/atom/movable/screen/alert/succumb/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/mob/living/living_owner = owner
 	living_owner.do_succumb(TRUE)
 
 /atom/movable/screen/alert/unpossess_object
 	name = "Покинуть тело"
 	desc = "Этот объект под вашим контролем. Нажмите сюда для прекращения контроля."
 	icon_state = "buckled"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/unpossess_object/Click(location, control, params)
 	. = ..()
-
 	if(!.)
-		return
+		return FALSE
 
-	qdel(usr.GetComponent(/datum/component/object_possession))
+	qdel(owner.GetComponent(/datum/component/object_possession))
+
+/atom/movable/screen/alert/status_effect/leaning
+	name = "Прислонившись"
+	desc = "Вы прислонились к чему-то."
+	icon_state = "buckled"
+	clickable_glow = TRUE
+
+/atom/movable/screen/alert/status_effect/leaning/Click()
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/mob/living/living_owner = owner
+	if(!istype(living_owner))
+		return FALSE
+
+	living_owner.changeNext_move(CLICK_CD_RESIST)
+	if(living_owner.last_special > world.time)
+		return FALSE
+
+	return living_owner.stop_leaning()

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -630,7 +630,6 @@
 /atom/movable/screen/alert/notify_cloning
 	name = "Реанимация"
 	desc = "Кто-то пытается вас реанимировать. Вернитесь в своё тело, если хотите возродиться!"
-	icon_state = "template"
 	timeout = 30 SECONDS
 	clickable_glow = TRUE
 
@@ -644,7 +643,6 @@
 /atom/movable/screen/alert/ghost
 	name = "Призрак"
 	desc = "Хотите стать призраком? Вы получите уведомление, когда ваше тело извлекут из гнезда."
-	icon_state = "template"
 	timeout = 5 MINUTES // longer than any infection should be
 	clickable_glow = TRUE
 
@@ -679,7 +677,6 @@
 /atom/movable/screen/alert/notify_action
 	name = "Тело создано"
 	desc = "Вы можете в него вселиться."
-	icon_state = "template"
 	timeout = 30 SECONDS
 	clickable_glow = TRUE
 	/// Weakref to the target atom to use the action on
@@ -801,7 +798,6 @@
 /atom/movable/screen/alert/notify_soulstone
 	name = "Камень душ"
 	desc = "Кто-то пытается заключить вашу душу в камень. Нажмите, чтобы согласиться."
-	icon_state = "template"
 	timeout = 10 SECONDS
 	clickable_glow = TRUE
 	var/obj/item/soulstone/stone = null
@@ -866,7 +862,6 @@
 	return living_owner.resist_buckle()
 
 /atom/movable/screen/alert/restrained
-	icon_state = "template"
 	clickable_glow = TRUE
 
 /atom/movable/screen/alert/restrained/handcuffed

--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -1,7 +1,8 @@
 /atom/movable/screen/blob
 	icon = 'icons/hud/blob.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
-/atom/movable/screen/blob/MouseEntered(location,control,params)
+/atom/movable/screen/blob/MouseEntered(location, control, params)
 	. = ..()
 	openToolTip(usr,src,params,title = name,content = desc, theme = "blob")
 

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -218,6 +218,7 @@
 	icon_state = "fullscreen_blocker" // Fullscreen semi transparent icon
 	plane = HUD_PLANE
 	mouse_opacity = MOUSE_OPACITY_ICON
+	default_click = TRUE
 	/// The mob whose cursor we are tracking.
 	var/mob/owner
 	/// Client view size of the scoping mob.

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -1,7 +1,8 @@
 /atom/movable/screen/ghost
 	icon = 'icons/mob/screen_ghost.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
-/atom/movable/screen/ghost/MouseEntered()
+/atom/movable/screen/ghost/MouseEntered(location, control, params)
 	. = ..()
 	flick(icon_state + "_anim", src)
 
@@ -77,8 +78,8 @@
 	icon_state = "minigames"
 
 /atom/movable/screen/ghost/Click()
-	var/mob/dead/observer/G = usr
-	G.open_minigames_menu()
+	var/mob/dead/observer/observer = usr
+	observer.open_minigames_menu()
 
 /atom/movable/screen/ghost/respawn_pai
 	name = "Настроить ПИИ"

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -6,11 +6,14 @@
 
 /datum/hud
 	var/mob/mymob
-
-	var/hud_shown = TRUE			//Used for the HUD toggle (F12)
-	var/hud_version = 1				//Current displayed version of the HUD
-	var/inventory_shown = FALSE		//Equipped item inventory
-	var/hotkey_ui_hidden = FALSE	//This is to hide the buttons that can be used via hotkeys. (hotkeybuttons list of buttons)
+	/// Used for the HUD toggle (F12)
+	var/hud_shown = TRUE
+	/// Current displayed version of the HUD
+	var/hud_version = HUD_STYLE_STANDARD
+	/// Equipped item inventory
+	var/inventory_shown = FALSE
+	/// This is to hide the buttons that can be used via hotkeys. (hotkeybuttons list of buttons)
+	var/hotkey_ui_hidden = FALSE
 
 	var/atom/movable/screen/lingchemdisplay
 	var/atom/movable/screen/lingstingdisplay
@@ -331,7 +334,7 @@
 	persistent_inventory_update(screenmob)
 	// Gives all of the actions the screenmob owes to their hud
 	screenmob.update_action_buttons(TRUE)
-	reorganize_alerts()
+	reorganize_alerts(screenmob)
 	reload_fullscreen()
 	if(screenmob == mymob)
 		update_parallax_pref(screenmob)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -4,6 +4,7 @@
 /atom/movable/screen/human/toggle
 	name = "toggle"
 	icon_state = "toggle"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/human/toggle/Click()
 	var/mob/targetmob = usr
@@ -42,6 +43,7 @@
 /atom/movable/screen/ling/sting
 	name = "current sting"
 	screen_loc = ui_lingstingdisplay
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/ling/sting/Click()
 	if(isobserver(usr))

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -1,5 +1,6 @@
 /atom/movable/screen/robot
 	icon = 'icons/mob/screen_robot.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/robot/module
 	name = "cyborg module"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -13,10 +13,11 @@
 	// NOTE: screen objects do NOT change their plane to match the z layer of their owner
 	// You shouldn't need this, but if you ever do and it's widespread, reconsider what you're doing.
 	plane = HUD_PLANE
-	appearance_flags = NO_CLIENT_COLOR
+	appearance_flags = APPEARANCE_UI
 	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_MOUSEDROP_IGNORE_CHECKS
 	flags = NO_SCREENTIPS
-	var/obj/master = null	//A reference to the object in the slot. Grabs or items, generally.
+	/// A reference to the object in the slot. Grabs or items, generally, but any datum will do.
+	var/datum/weakref/master_ref = null
 	VAR_PRIVATE/datum/hud/hud = null
 	/**
 	 * Map name assigned to this object.
@@ -33,6 +34,12 @@
 	var/del_on_map_removal = TRUE
 	/// If FALSE, this will not be cleared when calling /client/clear_screen()
 	var/clear_with_screen = TRUE
+	/// If TRUE, clicking the screen element will fall through and perform a default "Click" call
+	/// Obviously this requires your Click override, if any, to call parent on their own.
+	/// This is set to FALSE to default to dissade you from doing this.
+	/// Generally we don't want default Click stuff, which results in bugs like using Telekinesis on a screen element
+	/// or trying to point your gun at your screen.
+	var/default_click = FALSE
 
 /atom/movable/screen/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
@@ -41,13 +48,23 @@
 	set_new_hud(hud_owner)
 
 /atom/movable/screen/Destroy()
-	master = null
+	master_ref = null
 	hud = null
 	return ..()
+
+/atom/movable/screen/Click(location, control, params)
+	if(flags & INITIALIZED)
+		SEND_SIGNAL(src, COMSIG_SCREEN_ELEMENT_CLICK, location, control, params, usr)
+
+	if(default_click)
+		return ..()
 
 /// Screen elements are always on top of the players screen and don't move so yes they are adjacent
 /atom/movable/screen/Adjacent(atom/neighbor, atom/target, atom/movable/mover)
 	return TRUE
+
+/atom/movable/screen/examine(mob/user)
+	return list()
 
 /atom/movable/screen/proc/component_click(atom/movable/screen/component_button/component, params)
 	return
@@ -80,17 +97,23 @@
 	layer = ABOVE_HUD_LAYER
 	plane = ABOVE_HUD_PLANE
 	icon_state = "backpack_close"
+	mouse_over_pointer = MOUSE_HAND_POINTER
+
+/atom/movable/screen/close/Initialize(mapload, datum/hud/hud_owner, new_master)
+	. = ..()
+	master_ref = WEAKREF(new_master)
 
 /atom/movable/screen/close/Click()
-	if(master)
-		if(isstorage(master))
-			var/obj/item/storage/S = master
-			S.close(usr)
+	var/obj/item/storage/storage = master_ref?.resolve()
+	if(!istype(storage))
+		return
+	storage.close(usr)
 	return TRUE
 
 /atom/movable/screen/drop
 	name = "accurate drop"
 	icon_state = "act_drop"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/drop/Click()
 	if(usr.stat == CONSCIOUS)
@@ -100,6 +123,7 @@
 	name = "intent"
 	icon_state = "help"
 	screen_loc = ui_acti
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/act_intent/Click(location, control, params)
 	if(ishuman(usr) || isdevil(usr))
@@ -129,6 +153,7 @@
 /atom/movable/screen/mov_intent
 	name = "run/walk toggle"
 	icon_state = "running"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/mov_intent/update_icon_state()
 	if(hud?.mymob)
@@ -149,6 +174,7 @@
 	name = "stop pulling"
 	icon_state = "pull"
 	base_icon_state = "pull"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/pull/Click()
 	if(isobserver(usr))
@@ -162,6 +188,7 @@
 	name = "resist"
 	icon = 'icons/mob/screen_midnight.dmi'
 	icon_state = "act_resist"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/resist/Click()
 	if(isliving(usr))
@@ -172,6 +199,7 @@
 	name = "throw/catch"
 	icon = 'icons/mob/screen_midnight.dmi'
 	icon_state = "act_throw_off"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/throw_catch/Click()
 	if(iscarbon(usr))
@@ -181,7 +209,15 @@
 /atom/movable/screen/storage
 	name = "storage"
 
+/atom/movable/screen/storage/Initialize(mapload, datum/hud/hud_owner, new_master)
+	. = ..()
+	master_ref = WEAKREF(new_master)
+
 /atom/movable/screen/storage/Click(location, control, params)
+	var/obj/item/storage/storage_master = master_ref?.resolve()
+	if(!istype(storage_master))
+		return FALSE
+
 	if(world.time <= usr.next_move)
 		return TRUE
 
@@ -194,33 +230,33 @@
 	if(is_ventcrawling(usr)) // stops inventory actions in vents
 		return TRUE
 
-	if(isstorage(master))
-		var/obj/item/storage/storage_master = master
-		var/obj/item/item = usr.get_active_hand()
-		storage_master.attempt_insert(item)
+	var/obj/item/inserted = usr.get_active_hand()
+	if(inserted)
+		storage_master.attempt_insert(inserted)
+
 	return TRUE
 
 /atom/movable/screen/storage/mouse_drop_receive(obj/item/dropped, mob/user, params)
-	if(!user || !master || !istype(dropped) || user.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || ismecha(user.loc))
+	var/obj/item/storage/storage = master_ref?.resolve()
+	if(!istype(storage))
+		return
+
+	if(!user || !storage || !istype(dropped) || user.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || ismecha(user.loc))
 		return
 
 	if(is_ventcrawling(user))
 		return
 
-	var/obj/item/storage/S = master
-	if(!S)
-		return
-
-	if(dropped in S.contents) // If the item is already in the storage, move them to the end of the list
-		if(S.contents[length(S.contents)] == dropped) // No point moving them at the end if they're already there!
+	if(dropped in storage.contents) // If the item is already in the storage, move them to the end of the list
+		if(storage.contents[length(storage.contents)] == dropped) // No point moving them at the end if they're already there!
 			return
 
-		var/list/new_contents = S.contents.Copy()
-		if(S.display_contents_with_number)
+		var/list/new_contents = storage.contents.Copy()
+		if(storage.display_contents_with_number)
 			// Basically move all occurences of dropped to the end of the list.
 			var/list/obj/item/to_append = list()
-			for(var/obj/item/stored_item in S.contents)
-				if(S.can_items_stack(stored_item, dropped))
+			for(var/obj/item/stored_item in storage.contents)
+				if(storage.can_items_stack(stored_item, dropped))
 					new_contents -= stored_item
 					to_append += stored_item
 
@@ -228,13 +264,13 @@
 		else
 			new_contents -= dropped
 			new_contents += dropped // oof
-		S.contents = new_contents
+		storage.contents = new_contents
 
-		if(user.s_active == S)
-			S.orient2hud(user)
-			S.show_to(user)
+		if(user.s_active == storage)
+			storage.orient2hud(user)
+			storage.show_to(user)
 	else // If it's not in the storage, try putting it inside
-		S.attempt_insert(dropped)
+		storage.attempt_insert(dropped)
 
 /atom/movable/screen/storage/space_box
 	screen_loc = "7,7 to 10,8"
@@ -243,6 +279,7 @@
 	name = "damage zone"
 	icon_state = "zone_sel"
 	screen_loc = ui_zonesel
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/overlay_file = 'icons/mob/zone_sel.dmi'
 	var/selecting = BODY_ZONE_CHEST
 	var/list/hover_overlays_cache
@@ -429,6 +466,7 @@
 	icon = 'icons/mob/screen_midnight.dmi'
 	icon_state = "craft"
 	screen_loc = ui_crafting
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/craft/Click()
 	if(isobserver(usr))
@@ -442,6 +480,7 @@
 	icon = 'icons/mob/screen_midnight.dmi'
 	icon_state = "talk_wheel"
 	screen_loc = ui_language_menu
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/language_menu/Click()
 	var/mob/M = usr
@@ -669,6 +708,7 @@
 
 /atom/movable/screen/swap_hand
 	name = "swap hand"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/swap_hand/Click()
 	// At this point in client Click() code we have passed the 1/10 sec check and little else
@@ -754,12 +794,13 @@
 	var/filtered = FALSE //so we don't repeatedly create the mask of the mob every update
 
 /atom/movable/screen/component_button
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/atom/movable/screen/parent
 
-/atom/movable/screen/component_button/Initialize(mapload, atom/movable/screen/new_parent)
+/atom/movable/screen/component_button/Initialize(mapload, atom/movable/screen/parent)
 	. = ..()
-	parent = new_parent
+	src.parent = parent
 
-/atom/movable/screen/component_button/Click(params)
+/atom/movable/screen/component_button/Click(location, control, params)
 	if(parent)
 		parent.component_click(src, params)

--- a/code/datums/components/aura_healing.dm
+++ b/code/datums/components/aura_healing.dm
@@ -124,8 +124,7 @@
 
 	for(var/mob/living/candidate as anything in to_heal)
 		if(!current_alerts[candidate])
-			var/atom/movable/screen/alert/aura_healing/alert = candidate.throw_alert(alert_category, /atom/movable/screen/alert/aura_healing, new_master = parent)
-			alert.desc = "Аура, исходящая от [parent], исцеляет вас."
+			candidate.throw_alert(alert_category, /atom/movable/screen/alert/aura_healing, new_master = parent)
 			current_alerts[candidate] = TRUE
 			if(ishuman(candidate))
 				var/mob/living/carbon/human/human_candidate = candidate
@@ -240,5 +239,11 @@
 /atom/movable/screen/alert/aura_healing
 	name = "Исцеляющая аура"
 	icon_state = "template"
+	clickable_glow = TRUE
+	click_master = FALSE
+
+/atom/movable/screen/alert/aura_healing/update_desc(updates)
+	. = ..()
+	desc = "Аура, исходящая от [master_ref?.resolve()], исцеляет вас."
 
 #undef HEAL_EFFECT_COOLDOWN

--- a/code/datums/components/aura_healing.dm
+++ b/code/datums/components/aura_healing.dm
@@ -238,7 +238,6 @@
 
 /atom/movable/screen/alert/aura_healing
 	name = "Исцеляющая аура"
-	icon_state = "template"
 	clickable_glow = TRUE
 	click_master = FALSE
 

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -317,19 +317,6 @@
 		var/current_effect = difference > 0 ? -temp_effect : temp_effect
 		owner.adjust_bodytemperature(current_effect * TEMPERATURE_DAMAGE_COEFFICIENT)
 
-/atom/movable/screen/alert/status_effect/leaning
-	name = "Прислонившись"
-	desc = "Вы прислонились к чему-то."
-	icon_state = "buckled"
-
-/atom/movable/screen/alert/status_effect/leaning/Click()
-	var/mob/living/L = usr
-	if(!istype(L))
-		return
-	L.changeNext_move(CLICK_CD_RESIST)
-	if(L.last_special <= world.time)
-		return L.stop_leaning()
-
 /datum/status_effect/leaning
 	id = "leaning"
 	tick_interval = STATUS_EFFECT_NO_TICK

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -9,6 +9,8 @@
 	idle_power_usage = 2
 	active_power_usage = 4
 
+	mouse_over_pointer = MOUSE_HAND_POINTER
+
 	var/ai_control = TRUE
 	var/is_animating = FALSE
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_EMPTY(firealarms)
 	power_channel = ENVIRON
 	resistance_flags = FIRE_PROOF
 	cares_about_temperature = TRUE
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 	var/buildstage = FIRE_ALARM_READY
 	var/wiresexposed = FALSE

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/engines_and_power/power.dmi'
 	icon_state = "light1"
 	anchored = TRUE
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	/// Set this to a string, path, or area instance to control that area instead of the switch's location.
 	var/area/area = null
 	/// Should this lightswitch automatically rename itself to match the area it's in?

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -93,7 +93,7 @@
 		RegisterSignal(src, COMSIG_MOVABLE_SET_ANCHORED, PROC_REF(on_set_anchored))
 	target.set_buckled(src)
 	buckled_mobs |= target
-	target.throw_alert(ALERT_BUCKLED, /atom/movable/screen/alert/restrained/buckled)
+	target.throw_alert(ALERT_BUCKLED, /atom/movable/screen/alert/buckled)
 	target.set_glide_size(glide_size)
 	target.setDir(dir)
 

--- a/code/game/objects/items/weapons/RLF.dm
+++ b/code/game/objects/items/weapons/RLF.dm
@@ -27,32 +27,43 @@ RLF
 	if(!receiver.client)
 		to_chat(user, span_warning("You offer lollipop to [receiver], but they don't seem to respond..."))
 		return
-	var/obj/item/I = new /obj/item/reagent_containers/food/snacks/candy/sucker/lollipop
-	receiver.throw_alert("take item [I.UID()]", /atom/movable/screen/alert/take_item/RLF, alert_args = list(user, receiver, I))
+	var/obj/item/sucker = new /obj/item/reagent_containers/food/snacks/candy/sucker/lollipop
+	receiver.throw_alert("take item [sucker.UID()]", /atom/movable/screen/alert/take_item/RLF, alert_args = list(user, receiver, sucker))
 	to_chat(user, span_notice("You offer lollipop to [receiver]."))
 
 /atom/movable/screen/alert/take_item/RLF
 
 /atom/movable/screen/alert/take_item/RLF/Click(location, control, params)
-	var/mob/living/receiver = locateUID(receiver_UID)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/mob/living/receiver = owner
 	if(receiver.stat != CONSCIOUS)
-		return
-	var/obj/item/reagent_containers/food/snacks/candy/sucker/I = locateUID(item_UID)
+		return FALSE
+
+	var/mob/living/silicon/robot/borg = locateUID(giver_UID)
+	if(!isrobot(borg))
+		return FALSE
+
+	var/obj/item/reagent_containers/food/snacks/candy/sucker/sucker = locateUID(item_UID)
+	if(!sucker)
+		return FALSE
+
 	if(receiver.r_hand && receiver.l_hand)
-		to_chat(receiver, span_warning("You need to have your hands free to accept [I]!"))
-		return
-	var/mob/living/giver = locateUID(giver_UID)
-	if(!isrobot(giver))
-		return
-	if(!giver.Adjacent(receiver))
-		to_chat(receiver, span_warning("You need to stay in reaching distance of [giver] to take [I]!"))
-		return
-	UnregisterSignal(I, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
-	var/mob/living/silicon/robot/borg = giver
+		to_chat(receiver, span_warning("You need to have your hands free to accept [sucker]!"))
+		return FALSE
+
+	if(!borg.Adjacent(receiver))
+		to_chat(receiver, span_warning("You need to stay in reaching distance of [borg] to take [sucker]!"))
+		return FALSE
+
+	UnregisterSignal(sucker, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
 	borg.cell.charge -= 500
-	I.forceMove(get_turf(giver))
-	receiver.put_in_hands(I, ignore_anim = FALSE)
-	I.add_fingerprint(receiver)
-	I.on_give(giver, receiver)
-	receiver.visible_message(span_notice("[giver] handed [I] to [receiver]."))
+	sucker.forceMove(get_turf(borg))
+	receiver.put_in_hands(sucker, ignore_anim = FALSE)
+	sucker.add_fingerprint(receiver)
+	sucker.on_give(borg, receiver)
+	receiver.visible_message(span_notice("[borg] handed [sucker] to [receiver]."))
 	receiver.clear_alert("take item [item_UID]")
+	return TRUE

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -80,14 +80,14 @@
 	if(display_contents_with_number)
 		boxes = new /atom/movable/screen/storage()
 		boxes.name = "storage"
-		boxes.master = src
+		boxes.master_ref = WEAKREF(src)
 		boxes.icon_state = "block"
 		boxes.screen_loc = "7,7 to 10,8"
 		boxes.layer = HUD_LAYER
 		boxes.plane = HUD_PLANE
 
 	closer = new /atom/movable/screen/close()
-	closer.master = src
+	closer.master_ref = WEAKREF(src)
 
 	orient2hud()
 
@@ -391,33 +391,33 @@
 	/// Storage closer ref
 	var/atom/movable/screen/close/closer
 
-/datum/storage_box/New(master)
+/datum/storage_box/New(new_master)
 	// Making ref to parent storage
-	storage = master
+	storage = new_master
 
 	// Initialize screen objects
 	start = new
 	start.icon_state = "storage_start"
-	start.master = master
+	start.master_ref = WEAKREF(new_master)
 
 	end = new
 	end.icon_state = "storage_end"
-	end.master = master
+	end.master_ref = WEAKREF(new_master)
 
 	continued = new
 	continued.icon_state = "storage_continue"
-	continued.master = master
+	continued.master_ref = WEAKREF(new_master)
 
 	top = new
 	top.icon_state = "storage_top"
-	top.master = master
+	top.master_ref = WEAKREF(new_master)
 
 	bottom = new
 	bottom.icon_state = "storage_bottom"
-	bottom.master = master
+	bottom.master_ref = WEAKREF(new_master)
 
 	closer = new
-	closer.master = master
+	closer.master_ref = WEAKREF(new_master)
 
 	place_items = new
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -611,6 +611,10 @@ GLOBAL_LIST_INIT(wcCommon, pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e",
 		animate(src, color="#222222", time=5)
 		set_opacity(TRUE)
 
+/obj/machinery/button
+	name = "button"
+	mouse_over_pointer = MOUSE_HAND_POINTER
+
 /obj/machinery/button/windowtint
 	name = "window tint control"
 	icon = 'icons/obj/engines_and_power/power.dmi'

--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -5,6 +5,7 @@ GLOBAL_PROTECT(AdminProcCallHandler)
 /// Has to be a mob because IsAdminAdvancedProcCall() checks usr, which is a mob variable.
 /// So usr is set to this for any proccalls that don't have any usr mob/client to refer to.
 /mob/proccall_handler
+	abstract_type = /mob/proccall_handler
 	name = "ProcCall Handler"
 	desc = "If you are seeing this, tell a coder."
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -559,6 +559,15 @@ ADMIN_VERB(display_del_log_simple, R_DEBUG, "Display Simple del() Log", "Display
 ADMIN_VERB(view_runtimes, R_DEBUG|R_VIEWRUNTIMES, "View Runtimes", "Opens the runtime viewer.", ADMIN_CATEGORY_DEBUG)
 	GLOB.error_cache.show_to(user.mob)
 
+	// The runtime viewer has the potential to crash the server if there's a LOT of runtimes
+	// this has happened before, multiple times, so we'll just leave an alert on it
+	if(GLOB.total_runtimes >= 50000) // arbitrary number, I don't know when exactly it happens
+		var/warning = "There are a lot of runtimes, clicking any button (especially \"linear\") can have the potential to lag or crash the server"
+		if(GLOB.total_runtimes >= 100000)
+			warning = "There are a TON of runtimes, clicking any button (especially \"linear\") WILL LIKELY crash the server"
+		// Not using TGUI alert, because it's view runtimes, stuff is probably broken
+		alert(user, "[warning]. Proceed with caution. If you really need to see the runtimes, download the runtime log and view it in a text editor.", "HEED THIS WARNING CAREFULLY MORTAL")
+
 ADMIN_VERB(allow_browser_inspect, R_DEBUG, "Allow Browser Inspect", "Allow browser debugging via inspect.", ADMIN_CATEGORY_DEBUG)
 	if(user.byond_version < 516)
 		to_chat(user, span_warning("You can only use this on 516!"))

--- a/code/modules/buildmode/buttons.dm
+++ b/code/modules/buildmode/buttons.dm
@@ -1,6 +1,7 @@
 /atom/movable/screen/buildmode
 	icon = 'icons/misc/buildmode.dmi'
 	layer = BUILDMOD_LAYER
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/datum/click_intercept/buildmode/bd
 
 /atom/movable/screen/buildmode/New(bld)

--- a/code/modules/mini_games/mini_games.dm
+++ b/code/modules/mini_games/mini_games.dm
@@ -43,7 +43,7 @@
 					A.name = title
 				A.desc = message
 				A.action = action
-				A.target = source
+				A.target_ref = WEAKREF(source)
 				if(!alert_overlay)
 					var/old_layer = source.layer
 					var/old_plane = source.plane

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -282,8 +282,12 @@
 	else
 		to_chat(itemUser, failText)
 		return
-	to_chat(itemUser, span_notice("Змея, довольная вашей клятвой, намертво прирастает к вашему предплечью. Ваши мысли теперь вращаются только вокруг помощи другим, а вред — всего лишь смутное, греховное воспоминание..."))
-	var/datum/status_effect/hippocraticOath/effect = itemUser.apply_status_effect(STATUS_EFFECT_HIPPOCRATIC_OATH)
+
+	apply_oath(itemUser)
+
+/obj/item/rod_of_asclepius/proc/apply_oath(mob/living/carbon/user)
+	to_chat(user, span_notice("Змея, довольная вашей клятвой, намертво прирастает к вашему предплечью. Ваши мысли теперь вращаются только вокруг помощи другим, а вред — всего лишь смутное, греховное воспоминание..."))
+	var/datum/status_effect/hippocraticOath/effect = user.apply_status_effect(STATUS_EFFECT_HIPPOCRATIC_OATH)
 	effect.hand = usedHand
 	activated()
 

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -9,17 +9,17 @@
 	if(target.incapacitated() || HAS_TRAIT(target, TRAIT_HANDS_BLOCKED) || usr.incapacitated() || HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED) || target.client == null)
 		return
 
-	var/obj/item/I = get_active_hand()
+	var/obj/item/item = get_active_hand()
 
-	if(!I)
+	if(!item)
 		to_chat(usr, span_warning("У вас ничего нет в руке, чтобы передать [target.declent_ru(ACCUSATIVE)]."))
 		return
-	if(HAS_TRAIT(I, TRAIT_NODROP) || (I.item_flags & ABSTRACT))
+	if(HAS_TRAIT(item, TRAIT_NODROP) || (item.item_flags & ABSTRACT))
 		to_chat(usr, span_warning("Это нельзя просто так взять и передать."))
 		return
 	if(target.r_hand == null || target.l_hand == null)
-		var/ans = tgui_alert(target,"[usr] хо[PLUR_CHET_TYAT(usr)] передать вам [I.declent_ru(ACCUSATIVE)]?", "Передача предмета", list("Взять","Не брать"))
-		if(!I || !target)
+		var/ans = tgui_alert(target,"[usr] хо[PLUR_CHET_TYAT(usr)] передать вам [item.declent_ru(ACCUSATIVE)]?", "Передача предмета", list("Взять","Не брать"))
+		if(!item || !target)
 			return
 		switch(ans)
 			if("Взять")
@@ -29,25 +29,25 @@
 					to_chat(usr, span_warning("Нужно оставаться в пределах досягаемости!"))
 					to_chat(target, span_warning("[usr.name] ото[GEND_SHEL(usr)] слишком далеко."))
 					return
-				if(HAS_TRAIT(I, TRAIT_NODROP) || (I.item_flags & ABSTRACT))
-					to_chat(usr, span_warning("[DECLENT_RU_CAP(I, NOMINATIVE)] прилип[GEND_LA_LO_LI(I)]  к вашей руке и не отдаётся!"))
-					to_chat(target, span_warning("[DECLENT_RU_CAP(I, NOMINATIVE)] прилип[GEND_LA_LO_LI(I)] к руке [usr.name], когда вы попытались взять!"))
+				if(HAS_TRAIT(item, TRAIT_NODROP) || (item.item_flags & ABSTRACT))
+					to_chat(usr, span_warning("[DECLENT_RU_CAP(item, NOMINATIVE)] прилип[GEND_LA_LO_LI(item)]  к вашей руке и не отдаётся!"))
+					to_chat(target, span_warning("[DECLENT_RU_CAP(item, NOMINATIVE)] прилип[GEND_LA_LO_LI(item)] к руке [usr.name], когда вы попытались взять!"))
 					return
-				if(I != get_active_hand())
+				if(item != get_active_hand())
 					to_chat(usr, span_warning("Нужно держать предмет в активной руке."))
-					to_chat(target, span_warning("[usr.name] передумал[GEND_A_O_I(usr)] передавать вам [I.declent_ru(NOMINATIVE)]."))
+					to_chat(target, span_warning("[usr.name] передумал[GEND_A_O_I(usr)] передавать вам [item.declent_ru(NOMINATIVE)]."))
 					return
 				if(target.r_hand != null && target.l_hand != null)
 					to_chat(target, span_warning("Ваши руки заняты."))
 					to_chat(usr, span_warning("[GEND_HIS_HER_CAP(usr)] руки заняты."))
 					return
-				usr.drop_item_ground(I)
-				target.put_in_hands(I, ignore_anim = FALSE)
-				I.add_fingerprint(target)
-				target.visible_message(span_notice("[usr.name] передаёт [I.declent_ru(ACCUSATIVE)] [target.name]."))
-				I.on_give(usr, target)
+				usr.drop_item_ground(item)
+				target.put_in_hands(item, ignore_anim = FALSE)
+				item.add_fingerprint(target)
+				target.visible_message(span_notice("[usr.name] передаёт [item.declent_ru(ACCUSATIVE)] [target.name]."))
+				item.on_give(usr, target)
 			if("Не брать")
-				target.visible_message(span_warning("[usr.name] пытался передать [I.declent_ru(ACCUSATIVE)] [target.name], но [GEND_HE_SHE(usr)] отказал[GEND_SYA_AS_OS_IS(usr)]."))
+				target.visible_message(span_warning("[usr.name] пытался передать [item.declent_ru(ACCUSATIVE)] [target.name], но [GEND_HE_SHE(usr)] отказал[GEND_SYA_AS_OS_IS(usr)]."))
 	else
 		to_chat(usr, span_warning("Руки [target.name] заняты."))
 
@@ -66,14 +66,14 @@
 	if(istype(client.click_intercept, /datum/click_intercept/give))
 		QDEL_NULL(client.click_intercept)
 		return
-	var/obj/item/I = get_active_hand()
-	if(!I)
+	var/obj/item/item = get_active_hand()
+	if(!item)
 		to_chat(src, span_warning("У вас нет предмета в руке для передачи!"))
 		return
-	if(HAS_TRAIT(I, TRAIT_NODROP))
-		to_chat(src, span_warning("[DECLENT_RU_CAP(I, NOMINATIVE)] прилип[GEND_A_O_I(I)] к вашей руке и не отда[PLUR_YOT_YUT(I)]ся!"))
+	if(HAS_TRAIT(item, TRAIT_NODROP))
+		to_chat(src, span_warning("[DECLENT_RU_CAP(item, NOMINATIVE)] прилип[GEND_A_O_I(item)] к вашей руке и не отда[PLUR_YOT_YUT(item)]ся!"))
 		return
-	if(I.item_flags & ABSTRACT)
+	if(item.item_flags & ABSTRACT)
 		to_chat(src, span_warning("Такой предмет нельзя просто взять и передать."))
 		return
 
@@ -99,18 +99,27 @@
 	name = "Предложение предмета"
 	desc = "Вы предлагаете предмет игроку. Держите предмет в руке, чтобы он мог принять его! Нажмите чтобы отменить."
 	icon_state = "offering_item"
+	clickable_glow = TRUE
 	/// UID of the mob who's being offered the item.
 	var/receiver_UID
 	/// UID of the item being given.
 	var/item_UID
 
 /atom/movable/screen/alert/status_effect/offering_item/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/mob/living/carbon/giver = owner
 	var/mob/living/carbon/receiver = locateUID(receiver_UID)
-	var/mob/living/carbon/giver = attached_effect.owner
-	var/obj/item/I = locateUID(item_UID)
-	to_chat(giver, span_notice("Вы передумали передавать [I.declent_ru(ACCUSATIVE)] [receiver]."))
-	to_chat(receiver, span_warning("[giver] передумал[PLUR_I(giver)] передавать вам [I.declent_ru(ACCUSATIVE)]."))
+	var/obj/item/item = locateUID(item_UID)
+	if(!istype(receiver) || !item)
+		return FALSE
+
+	to_chat(giver, span_notice("Вы передумали передавать [item.declent_ru(ACCUSATIVE)] [receiver]."))
+	to_chat(receiver, span_warning("[giver] передумал[PLUR_I(giver)] передавать вам [item.declent_ru(ACCUSATIVE)]."))
 	receiver.clear_alert("take item [item_UID]") // This cancels *everything* related to the giving/item offering.
+	return TRUE
 
 /**
  * # Give click intercept
@@ -187,6 +196,7 @@
 	desc = "Вам хотят передать предмет!"
 	icon_state = "template"
 	timeout = 10 SECONDS
+	clickable_glow = TRUE
 	/// UID of the mob offering the receiver an item.
 	var/giver_UID
 	/// UID of the mob who has this alert.
@@ -206,7 +216,7 @@
 	// If either of these atoms are deleted, we need to cancel everything. Also saves having to do null checks before interacting with these atoms.
 	// So there is no more COMSIG_QDELETING for giver, because it overrides the same registration
 	// in /atom/movable/screen/proc/set_new_hud, which is probably worse then not having it here, because alert will be cleared
-	// anyway in do_timeout()
+	// anyway in alert_timeout()
 	RegisterSignal(item, list(COMSIG_QDELETING, COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED), PROC_REF(cancel_give))
 	RegisterSignal(giver, list(COMSIG_MOB_SWAP_HANDS, SIGNAL_ADDTRAIT(TRAIT_HANDS_BLOCKED)), PROC_REF(cancel_give))
 
@@ -233,50 +243,56 @@
 	receiver.clear_alert("take item [item_UID]")
 
 /atom/movable/screen/alert/take_item/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/mob/living/receiver = owner
 	var/mob/living/giver = locateUID(giver_UID)
-	var/mob/living/receiver = locateUID(receiver_UID)
 	// hopefully this will do instead of COMSIG_QDELETING
 	if(!giver)
 		to_chat(receiver, span_warning("Что-то пошло не так при передаче предмета, сообщите об этом в баг-репорты!"))
-		return
+		return FALSE
 
 	if(receiver.stat != CONSCIOUS)
-		return
+		return FALSE
 
-	var/obj/item/I = locateUID(item_UID)
-	if(!I)
-		return
+	var/obj/item/item = locateUID(item_UID)
+	if(!item)
+		return FALSE
 
 	if(receiver.r_hand && receiver.l_hand)
-		to_chat(receiver, span_warning("Освободите руки для принятия [I.declent_ru(ACCUSATIVE)]!"))
-		return
+		to_chat(receiver, span_warning("Освободите руки для принятия [item.declent_ru(ACCUSATIVE)]!"))
+		return FALSE
 
 	if(!giver.Adjacent(receiver))
-		to_chat(receiver, span_warning("Подойдите ближе к [giver] чтобы взять [I.declent_ru(ACCUSATIVE)]!"))
-		return
+		to_chat(receiver, span_warning("Подойдите ближе к [giver] чтобы взять [item.declent_ru(ACCUSATIVE)]!"))
+		return FALSE
 
-	if(HAS_TRAIT(I, TRAIT_NODROP))
-		to_chat(giver, span_warning("[DECLENT_RU_CAP(I, NOMINATIVE)] прилип к вашей руке при попытке передачи!"))
-		to_chat(receiver, span_warning("[DECLENT_RU_CAP(I, NOMINATIVE)] прилип к руке [giver] когда вы пытались взять!"))
-		return
+	if(HAS_TRAIT(item, TRAIT_NODROP))
+		to_chat(giver, span_warning("[DECLENT_RU_CAP(item, NOMINATIVE)] прилип к вашей руке при попытке передачи!"))
+		to_chat(receiver, span_warning("[DECLENT_RU_CAP(item, NOMINATIVE)] прилип к руке [giver] когда вы пытались взять!"))
+		return FALSE
 
-	UnregisterSignal(I, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED)) // We don't want these triggering `cancel_give` at this point, since the give is successful.
+	UnregisterSignal(item, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED)) // We don't want these triggering `cancel_give` at this point, since the give is successful.
 
-	giver.drop_item_ground(I)
-	receiver.put_in_hands(I, ignore_anim = FALSE)
+	giver.drop_item_ground(item)
+	receiver.put_in_hands(item, ignore_anim = FALSE)
 
-	I.add_fingerprint(receiver)
-	I.on_give(giver, receiver)
+	item.add_fingerprint(receiver)
+	item.on_give(giver, receiver)
 
-	receiver.visible_message(span_notice("[giver] переда[PLUR_YOT_YUT(giver)] [I.declent_ru(ACCUSATIVE)] [receiver]."))
+	receiver.visible_message(span_notice("[giver] переда[PLUR_YOT_YUT(giver)] [item.declent_ru(ACCUSATIVE)] [receiver]."))
 	receiver.clear_alert("take item [item_UID]")
+	return TRUE
 
-/atom/movable/screen/alert/take_item/do_timeout(mob/M, category)
-	var/mob/living/giver = locateUID(giver_UID)
-	var/mob/living/receiver = locateUID(receiver_UID)
-	// Make sure we're still nearby. We don't want to show a message if the giver not near us.
-	if(giver in view(3, receiver))
-		var/obj/item/I = locateUID(item_UID)
-		to_chat(giver, span_warning("Вы пытались передать [I.declent_ru(ACCUSATIVE)] [receiver], но [GEND_HE_SHE(receiver)] отказал[GEND_SYA_AS_OS_IS(receiver)]."))
-		to_chat(receiver, span_warning("[giver] прекратил[GEND_A_O_I(giver)] попытку передать вам [I.declent_ru(ACCUSATIVE)]."))
-	..()
+/mob/living/carbon/alert_timeout(atom/movable/screen/alert/alert, category)
+	if(istype(alert, /atom/movable/screen/alert/take_item))
+		var/atom/movable/screen/alert/take_item/take_alert = alert
+		var/mob/living/giver = locateUID(take_alert.giver_UID)
+		// Make sure we're still nearby. We don't want to show a message if the giver not near us.
+		if(giver in view(3, src))
+			var/obj/item/item = locateUID(take_alert.item_UID)
+			to_chat(giver, span_warning("Вы пытались передать [item.declent_ru(ACCUSATIVE)] [src], но [GEND_HE_SHE(src)] отказал[GEND_SYA_AS_OS_IS(src)]."))
+			to_chat(src, span_warning("[giver] прекратил[GEND_A_O_I(giver)] попытку передать вам [item.declent_ru(ACCUSATIVE)]."))
+	return ..()

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -194,7 +194,6 @@
 /atom/movable/screen/alert/take_item
 	name = "Взять предмет"
 	desc = "Вам хотят передать предмет!"
-	icon_state = "template"
 	timeout = 10 SECONDS
 	clickable_glow = TRUE
 	/// UID of the mob offering the receiver an item.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -777,6 +777,8 @@
 	return
 
 /mob/living/proc/revive()
+	if(QDELETED(src))
+		return FALSE
 	rejuvenate()
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1,4 +1,5 @@
-/mob/Destroy()//This makes sure that mobs with clients/keys are not just deleted from the game.
+// This makes sure that mobs with clients/keys are not just deleted from the game.
+/mob/Destroy()
 	persistent_client?.set_mob(null)
 	remove_from_mob_list()
 	remove_from_alive_mob_list()
@@ -15,8 +16,14 @@
 		spellremove(src)
 	mobspellremove(src)
 	QDEL_LIST(diseases)
+
+	if(length(progressbars))
+		stack_trace("[src] destroyed with elements in its progressbars list")
+		progressbars = null
+
 	for(var/alert in alerts)
-		clear_alert(alert)
+		clear_alert(alert, TRUE)
+
 	if(client)
 		clear_client_in_contents()
 	ghostize()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -489,35 +489,38 @@ GLOBAL_LIST_INIT(intents, list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM
 			to_chat(M, span_deadsay("[follow][lname][message]"))
 
 /proc/notify_ghosts(message, ghost_sound = null, enter_link = null, title = null, atom/source = null, image/alert_overlay = null, flashwindow = TRUE, action = NOTIFY_JUMP) //Easy notification of ghosts.
-	for(var/mob/dead/observer/O in GLOB.player_list)
-		if(O.client)
-			to_chat(O, span_ghostalert("[message][(enter_link) ? " [enter_link]" : ""]"))
+	for(var/mob/dead/observer/ghost in GLOB.player_list)
+		if(ghost.client)
+			to_chat(ghost, span_ghostalert("[message][(enter_link) ? " [enter_link]" : ""]"))
 			if(ghost_sound)
-				SEND_SOUND(O, sound(ghost_sound))
+				SEND_SOUND(ghost, sound(ghost_sound))
 			if(flashwindow)
-				window_flash(O.client)
+				window_flash(ghost.client)
 			if(source)
-				var/atom/movable/screen/alert/notify_action/A = O.throw_alert("[source.UID()]_notify_action", /atom/movable/screen/alert/notify_action)
-				if(A)
-					if(O.client.prefs && O.client.prefs.UI_style)
-						A.icon = ui_style2icon(O.client.prefs.UI_style)
+				var/atom/movable/screen/alert/notify_action/toast = ghost.throw_alert(
+					category = "[source.UID()]_notify_action",
+					type = /atom/movable/screen/alert/notify_action,
+				)
+				if(toast)
+					if(ghost.client.prefs && ghost.client.prefs.UI_style)
+						toast.icon = ui_style2icon(ghost.client.prefs.UI_style)
 					if(title)
-						A.name = title
-					A.desc = message
-					A.action = action
-					A.target = source
+						toast.name = title
+					toast.desc = message
+					toast.action = action
+					toast.target_ref = WEAKREF(source)
 					if(!alert_overlay)
 						var/old_layer = source.layer
 						var/old_plane = source.plane
 						source.layer = FLOAT_LAYER
 						source.plane = FLOAT_PLANE
-						A.add_overlay(source)
+						toast.add_overlay(source)
 						source.layer = old_layer
 						source.plane = old_plane
 					else
 						alert_overlay.layer = FLOAT_LAYER
 						alert_overlay.plane = FLOAT_PLANE
-						A.add_overlay(alert_overlay)
+						toast.add_overlay(alert_overlay)
 
 /**
  * Checks if a mob's ghost can reenter their body or not. Used to check for DNR or AntagHUD.

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -212,6 +212,7 @@ range 2-3
 	kinesis_beam = mod.wearer.Beam(grabbed_atom, "kinesis")
 	kinesis_catcher = mod.wearer.overlay_fullscreen("kinesis", /atom/movable/screen/fullscreen/cursor_catcher/kinesis, 0)
 	kinesis_catcher.assign_to_mob(mod.wearer)
+	RegisterSignal(kinesis_catcher, COMSIG_SCREEN_ELEMENT_CLICK, PROC_REF(on_catcher_click))
 	soundloop.start()
 	START_PROCESSING(SSfastprocess, src)
 
@@ -233,6 +234,13 @@ range 2-3
 		animate(grabbed_atom, 0.2 SECONDS, pixel_x = pre_pixel_x, pixel_y = pre_pixel_y)
 	grabbed_atom = null
 	soundloop.stop()
+
+/obj/item/mod/module/anomaly_locked/kinesis/proc/on_catcher_click(atom/source, location, control, params, user)
+	SIGNAL_HANDLER
+
+	var/list/modifiers = params2list(params)
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+		clear_grab()
 
 /obj/item/mod/module/anomaly_locked/kinesis/proc/range_check(atom/target)
 	if(!isturf(mod.wearer.loc))


### PR DESCRIPTION

## Что этот ПР делает
ТиГэ.

Ссылки в скрин муваблах и алертах заменены на викрефы. 
Отрефакторен throw_alert() и Click алертов. 
Click скрин муваблов запрещён, с обходом через COMSIG_SCREEN_ELEMENT_CLICK и default_click. Это убирает такие мемы, как осмотр алертов "Это Прислонился" и "бросание" билдмодов.
Добавлено изменение курсора на палец на кликабельных алертах, а также кнопках на стенах всяких.
Алерты, которые кликабельны подсвечиваются рамкой.
Общий рефактор кода.

## Список изменений
:cl:
qol: Курсор меняется на палец, при наведении на кликабельные элементы интерфейса и некоторых объектов на карте.
qol: Подсвечивание кликабельных алертов.
admin: Добавлено предупреждение при открытии рантайм вьюера, где слишком много рантаймов.
/:cl:
