### PR TITLE
Категории под фаба в дефайны + батарейки для под фаба

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -200,6 +200,15 @@
 #define MECH_FAB_CATEGORY_DARK_GYGAX "Тёмный Гигакс"
 #define MECH_FAB_CATEGORY_SYNDICATE "Синдикат"
 
+
+// Pod fabricator categories
+#define POD_FAB_CATEGORY_WEAPONRY "Вооружение"
+#define POD_FAB_CATEGORY_ARMOR "Броня"
+#define POD_FAB_CATEGORY_CARGO "Хранилища"
+#define POD_FAB_CATEGORY_PARTS "Детали"
+#define POD_FAB_CATEGORY_FRAME "Корпус"
+#define POD_FAB_CATEGORY_MISC "Разное"
+
 // Engine types
 #define ENGTYPE_SING "Сингулярность"
 #define ENGTYPE_TESLA "Тесла"

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -526,8 +526,6 @@
 	component_parts += new /obj/item/stack/sheet/glass(null)
 	RefreshParts()
 
-/obj/machinery/mecha_part_fabricator/spacepod/Initialize(mapload)
-	. = ..()
 	categories = list(
 		POD_FAB_CATEGORY_WEAPONRY,
 		POD_FAB_CATEGORY_ARMOR,

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -529,12 +529,12 @@
 /obj/machinery/mecha_part_fabricator/spacepod/Initialize(mapload)
 	. = ..()
 	categories = list(
-		"Pod_Weaponry",
-		"Pod_Armor",
-		"Pod_Cargo",
-		"Pod_Parts",
-		"Pod_Frame",
-		"Misc",
+		POD_FAB_CATEGORY_WEAPONRY,
+		POD_FAB_CATEGORY_ARMOR,
+		POD_FAB_CATEGORY_CARGO,
+		POD_FAB_CATEGORY_PARTS,
+		POD_FAB_CATEGORY_FRAME,
+		POD_FAB_CATEGORY_MISC,
 	)
 
 /**

--- a/code/modules/research/designs/protolathe/power_designs.dm
+++ b/code/modules/research/designs/protolathe/power_designs.dm
@@ -9,7 +9,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 50)
 	construction_time = 100
 	build_path = /obj/item/stock_parts/cell
-	category = list(AUTOLATHE_CATEGORY_MISC, PROTOLATHE_CATEGORY_POWER, AUTOLATHE_CATEGORY_MACHINERY, PRINTER_CATEGORY_INITIAL)
+	category = list(AUTOLATHE_CATEGORY_MISC, PROTOLATHE_CATEGORY_POWER, AUTOLATHE_CATEGORY_MACHINERY, PRINTER_CATEGORY_INITIAL, POD_FAB_CATEGORY_MISC)
 
 /datum/design/high_cell
 	id = "high_cell"
@@ -18,7 +18,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 60)
 	construction_time = 100
 	build_path = /obj/item/stock_parts/cell/high
-	category = list(AUTOLATHE_CATEGORY_MISC, PROTOLATHE_CATEGORY_POWER)
+	category = list(AUTOLATHE_CATEGORY_MISC, PROTOLATHE_CATEGORY_POWER, POD_FAB_CATEGORY_MISC)
 
 /datum/design/hyper_cell
 	id = "hyper_cell"
@@ -27,7 +27,7 @@
 	materials = list(MAT_METAL = 700, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 400)
 	construction_time = 100
 	build_path = /obj/item/stock_parts/cell/hyper
-	category = list(AUTOLATHE_CATEGORY_MISC, PROTOLATHE_CATEGORY_POWER)
+	category = list(AUTOLATHE_CATEGORY_MISC, PROTOLATHE_CATEGORY_POWER, POD_FAB_CATEGORY_MISC)
 
 /datum/design/super_cell
 	id = "super_cell"
@@ -36,7 +36,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 300)
 	construction_time = 100
 	build_path = /obj/item/stock_parts/cell/super
-	category = list(AUTOLATHE_CATEGORY_MISC, PROTOLATHE_CATEGORY_POWER)
+	category = list(AUTOLATHE_CATEGORY_MISC, PROTOLATHE_CATEGORY_POWER, POD_FAB_CATEGORY_MISC)
 
 /datum/design/bluespace_cell
 	id = "bluespace_cell"
@@ -45,7 +45,7 @@
 	materials = list(MAT_METAL = 800, MAT_GOLD = 120, MAT_GLASS = 600, MAT_DIAMOND = 160, MAT_TITANIUM = 300, MAT_BLUESPACE = 100)
 	construction_time = 100
 	build_path = /obj/item/stock_parts/cell/bluespace
-	category = list(AUTOLATHE_CATEGORY_MISC, PROTOLATHE_CATEGORY_POWER)
+	category = list(AUTOLATHE_CATEGORY_MISC, PROTOLATHE_CATEGORY_POWER, POD_FAB_CATEGORY_MISC)
 
 /datum/design/pacman
 	id = "pacman"

--- a/code/modules/research/designs/protolathe/power_designs.dm
+++ b/code/modules/research/designs/protolathe/power_designs.dm
@@ -41,7 +41,7 @@
 /datum/design/bluespace_cell
 	id = "bluespace_cell"
 	req_tech = list(RESEARCH_TREE_POWERSTORAGE = 6, RESEARCH_TREE_MATERIALS = 5, RESEARCH_TREE_ENGINEERING = 5, RESEARCH_TREE_BLUESPACE = 5)
-	build_type = PROTOLATHE | MECHFAB
+	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 800, MAT_GOLD = 120, MAT_GLASS = 600, MAT_DIAMOND = 160, MAT_TITANIUM = 300, MAT_BLUESPACE = 100)
 	construction_time = 100
 	build_path = /obj/item/stock_parts/cell/bluespace

--- a/code/modules/research/designs/spacepod_designs.dm
+++ b/code/modules/research/designs/spacepod_designs.dm
@@ -7,7 +7,7 @@
 	build_type = PODFAB
 	materials = list(MAT_METAL=5000)
 	build_path = /obj/item/circuitboard/mecha/pod
-	category = list("Pod_Parts")
+	category = list(POD_FAB_CATEGORY_PARTS)
 
 //////////////////////////////////////////////////
 /////////SPACEPOD PARTS///////////////////////////
@@ -21,7 +21,7 @@
 	build_type = PODFAB
 	req_tech = list(RESEARCH_TREE_MATERIALS = 1)
 	build_path = /obj/item/pod_parts/pod_frame/fore_port
-	category = list("Pod_Frame")
+	category = list(POD_FAB_CATEGORY_FRAME)
 	materials = list(MAT_METAL=15000,MAT_GLASS=5000)
 
 /datum/design/podframe_ap
@@ -32,7 +32,7 @@
 	build_type = PODFAB
 	req_tech = list(RESEARCH_TREE_MATERIALS = 1)
 	build_path = /obj/item/pod_parts/pod_frame/aft_port
-	category = list("Pod_Frame")
+	category = list(POD_FAB_CATEGORY_FRAME)
 	materials = list(MAT_METAL=15000,MAT_GLASS=5000)
 
 /datum/design/podframe_fs
@@ -43,7 +43,7 @@
 	build_type = PODFAB
 	req_tech = list(RESEARCH_TREE_MATERIALS = 1)
 	build_path = /obj/item/pod_parts/pod_frame/fore_starboard
-	category = list("Pod_Frame")
+	category = list(POD_FAB_CATEGORY_FRAME)
 	materials = list(MAT_METAL=15000,MAT_GLASS=5000)
 
 /datum/design/podframe_as
@@ -54,7 +54,7 @@
 	build_type = PODFAB
 	req_tech = list(RESEARCH_TREE_MATERIALS = 1)
 	build_path = /obj/item/pod_parts/pod_frame/aft_starboard
-	category = list("Pod_Frame")
+	category = list(POD_FAB_CATEGORY_FRAME)
 	materials = list(MAT_METAL=15000,MAT_GLASS=5000)
 
 //////////////////////////
@@ -69,7 +69,7 @@
 	build_type = MECHFAB | PODFAB
 	req_tech = list(RESEARCH_TREE_MATERIALS = 1)
 	build_path = /obj/item/pod_parts/core
-	category = list("Pod_Parts")
+	category = list(POD_FAB_CATEGORY_PARTS)
 	materials = list(MAT_METAL=5000,MAT_URANIUM=1000,MAT_PLASMA=5000)
 
 //////////////////////////////////////////
@@ -84,7 +84,7 @@
 	build_type = PODFAB
 	req_tech = list(RESEARCH_TREE_MATERIALS = 1)
 	build_path = /obj/item/pod_parts/armor
-	category = list("Pod_Armor")
+	category = list(POD_FAB_CATEGORY_ARMOR)
 	materials = list(MAT_METAL=15000,MAT_GLASS=5000,MAT_PLASMA=10000)
 
 //////////////////////////////////////////
@@ -99,7 +99,7 @@
 	build_type = PODFAB
 	req_tech = list(RESEARCH_TREE_MATERIALS = 2, RESEARCH_TREE_COMBAT = 2)
 	build_path = /obj/item/spacepod_equipment/weaponry/taser
-	category = list("Pod_Weaponry")
+	category = list(POD_FAB_CATEGORY_WEAPONRY)
 	materials = list(MAT_METAL = 15000)
 	locked = 1
 
@@ -111,7 +111,7 @@
 	build_type = PODFAB
 	req_tech = list(RESEARCH_TREE_MATERIALS = 3, RESEARCH_TREE_COMBAT = 3)
 	build_path = /obj/item/spacepod_equipment/weaponry/burst_taser
-	category = list("Pod_Weaponry")
+	category = list(POD_FAB_CATEGORY_WEAPONRY)
 	materials = list(MAT_METAL = 15000,MAT_PLASMA=2000)
 	locked = 1
 
@@ -123,7 +123,7 @@
 	build_type = PODFAB
 	req_tech = list(RESEARCH_TREE_MATERIALS = 3, RESEARCH_TREE_COMBAT = 3, RESEARCH_TREE_PLASMA = 2)
 	build_path = /obj/item/spacepod_equipment/weaponry/laser
-	category = list("Pod_Weaponry")
+	category = list(POD_FAB_CATEGORY_WEAPONRY)
 	materials = list(MAT_METAL=10000,MAT_GLASS=5000,MAT_GOLD=1000,MAT_SILVER=2000)
 	locked = 1
 
@@ -135,7 +135,7 @@
 	build_type = PODFAB
 	req_tech = list(RESEARCH_TREE_COMBAT = 4, RESEARCH_TREE_MAGNETS = 4, RESEARCH_TREE_ENGINEERING = 4)
 	build_path = /obj/item/spacepod_equipment/weaponry/solaris
-	category = list("Pod_Weaponry")
+	category = list(POD_FAB_CATEGORY_WEAPONRY)
 	materials = list(MAT_METAL=20000,MAT_GLASS=10000,MAT_GOLD=2000,MAT_SILVER=4000)
 	locked = 1
 
@@ -148,7 +148,7 @@
 	build_type = PODFAB
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 5000, MAT_SILVER = 2000, MAT_URANIUM = 2000)
 	build_path = /obj/item/spacepod_equipment/weaponry/mining_laser_basic
-	category = list("Pod_Weaponry")
+	category = list(POD_FAB_CATEGORY_WEAPONRY)
 
 /datum/design/pod_mining_laser
 	construction_time = 200
@@ -159,7 +159,7 @@
 	build_type = PODFAB
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 5000, MAT_SILVER = 2000, MAT_GOLD = 2000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/spacepod_equipment/weaponry/mining_laser
-	category = list("Pod_Weaponry")
+	category = list(POD_FAB_CATEGORY_WEAPONRY)
 
 //////////////////////////////////////////
 //////SPACEPOD MISC. ITEMS////////////////
@@ -174,7 +174,7 @@
 	build_type = PODFAB
 	materials = list(MAT_METAL=5000)
 	build_path = /obj/item/spacepod_equipment/misc/tracker
-	category = list("Pod_Parts")
+	category = list(POD_FAB_CATEGORY_PARTS)
 
 //////////////////////////////////////////
 //////SPACEPOD CARGO ITEMS////////////////
@@ -189,7 +189,7 @@
 	build_type = PODFAB
 	materials = list(MAT_METAL=20000, MAT_GLASS=2000)
 	build_path = /obj/item/spacepod_equipment/cargo/ore
-	category = list("Pod_Cargo")
+	category = list(POD_FAB_CATEGORY_CARGO)
 
 /datum/design/pod_cargo_crate
 	construction_time = 100
@@ -200,7 +200,7 @@
 	build_type = PODFAB
 	materials = list(MAT_METAL=25000)
 	build_path = /obj/item/spacepod_equipment/cargo/crate
-	category = list("Pod_Cargo")
+	category = list(POD_FAB_CATEGORY_CARGO)
 
 //////////////////////////////////////////
 //////SPACEPOD SEC CARGO ITEMS////////////
@@ -215,7 +215,7 @@
 	build_type = PODFAB
 	materials = list(MAT_METAL=7500, MAT_GLASS=2500)
 	build_path = /obj/item/spacepod_equipment/sec_cargo/chair
-	category = list("Pod_Cargo")
+	category = list(POD_FAB_CATEGORY_CARGO)
 
 /datum/design/loot_box
 	construction_time = 100
@@ -226,7 +226,7 @@
 	build_type = PODFAB
 	materials = list(MAT_METAL=7500, MAT_GLASS=2500)
 	build_path = /obj/item/spacepod_equipment/sec_cargo/loot_box
-	category = list("Pod_Cargo")
+	category = list(POD_FAB_CATEGORY_CARGO)
 
 //////////////////////////////////////////
 //////SPACEPOD LOCK ITEMS////////////////
@@ -240,7 +240,7 @@
 	build_type = PODFAB
 	materials = list(MAT_METAL=4500)
 	build_path = /obj/item/spacepod_equipment/lock/keyed
-	category = list("Pod_Parts")
+	category = list(POD_FAB_CATEGORY_PARTS)
 
 /datum/design/pod_key
 	construction_time = 100
@@ -251,7 +251,7 @@
 	build_type = PODFAB
 	materials = list(MAT_METAL=500)
 	build_path = /obj/item/spacepod_equipment/key
-	category = list("Pod_Parts")
+	category = list(POD_FAB_CATEGORY_PARTS)
 
 //////////////////////////////////////////
 //////SPACEPOD LOCATORS////////////////
@@ -265,4 +265,4 @@
 	build_type = PODFAB
 	materials = list(MAT_METAL=1000, MAT_GLASS=2000, MAT_SILVER=1000)
 	build_path = /obj/item/spacepod_equipment/locators/basic_pod_locator
-	category = list("Pod_Parts")
+	category = list(POD_FAB_CATEGORY_PARTS)


### PR DESCRIPTION

## Что этот ПР делает
Делает красивые дефайны категорий, возвращает батарейки в категорию "Misk" (а ныне "Разное") под фаба. Ну и чутка перевел категории под фаба
Багрепорт: https://discord.com/channels/617003227182792704/1506321604890853446
## Почему это хорошо для игры
Багрепорт - хорошо, чутка кодстиля - тоже хорошо
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
https://prnt.sc/A5pUR8SFox8I
</p>
</details>

## Список изменений
:cl:

bugfix: Возвращены батарейки в под фабрикатор во складке "Разное"
local: Локализованы категории под фабрикатора
/:cl:
