### PR TITLE
Фикс рекурсии в конце раунда

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -155,7 +155,7 @@
 	return original_mob_UID == o_mob.UID()
 
 // Do not use for admin related things as this can hide the mob's ckey
-/datum/mind/proc/get_display_key()
+/datum/mind/proc/get_mind_key()
 	// Lets try find a client so we can check their prefs
 	var/client/C = null
 

--- a/code/game/gamemodes/auto_decrare.dm
+++ b/code/game/gamemodes/auto_decrare.dm
@@ -5,7 +5,7 @@
 	var/list/text = list(span_fontsize2("<b>Морфами были:</b>"))
 	for(var/datum/mind/morph in morphs)
 		var/traitorwin = TRUE
-		text += "<br>[morph.get_display_key()] был [morph.name] ("
+		text += "<br>[morph.get_mind_key()] был [morph.name] ("
 		if(morph.current)
 			if(morph.current.stat == DEAD)
 				text += "умер"
@@ -44,7 +44,7 @@
 	var/list/text = list(span_fontsize2("<b>Ревенантами были:</b>"))
 	for(var/datum/mind/revenant in revenants)
 		var/traitorwin = TRUE
-		text += "<br>[revenant.get_display_key()] был [revenant.name] ("
+		text += "<br>[revenant.get_mind_key()] был [revenant.name] ("
 		if(revenant.current)
 			if(revenant.current.stat == DEAD)
 				text += "умер"
@@ -83,7 +83,7 @@
 	var/list/text = list(span_fontsize2("<b>Членами Хонксквада были:</b>"))
 	for(var/datum/mind/honker in honksquad)
 		var/traitorwin = TRUE
-		text += "<br>[honker.get_display_key()] был [honker.name] ("
+		text += "<br>[honker.get_mind_key()] был [honker.name] ("
 		if(honker.current)
 			if(honker.current.stat == DEAD)
 				text += "умер"
@@ -124,7 +124,7 @@
 	var/list/text = list(span_fontsize2("<b>Бойцами Отряда Смерти были:</b>"))
 	for(var/datum/mind/commando in deathsquad)
 		var/traitorwin = TRUE
-		text += "<br>[commando.get_display_key()] был [commando.name] ("
+		text += "<br>[commando.get_mind_key()] был [commando.name] ("
 		if(commando.current)
 			if(commando.current.stat == DEAD)
 				text += "умер"
@@ -165,7 +165,7 @@
 	var/list/text = list(span_fontsize2("<b>Бойцами Ударного Отряда \"Синдиката\" были:</b>"))
 	for(var/datum/mind/commando in sst)
 		var/traitorwin = TRUE
-		text += "<br>[commando.get_display_key()] был [commando.name] ("
+		text += "<br>[commando.get_mind_key()] был [commando.name] ("
 		if(commando.current)
 			if(commando.current.stat == DEAD)
 				text += "умер"
@@ -206,7 +206,7 @@
 	var/list/text = list(span_fontsize2("<b>Агентами Диверсионного Отряда \"Синдиката\" были:</b>"))
 	for(var/datum/mind/commando in sit)
 		var/traitorwin = TRUE
-		text += "<br>[commando.get_display_key()] был [commando.name] ("
+		text += "<br>[commando.get_mind_key()] был [commando.name] ("
 		if(commando.current)
 			if(commando.current.stat == DEAD)
 				text += "умер"

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -55,7 +55,7 @@
 		for(var/datum/mind/changeling in changelings)
 			var/changelingwin = TRUE
 
-			text += "<br>[changeling.get_display_key()] was [changeling.name] ("
+			text += "<br>[changeling.get_mind_key()] was [changeling.name] ("
 			if(changeling.current)
 				if(changeling.current.stat == DEAD)
 					text += "died"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -754,7 +754,7 @@
 	if(player.assigned_role)
 		jobtext = " the <b>[player.assigned_role]</b>"
 
-	var/text = "<b>[player.get_display_key()]</b> was <b>[player.name]</b>[jobtext] and"
+	var/text = "<b>[player.get_mind_key()]</b> was <b>[player.name]</b>[jobtext] and"
 	if(player.current)
 		if(player.current.stat == DEAD)
 			text += " [span_redtext("died")]"
@@ -775,7 +775,7 @@
 	return text
 
 /proc/printeventplayer(datum/mind/player)
-	var/text = "<b>[player.get_display_key()]</b> was <b>[player.name]</b>"
+	var/text = "<b>[player.get_mind_key()]</b> was <b>[player.name]</b>"
 	if(player.special_role != SPECIAL_ROLE_EVENTMISC)
 		text += " the [player.special_role]"
 

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -247,7 +247,7 @@ GLOBAL_LIST_EMPTY(cortical_stacks) //Stacks for 'leave nobody behind' objective.
 		var/list/text = list("<span style='font-size: 2;'><b>The Vox raiders were:</b></span>")
 
 		for(var/datum/mind/vox in raiders)
-			text += "<br>[vox.get_display_key()] was [vox.name] ("
+			text += "<br>[vox.get_mind_key()] was [vox.name] ("
 			if(check_return)
 				var/obj/stack = raiders[vox]
 				if(get_area(stack.loc) != locate(/area/shuttle/vox))
@@ -282,7 +282,7 @@ GLOBAL_LIST_EMPTY(cortical_stacks) //Stacks for 'leave nobody behind' objective.
 
 /obj/machinery/vox_win_button/Initialize(mapload)
 	. = ..()
-	
+
 	add_overlay(icon('icons/obj/machines/computer.dmi', "syndie"))
 
 /obj/machinery/vox_win_button/attack_hand(mob/user)

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -283,7 +283,7 @@ Made by Xhuis
 	if(length(shadows))
 		text += "<br>[span_big("<b>Тенелингами были:</b>")]"
 		for(var/datum/mind/shadow in shadows)
-			text += "<br>[shadow.get_display_key()] was [shadow.name] ("
+			text += "<br>[shadow.get_mind_key()] was [shadow.name] ("
 			if(shadow.current)
 				if(shadow.current.stat == DEAD)
 					text += "мертвы"
@@ -298,7 +298,7 @@ Made by Xhuis
 		if(length(shadowling_thralls))
 			text += "<br>[span_big("<b>Рабами были:</b>")]"
 			for(var/datum/mind/thrall in shadowling_thralls)
-				text += "<br>[thrall.get_display_key()] was [thrall.name] ("
+				text += "<br>[thrall.get_mind_key()] was [thrall.name] ("
 				if(thrall.current)
 					if(thrall.current.stat == DEAD)
 						text += "мертвы"

--- a/code/game/gamemodes/spaceninja/space_ninja.dm
+++ b/code/game/gamemodes/spaceninja/space_ninja.dm
@@ -74,7 +74,7 @@
 
 	for(var/datum/mind/ninja in space_ninjas)
 
-		text += "<br><b>[ninja.get_display_key()]</b> был <b>[ninja.name]</b> ("
+		text += "<br><b>[ninja.get_mind_key()]</b> был <b>[ninja.name]</b> ("
 		if(ninja.current)
 			if(ninja.current.stat == DEAD)
 				text += "Умер"

--- a/code/game/gamemodes/vampire/goon_vampire.dm
+++ b/code/game/gamemodes/vampire/goon_vampire.dm
@@ -55,7 +55,7 @@
 	var/list/text = list("<span style='font-size: 2;'><b>The vampires were:</b></span>")
 	for(var/datum/mind/vampire in goon_vampires)
 		var/traitorwin = TRUE
-		text += "<br>[vampire.get_display_key()] was [vampire.name] ("
+		text += "<br>[vampire.get_mind_key()] was [vampire.name] ("
 		if(vampire.current)
 			if(vampire.current.stat == DEAD)
 				text += "died"
@@ -107,7 +107,7 @@
 
 	var/list/text = list("<span style='font-size: 2;'><b>The Enthralled were:</b></span>")
 	for(var/datum/mind/mind in goon_vampire_enthralled)
-		text += "<br>[mind.get_display_key()] was [mind.name] ("
+		text += "<br>[mind.get_mind_key()] was [mind.name] ("
 		if(mind.current)
 			if(mind.current.stat == DEAD)
 				text += "died"

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -53,7 +53,7 @@
 	for(var/datum/mind/vampire in vampires)
 		var/traitorwin = TRUE
 		var/datum/antagonist/vampire/vamp = vampire.has_antag_datum(/datum/antagonist/vampire)
-		text += "<br>[vampire.get_display_key()] was [vampire.name] ("
+		text += "<br>[vampire.get_mind_key()] was [vampire.name] ("
 		if(vampire.current)
 			if(vampire.current.stat == DEAD)
 				text += "died"
@@ -107,7 +107,7 @@
 
 	var/list/text = list("<span style='font-size: 2;'><b>The Enthralled were:</b></span>")
 	for(var/datum/mind/mind in vampire_enthralled)
-		text += "<br>[mind.get_display_key()] was [mind.name] ("
+		text += "<br>[mind.get_mind_key()] was [mind.name] ("
 		if(mind.current)
 			if(mind.current.stat == DEAD)
 				text += "died"

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -298,7 +298,7 @@
 
 		for(var/datum/mind/wizard in wizards)
 
-			text += "<br>[span_bold(wizard.get_display_key())] was [span_bold(wizard.name)] ("
+			text += "<br>[span_bold(wizard.get_mind_key())] was [span_bold(wizard.name)] ("
 			if(wizard.current)
 				if(wizard.current.stat == DEAD)
 					text += "died"
@@ -341,7 +341,7 @@
 		if(length(apprentices))
 			text += span_bold(span_fontsize3("<br>the wizards/witches apprentices were:"))
 			for(var/datum/mind/apprentice in apprentices)
-				text += "<br><b>[apprentice.get_display_key()]</b> was <b>[apprentice.name]</b> ("
+				text += "<br><b>[apprentice.get_mind_key()]</b> was <b>[apprentice.name]</b> ("
 				if(apprentice.current)
 					if(apprentice.current.stat == DEAD)
 						text += "died"

--- a/code/modules/antagonists/devil/devil.dm
+++ b/code/modules/antagonists/devil/devil.dm
@@ -324,7 +324,7 @@
 /datum/antagonist/devil/roundend_report()
 	var/text
 	var/traitorwin = TRUE
-	text += "<br>[owner.get_display_key()] был [owner.name], известный в аду как [info.truename]("
+	text += "<br>[owner.get_mind_key()] был [owner.name], известный в аду как [info.truename]("
 	if(owner.current)
 		if(owner.current.stat == DEAD)
 			text += "умер"

--- a/code/modules/antagonists/devil/sintouched.dm
+++ b/code/modules/antagonists/devil/sintouched.dm
@@ -49,7 +49,7 @@
 /datum/antagonist/sintouched/roundend_report()
 	var/text
 	var/traitorwin = TRUE
-	text += "<br>[owner.get_display_key()] был [owner.name]("
+	text += "<br>[owner.get_mind_key()] был [owner.name]("
 	if(owner.current)
 		if(owner.current.stat == DEAD)
 			text += "умер"

--- a/code/modules/antagonists/syndicate/nuclear/nuclear_team.dm
+++ b/code/modules/antagonists/syndicate/nuclear/nuclear_team.dm
@@ -182,7 +182,7 @@
 
 	for(var/datum/mind/syndicate in members)
 
-		text += "<br><b>[syndicate.get_display_key()]</b> был <b>[syndicate.name]</b> ("
+		text += "<br><b>[syndicate.get_mind_key()]</b> был <b>[syndicate.name]</b> ("
 		if(syndicate.current)
 			if(syndicate.current.stat == DEAD)
 				text += "мёртв"


### PR DESCRIPTION

## Что этот ПР делает
Убирает рекурсию из https://github.com/ss220-space/Paradise/pull/9128 из-за которой в конце раунда не показывался гринтекст и сервер падал в хардрестарт
## Список изменений
:cl:
bugfix: Исправлен показ гринтекста в конце раунда.
/:cl:
