### PR TITLE
mining scanner mineral overlay

### DIFF
--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -134,8 +134,9 @@
 		return
 
 	for(var/turf/simulated/mineral/mineral as anything in minerals)
-		mineral.add_overlay(image('icons/effects/ore_overlays.dmi', mineral.scan_state))
-		mineral.addtimer(CALLBACK(mineral, TYPE_PROC_REF(/atom, cut_overlays)), 3.5 SECONDS)
+		var/image/mineral_overlay = image('icons/effects/ore_overlays.dmi', icon_state = mineral.scan_state)
+		mineral.add_overlay(mineral_overlay)
+		mineral.addtimer(CALLBACK(mineral, TYPE_PROC_REF(/atom, cut_overlay), mineral_overlay), 3.5 SECONDS)
 
 /obj/effect/temp_visual/mining_overlay
 	plane = FULLSCREEN_PLANE


### PR DESCRIPTION

## Что этот ПР делает
Теперь шахтёрский сканер после сканирования руд не будет убирать степень повреждения руд или взрывчатку на них, а только сам спрайт оверлея руды
## Почему это хорошо для игры
ШШахтёры теперь не будут удивляться, почему крепкий камень сломался за один выстрел и куда делась взрывчатка, что была прикреплена на камне
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
bugfix: Исправлен скан руды у шахтёрского сканнера минералов.
/:cl:
