### PR TITLE
Фикс включения джукбокса ПКМом + сокращение логирования

### DIFF
--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -93,7 +93,7 @@
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || !allowed(user) || !anchored)
 		return .
-	if(need_coin && !payment)
+	if(need_coin && !payment && isnull(music_player.active_song_sound))
 		balloon_alert(user, "нужна монета для воспроизведения!")
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	toggle_playing(user)

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -93,6 +93,9 @@
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || !allowed(user) || !anchored)
 		return .
+	if(need_coin && !payment)
+		balloon_alert(user, "нужна монета для воспроизведения!")
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	toggle_playing(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 

--- a/code/modules/admin/verbs/jukebox_moderation.dm
+++ b/code/modules/admin/verbs/jukebox_moderation.dm
@@ -22,9 +22,7 @@ ADMIN_VERB(upload_jukebox_music, R_SOUNDS, "Jukebox Upload Music", "Загруз
 	// Copy uploaded file to the server
 	fcopy(file, save_path)
 
-	var/msg = "[key_name_admin(user)] uploaded [clean_name] to the jukebox!"
-	message_admins(msg)
-	log_admin(msg)
+	log_and_message_admins("uploaded [clean_name] to the jukebox!")
 	SSblackbox.record_feedback("associative", "jukebox_upload", 1, list("round_id" = "[GLOB.round_id]", "uploader" = "[key_name_admin(user)]", "uploaded" = "[clean_name]"))
 	to_chat(user, span_notice("[clean_name] успешно загружен!"))
 
@@ -49,9 +47,7 @@ ADMIN_VERB(browse_jukebox_music, R_SOUNDS, "Jukebox Browse Music", "Просмо
 			SEND_SOUND(user, sound(path))
 		if("Удалить")
 			fdel(path)
-			var/msg = "[key_name_admin(user)] deleted [choice] from the jukebox!"
-			message_admins(msg)
-			log_admin(msg)
+			log_and_message_admins("deleted [choice] from the jukebox!")
 			SSblackbox.record_feedback("associative", "jukebox_deletion", 1, list("round_id" = "[GLOB.round_id]", "deletor" = "[key_name_admin(user)]", "deleted" = "[choice]"))
 		if("Скачать")
 			user << ftp(WRAP_FILE(path))


### PR DESCRIPTION

## Что этот ПР делает
Если джукбокс требует монетку и в нем НЕТУ монетки - на ПКМ не будет включатся выбранная музыка
Сократил отдельные message_admins(msg) и log_admin(msg) в 1 log_and_message_admins(*лог*)
## Почему это хорошо для игры
Типи багфикс + сокращение кода будто бы круто
## Список изменений
:cl:
bugfix: Больше нельзя включить барный музыкальный автомат на ПКМ пока в нем нет монетки.
/:cl:
