### PR TITLE
Обновление внешности кошелька при приклеивании наклейки на карту

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -354,3 +354,6 @@
 
 /// Called when attempting to swap two-handed weapons
 #define COMSIG_ITEM_SWAP_BLOCKED "item_swap_blocked"
+
+/// Called when card decal applied to ID card.
+#define COMSIG_CARD_DECAL_APPLIED "card_decal_applied"

--- a/code/game/objects/items/id_cards/__id_card.dm
+++ b/code/game/objects/items/id_cards/__id_card.dm
@@ -233,6 +233,7 @@
 		desc = decal.decal_desc
 		icon_state = decal.decal_icon_state
 		item_state = decal.decal_item_state
+		SEND_SIGNAL(loc, COMSIG_CARD_DECAL_APPLIED)
 		qdel(decal)
 		return ATTACK_CHAIN_BLOCKED_ALL
 

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -61,7 +61,7 @@
 	. = ..()
 	refresh_ID()
 
-/obj/item/storage/wallet/proc/refresh_on_signal(datum/source)
+/obj/item/storage/wallet/proc/refresh_id_on_signal(datum/source)
 	SIGNAL_HANDLER
 
 	refresh_ID()

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -38,6 +38,10 @@
 	var/obj/item/card/id/front_id = null
 	var/image/front_id_overlay = null
 
+/obj/item/storage/wallet/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_CARD_DECAL_APPLIED, PROC_REF(refresh_ID))
+
 /obj/item/storage/wallet/remove_from_storage(obj/item/I, atom/new_location)
 	. = ..()
 	if(. && is_id_card(I))

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -40,7 +40,7 @@
 
 /obj/item/storage/wallet/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_CARD_DECAL_APPLIED, PROC_REF(refresh_ID))
+	RegisterSignal(src, COMSIG_CARD_DECAL_APPLIED, PROC_REF(refresh_on_signal))
 
 /obj/item/storage/wallet/remove_from_storage(obj/item/I, atom/new_location)
 	. = ..()
@@ -59,6 +59,11 @@
 
 /obj/item/storage/wallet/orient2hud(mob/user)
 	. = ..()
+	refresh_ID()
+
+/obj/item/storage/wallet/proc/refresh_on_signal(datum/source)
+	SIGNAL_HANDLER
+
 	refresh_ID()
 
 /obj/item/storage/wallet/proc/refresh_ID()

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -40,7 +40,7 @@
 
 /obj/item/storage/wallet/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_CARD_DECAL_APPLIED, PROC_REF(refresh_on_signal))
+	RegisterSignal(src, COMSIG_CARD_DECAL_APPLIED, PROC_REF(refresh_id_on_signal))
 
 /obj/item/storage/wallet/remove_from_storage(obj/item/I, atom/new_location)
 	. = ..()


### PR DESCRIPTION

## Что этот ПР делает
Сигналом запускает обновление аппиренса кошелька при приклеивании на карту скина
## Почему это хорошо для игры
По-сути багфикс, а багфиксы круто
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:

bugfix: Обновление спрайта кошелька при приклеивании в нем наклейки на карту.
/:cl:
