### PR TITLE
Фикс (нано рефактор?) БФЛ

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -10,6 +10,7 @@
 	var/static/list/forbidden_types = typecacheof(list(
 		/mob/living/simple_animal/hostile/asteroid/elite,
 		/mob/living/simple_animal/hostile/megafauna,
+		/obj/bfl_crack,
 		/obj/docking_port,
 		/obj/effect/abstract,
 		/obj/effect/collapse,

--- a/code/modules/station_goals/bfl.dm
+++ b/code/modules/station_goals/bfl.dm
@@ -151,10 +151,6 @@
 
 	var/obj/machinery/bfl_receiver/receiver = receiver_ref?.resolve()
 
-	if(QDELETED(receiver))
-		receiver = null
-		receiver_ref = null
-
 	if(!receiver || !receiver.state || emag || !receiver.lens || !receiver.lens.anchored)
 		var/turf/rand_location = locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), lavaland_z_lvl)
 		laser = new (rand_location)
@@ -189,10 +185,6 @@
 		turf_lasers += turf_laser
 		below = GET_TURF_BELOW(below) // dig deeper and try another laser
 
-	if(QDELETED(receiver))
-		receiver = null
-		receiver_ref = null
-
 	if(!receiver)
 		for(var/obj/machinery/bfl_receiver/bfl_receiver in SSmachines.get_by_type(/obj/machinery/bfl_receiver))
 			var/turf/receiver_turf = get_turf(bfl_receiver)
@@ -205,9 +197,6 @@
 
 /obj/machinery/power/bfl_emitter/proc/emitter_deactivate()
 	var/obj/machinery/bfl_receiver/receiver = receiver_ref?.resolve()
-	if(QDELETED(receiver))
-		receiver = null
-		receiver_ref = null
 
 	state = FALSE
 	update_icon(UPDATE_ICON_STATE)

--- a/code/modules/station_goals/bfl.dm
+++ b/code/modules/station_goals/bfl.dm
@@ -92,7 +92,7 @@
 	var/emag = FALSE
 	var/state = FALSE
 	var/obj/singularity/bfl_red/laser = null
-	var/obj/machinery/bfl_receiver/receiver = FALSE
+	var/datum/weakref/receiver_ref
 	var/list/obj/effect/bfl_laser/turf_lasers = list()
 	var/deactivate_time = 0
 	var/list/obj/structure/fillers = list()
@@ -149,6 +149,8 @@
 	if(laser)
 		return
 
+	var/obj/machinery/bfl_receiver/receiver = receiver_ref?.resolve()
+
 	if(!receiver || !receiver.state || emag || !receiver.lens || !receiver.lens.anchored)
 		var/turf/rand_location = locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), lavaland_z_lvl)
 		laser = new (rand_location)
@@ -163,6 +165,7 @@
 				receiver.lens.deactivate_lens()
 
 /obj/machinery/power/bfl_emitter/proc/receiver_test()
+	var/obj/machinery/bfl_receiver/receiver = receiver_ref?.resolve()
 	if(receiver)
 		if(receiver.state && receiver.lens)
 			receiver.lens.activate_lens()
@@ -176,6 +179,7 @@
 	location.ChangeTurf(location.baseturf)
 	working_sound()
 	var/turf/below = GET_TURF_BELOW(location)
+	var/obj/machinery/bfl_receiver/receiver = receiver_ref?.resolve()
 	while(below)
 		var/obj/effect/bfl_laser/turf_laser = new(below)
 		turf_lasers += turf_laser
@@ -189,11 +193,13 @@
 			var/turf/receiver_turf = get_turf(bfl_receiver)
 			if(receiver_turf.z == lavaland_z_lvl)
 				receiver = bfl_receiver
+				receiver_ref = WEAKREF(bfl_receiver)
 				break
 
 	receiver_test()
 
 /obj/machinery/power/bfl_emitter/proc/emitter_deactivate()
+	var/obj/machinery/bfl_receiver/receiver = receiver_ref?.resolve()
 	state = FALSE
 	update_icon(UPDATE_ICON_STATE)
 	if(receiver)

--- a/code/modules/station_goals/bfl.dm
+++ b/code/modules/station_goals/bfl.dm
@@ -151,6 +151,10 @@
 
 	var/obj/machinery/bfl_receiver/receiver = receiver_ref?.resolve()
 
+	if(QDELETED(receiver))
+		receiver = null
+		receiver_ref = null
+
 	if(!receiver || !receiver.state || emag || !receiver.lens || !receiver.lens.anchored)
 		var/turf/rand_location = locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), lavaland_z_lvl)
 		laser = new (rand_location)
@@ -187,6 +191,7 @@
 
 	if(QDELETED(receiver))
 		receiver = null
+		receiver_ref = null
 
 	if(!receiver)
 		for(var/obj/machinery/bfl_receiver/bfl_receiver in SSmachines.get_by_type(/obj/machinery/bfl_receiver))
@@ -200,6 +205,10 @@
 
 /obj/machinery/power/bfl_emitter/proc/emitter_deactivate()
 	var/obj/machinery/bfl_receiver/receiver = receiver_ref?.resolve()
+	if(QDELETED(receiver))
+		receiver = null
+		receiver_ref = null
+
 	state = FALSE
 	update_icon(UPDATE_ICON_STATE)
 	if(receiver)


### PR DESCRIPTION

## Что этот ПР делает
Фиксит рантайм при запуске БФЛ (из-за нового QDELETED) переводом переменной receiver на weakref + фиксит падения разлом плазмы в чазм 
## Почему это хорошо для игры
Багфиксы круто, викрефы тоже круто
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:

bugfix: Чинит падения разлома плазмы в чазм + чинит рантайм при запуске БФЛ
refactor: Перевод receiver на викрефы для фикса рантайма

/:cl:
