### PR TITLE
Нерф ионных оружий

### DIFF
--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -4,6 +4,8 @@
 	muzzle_flash_color = LIGHT_COLOR_BLUE
 	select_name = "ion"
 	fire_sound = 'sound/weapons/ionrifle.ogg'
+	delay = 3
+	e_cost = 250
 
 // MARK: Declone
 /obj/item/ammo_casing/energy/declone

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -4,7 +4,7 @@
 	muzzle_flash_color = LIGHT_COLOR_BLUE
 	select_name = "ion"
 	fire_sound = 'sound/weapons/ionrifle.ogg'
-	e_cost = 200
+	e_cost = 150
 
 // MARK: Declone
 /obj/item/ammo_casing/energy/declone

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -4,8 +4,7 @@
 	muzzle_flash_color = LIGHT_COLOR_BLUE
 	select_name = "ion"
 	fire_sound = 'sound/weapons/ionrifle.ogg'
-	delay = 3
-	e_cost = 250
+	e_cost = 200
 
 // MARK: Declone
 /obj/item/ammo_casing/energy/declone

--- a/code/modules/projectiles/guns/energy/gun_like.dm
+++ b/code/modules/projectiles/guns/energy/gun_like.dm
@@ -225,7 +225,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/ion)
 	ammo_x_offset = 3
 	accuracy = GUN_ACCURACY_RIFLE_LASER
-	fire_deley = 25
+	fire_delay = 2.5 SECONDS
 
 /obj/item/gun/energy/ionrifle/emp_act(severity)
 	return
@@ -237,7 +237,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT
 	zoomable = FALSE
-	fire_deley = 40
+	fire_delay = 4 SECONDS
 	ammo_x_offset = 2
 	accuracy = GUN_ACCURACY_RIFLE_LASER
 	attachable_allowed = GUN_MODULE_CLASS_RIFLE_RAIL | GUN_MODULE_CLASS_RIFLE_UNDER

--- a/code/modules/projectiles/guns/energy/gun_like.dm
+++ b/code/modules/projectiles/guns/energy/gun_like.dm
@@ -225,6 +225,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/ion)
 	ammo_x_offset = 3
 	accuracy = GUN_ACCURACY_RIFLE_LASER
+	fire_deley = 25
 
 /obj/item/gun/energy/ionrifle/emp_act(severity)
 	return
@@ -236,6 +237,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT
 	zoomable = FALSE
+	fire_deley = 40
 	ammo_x_offset = 2
 	accuracy = GUN_ACCURACY_RIFLE_LASER
 	attachable_allowed = GUN_MODULE_CLASS_RIFLE_RAIL | GUN_MODULE_CLASS_RIFLE_UNDER


### PR DESCRIPTION
## Что этот ПР делает

Добавляет КД между выстреами ионок:
Ионная винтовка - 2.5 секунд
Ионный карабин - 4 секунды

Повышает стоимость энергии с 100 до 150 [Общее количество выстрелов уменьшилось с 15 до 10]

## Почему это хорошо для игры

В данный момент много небеспочвенных жалоб что любая попытка антагониста поиграть через мехов, или на расе КеПеБе заканчивается быстрым спамом ионкой по бедолаге, так будет небольшой шанс выжить и даже победить противника

## Список изменений

:cl:
balance: Добавляет задержку между выстреами ионок, и повышение стоимости выстрела до 150
/:cl:

