### PR TITLE
Fix energy shuriken_emitter borg

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -533,6 +533,7 @@
 	name = "robotic shuriken emitter"
 	desc = "A device sneakily hidden inside your robotic hand. Shoots 3 energy shurikens that slows and temporary blinds their targets"
 	ammo_type = list(/obj/item/ammo_casing/energy/shuriken/borg)
+	item_flags = ABSTRACT|NOBLUDGEON
 	// Эти два значения не нужны боргам — они не носят ниндзя костюм
 	cost = null
 	my_suit = null

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -534,11 +534,14 @@
 	desc = "A device sneakily hidden inside your robotic hand. Shoots 3 energy shurikens that slows and temporary blinds their targets"
 	ammo_type = list(/obj/item/ammo_casing/energy/shuriken/borg)
 	item_flags = ABSTRACT|NOBLUDGEON
-	// Эти два значения не нужны боргам — они не носят ниндзя костюм
+	// These two values are not needed for borgs - they don't wear a ninja suit
 	cost = null
 	my_suit = null
 
 /obj/item/gun/energy/shuriken_emitter/borg/equip_to_best_slot(mob/M)
+	return
+
+/obj/item/gun/energy/shuriken_emitter/borg/run_drop_held_item(mob/user)
 	return
 
 /obj/item/gun/energy/shuriken_emitter/borg/can_shoot(mob/user)


### PR DESCRIPTION
## Что этот ПР делает
удаляет айтем флаг DROPDEL который присваивался с родительского обьекта и тем самым
>исправляет этот баг: https://discord.com/channels/617003227182792704/1504435645785964616

## Список изменений
:cl:
bugfix: Модуль сюрикенов у ниндзя борга не пропадает при перемещении в хранилище
/:cl: