### PR TITLE
Багфикс метки на легионе

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
@@ -388,6 +388,7 @@
 	nightvision = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	tts_seed = "Mannoroth"
+	mob_size = MOB_SIZE_LARGE
 
 /mob/living/simple_animal/hostile/big_legion/get_ru_names()
 	return list(


### PR DESCRIPTION

## Что этот ПР делает
из-за наследования от иного моба легион не имел переменную mob_size = MOB_SIZE_LARGE, из-за этого метка крашера не вешалась 
## Почему это хорошо для игры
баги плохо, фиксы хорошо
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
bugfix: Метку крашера можно вешать на большого легиона с некрополя (не мегафауна)
/:cl:
