### PR TITLE
Убирает 2 мусорных префаба настенных дефибов

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -32,7 +32,9 @@
 	},
 /area/crew_quarters/serviceyard)
 "aah" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "aam" = (
@@ -167,7 +169,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /mob/living/simple_animal/parrot/Poly,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -189,7 +191,9 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "aax" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/iv_drip,
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
@@ -252,7 +256,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /mob/living/simple_animal/pet/dog/corgi/borgi,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -295,6 +299,13 @@
 	icon_state = "dark"
 	},
 /area/toxins/xenobiology)
+"abl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel,
+/area/quartermaster/storage)
 "abO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -360,7 +371,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "acr" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkblue"
@@ -369,7 +382,9 @@
 "act" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/storage/box/masks,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
 "acC" = (
@@ -390,7 +405,7 @@
 /area/crew_quarters/heads/hop)
 "acU" = (
 /obj/machinery/portable_atmospherics/scrubber/huge/stationary,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -399,7 +414,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -407,7 +424,9 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "adc" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
@@ -464,7 +483,6 @@
 	amount = 20
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -478,7 +496,9 @@
 "aex" = (
 /obj/machinery/recharge_station,
 /obj/machinery/alarm/directional/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/aisat/maintenance)
 "aeE" = (
@@ -519,7 +539,6 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/window/plasmareinforced{
@@ -536,7 +555,9 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "afE" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "afL" = (
@@ -549,7 +570,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -629,7 +650,9 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry/westarrival)
 "agr" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/toxins/launch)
 "agA" = (
@@ -732,7 +755,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/additional)
 "ahs" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aht" = (
@@ -802,7 +827,7 @@
 	network = list("Engineering","SS13");
 	pixel_y = -22
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -882,7 +907,9 @@
 	},
 /area/quartermaster/miningdock)
 "ajn" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "ajy" = (
@@ -924,10 +951,10 @@
 /turf/simulated/wall,
 /area/hallway/secondary/entry/eastarrival)
 "ajP" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
 /obj/machinery/atm{
@@ -1012,7 +1039,7 @@
 	},
 /area/engineering/mechanic_workshop)
 "ald" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/sign/vacuum{
 	pixel_y = 32
 	},
@@ -1023,7 +1050,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "alt" = (
@@ -1039,7 +1066,9 @@
 /obj/structure/sign/pods{
 	pixel_x = -32
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "alN" = (
@@ -1062,7 +1091,9 @@
 	},
 /area/security/main)
 "alQ" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "alT" = (
@@ -1150,7 +1181,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
@@ -1166,7 +1197,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "amw" = (
@@ -1233,7 +1264,7 @@
 /area/bridge)
 "amZ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
@@ -1284,7 +1315,7 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/station_map/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1310,7 +1341,9 @@
 	},
 /area/quartermaster/sorting)
 "anN" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "anP" = (
@@ -1363,7 +1396,7 @@
 /area/teleporter/abandoned)
 "aoc" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -1445,7 +1478,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "aoS" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/door/airlock/external{
 	id_tag = "admin_home";
 	locked = 1
@@ -1461,7 +1496,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aph" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "api" = (
@@ -1532,7 +1567,7 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "apE" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 1
 	},
@@ -1551,7 +1586,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "apJ" = (
@@ -1637,7 +1674,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "neutral"
@@ -1664,7 +1703,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "aqq" = (
@@ -1691,7 +1732,7 @@
 /area/toxins/sm_test_chamber)
 "aqB" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -1703,7 +1744,7 @@
 "aqY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -1737,7 +1778,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "arm" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1861,7 +1902,9 @@
 	},
 /area/engineering/mechanic_workshop/expedition)
 "arX" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "asb" = (
@@ -1874,7 +1917,9 @@
 /turf/simulated/wall,
 /area/engineering/mechanic_workshop/hangar)
 "ase" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -1984,18 +2029,24 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "atW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aua" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2008,14 +2059,18 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "auf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -2050,7 +2105,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "neutral"
@@ -2132,7 +2189,7 @@
 	name = "Hangar Gate"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2152,7 +2209,7 @@
 /area/hallway/secondary/entry/lounge)
 "avg" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/sign/botany{
 	pixel_x = -32
 	},
@@ -2196,7 +2253,7 @@
 	},
 /area/engineering/mechanic_workshop)
 "avq" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	pixel_y = 15
 	},
 /turf/simulated/floor/plasteel{
@@ -2227,7 +2284,9 @@
 	},
 /area/engineering/controlroom)
 "avC" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
@@ -2244,7 +2303,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "avL" = (
@@ -2252,7 +2313,9 @@
 	dir = 1
 	},
 /obj/item/wrench,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/test_chamber)
 "avO" = (
@@ -2260,7 +2323,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "avX" = (
@@ -2275,7 +2338,7 @@
 	},
 /area/toxins/sm_test_chamber)
 "avZ" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "awg" = (
@@ -2283,7 +2346,9 @@
 	pixel_x = -32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "awh" = (
@@ -2308,7 +2373,9 @@
 	pixel_x = 32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aws" = (
@@ -2331,7 +2398,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -2345,7 +2412,9 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/supermatter)
 "awJ" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -2367,7 +2436,9 @@
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/arrival/station)
 "awV" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "awY" = (
@@ -2381,7 +2452,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "axa" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "axf" = (
@@ -2425,7 +2498,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "axm" = (
@@ -2476,7 +2549,9 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop)
 "axM" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -2521,7 +2596,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aym" = (
@@ -2558,8 +2635,10 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "ays" = (
@@ -2580,7 +2659,9 @@
 /turf/simulated/wall,
 /area/quartermaster/sorting)
 "ayB" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "ayD" = (
@@ -2595,8 +2676,10 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "ayH" = (
@@ -2606,8 +2689,12 @@
 	},
 /area/engineering/mechanic_workshop)
 "ayI" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop)
@@ -2618,7 +2705,7 @@
 	name = "Hangar Gate"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/hangar)
 "ayU" = (
@@ -2647,7 +2734,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -2698,11 +2784,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "azC" = (
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -2722,13 +2810,15 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/arrival/station)
 "aAb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "aAc" = (
@@ -2744,8 +2834,10 @@
 	},
 /area/hallway/secondary/entry/additional)
 "aAh" = (
-/obj/effect/decal/warning_stripes/blue,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/delivery/blue,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/sink{
 	pixel_y = 22
 	},
@@ -2848,8 +2940,10 @@
 	pixel_x = -32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aAO" = (
@@ -2864,7 +2958,7 @@
 /area/hallway/primary/port)
 "aAT" = (
 /obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/door_control{
 	desiredstate = 1;
 	id = "toilet2";
@@ -2876,6 +2970,7 @@
 /obj/structure/toilet{
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
 "aAW" = (
@@ -2883,8 +2978,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aAY" = (
@@ -2935,7 +3032,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aBn" = (
@@ -2987,7 +3086,9 @@
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "aBy" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -3047,7 +3148,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/simulated/floor/plating,
 /area/aisat/maintenance)
@@ -3061,6 +3162,12 @@
 	icon_state = "dark"
 	},
 /area/engineering/mechanic_workshop/hangar)
+"aCd" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/atmos)
 "aCf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3071,6 +3178,17 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
+"aCt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/aft)
 "aCv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -3101,11 +3219,13 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "aCA" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aCD" = (
-/obj/effect/decal/warning_stripes/blue,
+/obj/effect/turf_decal/delivery/blue,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
@@ -3126,7 +3246,7 @@
 /obj/item/radio,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light_switch/directional/east,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -3140,15 +3260,15 @@
 	},
 /area/maintenance/asmaint4)
 "aDe" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/binary/volume_pump/on,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "aDh" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3189,7 +3309,9 @@
 /obj/structure/sign/vacuum{
 	pixel_x = -32
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aDz" = (
@@ -3212,7 +3334,9 @@
 	c_tag = "Cargo Office North-West";
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/computer/supplycomp{
 	dir = 4
 	},
@@ -3263,7 +3387,9 @@
 /area/shuttle/arrival/station)
 "aEh" = (
 /obj/machinery/vending/coffee,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whitepurple"
@@ -3301,8 +3427,6 @@
 /area/maintenance/casino)
 "aEn" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3438,15 +3562,13 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3645,7 +3767,7 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aGL" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "aGO" = (
@@ -3658,6 +3780,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -3667,7 +3790,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3681,8 +3806,6 @@
 /area/crew_quarters/serviceyard)
 "aHc" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -3693,8 +3816,6 @@
 "aHe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3703,7 +3824,7 @@
 /area/engineering/controlroom)
 "aHf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/blue,
+/obj/effect/turf_decal/delivery/blue,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -3717,7 +3838,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3725,7 +3846,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "aHs" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aHu" = (
@@ -3852,7 +3973,7 @@
 	name = "Turbine Generator Access";
 	req_access = list(24)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "aIC" = (
@@ -4006,7 +4127,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4014,7 +4137,9 @@
 /area/engineering/controlroom)
 "aJQ" = (
 /obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -4102,7 +4227,6 @@
 	},
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -4129,8 +4253,8 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aKH" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel,
@@ -4180,6 +4304,13 @@
 	icon_state = "dark"
 	},
 /area/engineering/mechanic_workshop/hangar)
+"aKR" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/storage/tech)
 "aKS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4234,7 +4365,7 @@
 	name = "Atmospherics Access";
 	req_access = list(24)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4290,12 +4421,12 @@
 /area/engineering/mechanic_workshop)
 "aLr" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "aLs" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/camera{
 	c_tag = "Arrivals West Bay 4"
 	},
@@ -4315,7 +4446,7 @@
 	},
 /area/engineering/mechanic_workshop)
 "aLv" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -4336,7 +4467,7 @@
 /area/bridge/checkpoint/south)
 "aLE" = (
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/blue,
+/obj/effect/turf_decal/delivery/blue,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aLG" = (
@@ -4551,7 +4682,9 @@
 	c_tag = "Arrivals West-North";
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aNj" = (
@@ -4629,7 +4762,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "aNA" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aNB" = (
@@ -4686,7 +4821,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "aNY" = (
@@ -4697,7 +4834,9 @@
 	},
 /area/crew_quarters/fitness)
 "aOc" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aOd" = (
@@ -4825,13 +4964,11 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aOP" = (
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding1"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4961,7 +5098,7 @@
 /area/security/permabrig)
 "aPx" = (
 /obj/structure/bookcase,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -4976,7 +5113,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
 	req_access = list(10)
@@ -5084,7 +5221,9 @@
 /turf/simulated/floor/greengrid,
 /area/engineering/controlroom)
 "aQM" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 6;
@@ -5093,7 +5232,9 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "aQO" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -5103,7 +5244,9 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "aQS" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -5260,6 +5403,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
@@ -5304,7 +5448,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "aSH" = (
@@ -5388,7 +5534,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aTm" = (
@@ -5489,7 +5637,7 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "aTU" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	dir = 4;
@@ -5500,6 +5648,10 @@
 	icon_state = "neutralfull"
 	},
 /area/atmos)
+"aTV" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/mech_bay_recharge_floor,
+/area/assembly/chargebay)
 "aTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip{
@@ -5543,7 +5695,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "aUr" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -5663,7 +5817,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -5678,7 +5834,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -5688,7 +5846,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -5702,6 +5860,7 @@
 	c_tag = "Fore Hallway South 2";
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -5727,7 +5886,7 @@
 "aVI" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -5751,8 +5910,8 @@
 	dir = 1
 	},
 /obj/machinery/plantgenes,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/green,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/delivery/green,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -5778,7 +5937,7 @@
 	},
 /area/crew_quarters/bar)
 "aWr" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/cargotech,
 /obj/item/stamp/granted,
 /obj/item/stamp/denied,
@@ -5883,15 +6042,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/brig)
 "aXd" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/item/extinguisher/mini,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "aXe" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/sign/vacuum{
 	pixel_x = -32
 	},
@@ -5925,11 +6088,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aXt" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
@@ -5989,11 +6154,15 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "aXM" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -6065,11 +6234,13 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "aYx" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/suit_storage_unit/atmos,
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -6087,7 +6258,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "aYH" = (
@@ -6134,6 +6307,7 @@
 	name = "Waste Incinerator";
 	req_access = list(12,24,39)
 	},
+/obj/structure/plasticflaps/kitchen,
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "aYW" = (
@@ -6163,8 +6337,8 @@
 /area/hallway/primary/fore)
 "aZc" = (
 /obj/structure/dispenser,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/eastsouthwest,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/end,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -6206,7 +6380,9 @@
 /obj/machinery/atm{
 	pixel_x = 32
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aZi" = (
@@ -6218,7 +6394,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -6347,13 +6523,17 @@
 	},
 /area/quartermaster/storage)
 "baj" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/suit_storage_unit/atmos,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bal" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/suit_storage_unit/atmos,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel,
@@ -6369,7 +6549,7 @@
 /area/atmos)
 "baD" = (
 /obj/machinery/recharge_station,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/camera{
 	c_tag = "Briefing Room South";
@@ -6382,7 +6562,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/structure/closet/firecloset,
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel,
@@ -6403,7 +6583,6 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -6522,13 +6701,28 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "bbw" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/entry/commercial)
+"bbx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/central/sw)
 "bbE" = (
 /obj/machinery/camera{
 	c_tag = "Rec Room Center";
@@ -6559,7 +6753,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/fireaxecabinet{
 	pixel_x = 30
 	},
@@ -6599,7 +6793,7 @@
 	pixel_x = -1;
 	pixel_y = 9
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -6640,7 +6834,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/banya)
 "bck" = (
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -6648,7 +6842,7 @@
 /area/engineering/mechanic_workshop/hangar)
 "bcn" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -6690,7 +6884,7 @@
 	},
 /area/quartermaster/office)
 "bcy" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bcz" = (
@@ -6778,7 +6972,9 @@
 	},
 /area/maintenance/bar)
 "bdu" = (
-/obj/effect/decal/warning_stripes/northwestsouth,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
 /obj/structure/bed/amb_trolley{
 	dir = 4
 	},
@@ -6797,7 +6993,7 @@
 	},
 /area/crew_quarters/kitchen)
 "bdA" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/cargotech,
 /obj/item/stamp/granted,
 /obj/item/stamp/denied,
@@ -6817,12 +7013,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "bdO" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/closet/walllocker/emerglocker/directional/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
@@ -6870,14 +7066,14 @@
 /area/quartermaster/miningdock)
 "bef" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
 "bei" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "bek" = (
@@ -6903,8 +7099,6 @@
 /area/security/medbay)
 "bep" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/lattice/catwalk,
@@ -6924,6 +7118,12 @@
 "beC" = (
 /turf/simulated/wall,
 /area/engineering/mechanic_workshop)
+"beM" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "beO" = (
 /obj/machinery/atmospherics/air_sensor/n2{
 	id_tag = "n2_sensor"
@@ -6962,7 +7162,9 @@
 	id_tag = "janitorshutters";
 	name = "Janitor Shutters"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -6982,7 +7184,7 @@
 /area/maintenance/consarea_virology)
 "bfw" = (
 /obj/structure/ore_box,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "bfz" = (
@@ -6999,7 +7201,9 @@
 	},
 /area/space)
 "bfF" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/door/airlock/external{
 	id_tag = "specops_home";
 	locked = 1
@@ -7019,12 +7223,14 @@
 /turf/simulated/floor/carpet/red,
 /area/maintenance/casino)
 "bfU" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
 "bfW" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -7041,7 +7247,9 @@
 /area/library)
 "bge" = (
 /obj/machinery/chem_dispenser,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/door_control{
 	id = "Chemistry2";
 	name = "Chem Medbay Desk Shutters";
@@ -7078,7 +7286,7 @@
 	id_tag = "eva-shutters";
 	name = "E.V.A. Storage Shutters"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -7283,7 +7491,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -7441,14 +7649,14 @@
 /obj/machinery/vending/wallmed{
 	pixel_y = -30
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/miningdock)
 "bib" = (
 /obj/machinery/space_heater,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7473,9 +7681,20 @@
 /area/quartermaster/miningdock)
 "bif" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
+"bim" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/quartermaster/qm)
 "biq" = (
 /obj/structure/falsewall,
 /turf/simulated/floor/plating,
@@ -7506,6 +7725,7 @@
 	drive_range = 58;
 	id_tag = "toxinsdriver"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plating,
 /area/toxins/launch)
 "biC" = (
@@ -7519,7 +7739,7 @@
 	},
 /area/maintenance/bar)
 "biL" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	dir = 9;
@@ -7563,7 +7783,9 @@
 /turf/simulated/floor/plasteel/grimy,
 /area/civilian/vacantoffice)
 "biW" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -7571,7 +7793,7 @@
 	},
 /area/toxins/mixing)
 "biX" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -7580,8 +7802,10 @@
 /area/toxins/mixing)
 "biZ" = (
 /obj/machinery/mecha_part_fabricator,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -7597,7 +7821,9 @@
 	},
 /area/crew_quarters/kitchen)
 "bjg" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -7605,7 +7831,9 @@
 "bjh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -7621,7 +7849,9 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -7658,7 +7888,7 @@
 /turf/simulated/wall,
 /area/crew_quarters/bar/atrium)
 "bju" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -7821,7 +8051,7 @@
 	name = "Distribution Loop";
 	req_access = list(24)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bkE" = (
@@ -7911,10 +8141,10 @@
 	},
 /area/quartermaster/storage)
 "bkV" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -8008,7 +8238,7 @@
 /area/hallway/secondary/entry/commercial)
 "blw" = (
 /obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -8031,7 +8261,7 @@
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
 "blB" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/sign/cargo{
 	pixel_x = 32;
 	pixel_y = 32
@@ -8059,7 +8289,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "blL" = (
@@ -8099,7 +8329,7 @@
 /area/hallway/secondary/entry/commercial)
 "blS" = (
 /obj/structure/weightmachine/stacklifter,
-/obj/effect/decal/warning_stripes/white/hollow,
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -8301,11 +8531,12 @@
 	},
 /area/hallway/primary/starboard/east)
 "bnT" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Escape Private Room";
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/purple,
@@ -8356,7 +8587,9 @@
 	},
 /area/quartermaster/storage)
 "bot" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bov" = (
@@ -8371,7 +8604,7 @@
 /area/medical/research)
 "boD" = (
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "boG" = (
@@ -8401,7 +8634,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "boK" = (
@@ -8419,7 +8652,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "boU" = (
@@ -8609,7 +8842,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -8625,10 +8860,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -8637,7 +8872,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -8661,7 +8898,7 @@
 	},
 /area/maintenance/banya)
 "brc" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -8750,7 +8987,9 @@
 /area/quartermaster/office)
 "brB" = (
 /obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 5;
@@ -8769,7 +9008,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "brF" = (
-/obj/structure/plasticflaps/mining,
+/obj/structure/plasticflaps,
 /obj/effect/spawner/lootdrop/maintenance/double,
 /obj/machinery/conveyor{
 	dir = 8;
@@ -8804,7 +9043,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -8919,8 +9158,6 @@
 /area/civilian/vacantoffice)
 "bsu" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -8929,8 +9166,6 @@
 /area/engineering/controlroom)
 "bsw" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -8938,11 +9173,9 @@
 	},
 /area/engineering/controlroom)
 "bsx" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -8954,8 +9187,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -8979,7 +9210,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -9003,7 +9233,9 @@
 /obj/machinery/atm{
 	pixel_x = -32
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -9018,7 +9250,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "bsH" = (
@@ -9038,7 +9272,7 @@
 	name = "E.V.A.";
 	req_access = list(18)
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "bsM" = (
@@ -9064,6 +9298,7 @@
 	},
 /obj/structure/bed/wicker,
 /obj/item/radio/intercom/locked/prison/directional/east,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plating,
 /area/security/visiting_room)
 "bta" = (
@@ -9144,8 +9379,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/plasticflaps,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -9160,7 +9395,9 @@
 	c_tag = "Arrivals Center South";
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "btq" = (
@@ -9189,7 +9426,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9203,7 +9440,7 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -9220,7 +9457,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -9248,7 +9487,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -9295,7 +9534,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "btT" = (
@@ -9336,7 +9577,7 @@
 /area/engineering/controlroom)
 "btY" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -9375,17 +9616,15 @@
 	pixel_y = 32
 	},
 /obj/machinery/firealarm/directional/east,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "buf" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "bul" = (
@@ -9393,7 +9632,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
 	req_access = list(10)
@@ -9453,14 +9692,14 @@
 	dir = 1
 	},
 /obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "buK" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9471,7 +9710,7 @@
 /area/hallway/secondary/entry/lounge)
 "buO" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/lounge)
 "buP" = (
@@ -9485,7 +9724,9 @@
 	c_tag = "Arrivals Center Aft";
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "buR" = (
@@ -9521,7 +9762,9 @@
 	c_tag = "Arrivals Aft Starboard";
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "bvj" = (
@@ -9542,7 +9785,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -9576,7 +9821,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -9656,8 +9901,10 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "escape"
 	},
@@ -9750,7 +9997,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "bwF" = (
@@ -9812,11 +10061,11 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "bwS" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "bwT" = (
-/obj/effect/decal/warning_stripes/blue,
+/obj/effect/turf_decal/delivery/blue,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
@@ -9926,7 +10175,7 @@
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/decal/warning_stripes/white,
+/obj/effect/turf_decal/delivery/white,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -10079,7 +10328,9 @@
 	},
 /area/hallway/primary/port/west)
 "byA" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/camera{
 	c_tag = "Supermatter Entrance";
 	network = list("SS13","Engineering")
@@ -10093,7 +10344,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/turf_decal/delivery/partial,
 /obj/structure/chair/sofa/bench/left,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -10172,7 +10423,7 @@
 /area/bridge)
 "byY" = (
 /obj/machinery/alarm/directional/east,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/computer/general_air_control{
 	frequency = 1443;
 	level = 3;
@@ -10244,7 +10495,9 @@
 	},
 /area/atmos)
 "bzj" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/flasher/portable,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -10275,7 +10528,9 @@
 	},
 /area/maintenance/asmaint4)
 "bzr" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -10338,7 +10593,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -10355,7 +10612,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/landmark/lightsout,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10377,7 +10634,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northwestsouth,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "bzL" = (
@@ -10387,9 +10646,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "bzT" = (
@@ -10440,7 +10701,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -10517,7 +10778,7 @@
 /area/bridge/checkpoint/north)
 "bAu" = (
 /obj/machinery/firealarm/directional/east,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/reagent_dispensers/oil,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/simulated/floor/plasteel{
@@ -10657,7 +10918,9 @@
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -10686,12 +10949,14 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "bBj" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "bBn" = (
@@ -10711,7 +10976,9 @@
 	},
 /area/quartermaster/storage)
 "bBt" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "bBx" = (
@@ -10796,7 +11063,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/circuitboard/chem_dispenser{
 	pixel_x = -1;
 	pixel_y = 1
@@ -10828,14 +11095,18 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/storage/tech)
 "bBQ" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/door/poddoor/multi_tile/two_tile_ver{
 	id_tag = "mechanicgate"
 	},
@@ -10905,7 +11176,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "bCl" = (
@@ -11051,7 +11324,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel{
@@ -11064,7 +11337,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/pen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -11077,7 +11350,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -11105,7 +11380,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bDw" = (
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
@@ -11146,7 +11421,7 @@
 	},
 /area/bridge)
 "bDS" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -11203,7 +11478,9 @@
 	},
 /area/bridge/checkpoint/north)
 "bEf" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "bEg" = (
@@ -11217,7 +11494,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "bEh" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -11278,8 +11555,8 @@
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
 "bEw" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/plasticflaps,
+/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
@@ -11288,7 +11565,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
 "bEG" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11372,19 +11649,25 @@
 	},
 /area/engineering/break_room)
 "bEV" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "bEX" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "bFb" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "bFd" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -11401,7 +11684,7 @@
 	pixel_y = 3
 	},
 /obj/item/circuitboard/powermonitor,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -11410,7 +11693,7 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/storage/box/lights/mixed,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -11451,7 +11734,7 @@
 	},
 /area/turret_protected/ai_upload)
 "bFA" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -11626,7 +11909,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -11656,11 +11939,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "bGD" = (
@@ -11692,13 +11977,13 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/storage/tech)
 "bGL" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/rack,
 /obj/item/circuitboard/autolathe{
 	pixel_x = 3;
@@ -11738,7 +12023,7 @@
 "bHd" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/storage/firstaid/regular{
 	pixel_x = 4;
 	pixel_y = 4
@@ -11768,7 +12053,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bHo" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -11942,7 +12227,7 @@
 /obj/machinery/vending/wallmed{
 	pixel_x = -25
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -12019,7 +12304,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "bIP" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	dir = 10;
@@ -12092,7 +12377,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "bJk" = (
@@ -12113,7 +12398,7 @@
 	},
 /area/maintenance/electrical)
 "bJq" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/chair/sofa/bench{
 	dir = 1
 	},
@@ -12136,8 +12421,6 @@
 /area/bridge/checkpoint/north)
 "bJx" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
@@ -12154,7 +12437,7 @@
 	pixel_x = -32
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -12299,7 +12582,9 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -12334,7 +12619,7 @@
 /area/crew_quarters/kitchen)
 "bKV" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/vending/wallmed{
 	pixel_x = 26
 	},
@@ -12511,8 +12796,10 @@
 /turf/space,
 /area/solar/auxport)
 "bMn" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -12576,8 +12863,10 @@
 	},
 /area/bridge/checkpoint/north)
 "bMD" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "bME" = (
@@ -12604,7 +12893,7 @@
 /area/ntrep)
 "bMH" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -12656,7 +12945,7 @@
 /area/turret_protected/ai_upload)
 "bNc" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -12695,7 +12984,7 @@
 /area/security/prison/cell_block/A)
 "bNz" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -12780,7 +13069,7 @@
 /area/aisat/aihallway)
 "bNS" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
 "bNT" = (
@@ -12820,7 +13109,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -12850,7 +13141,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -12861,7 +13152,7 @@
 /area/hallway/secondary/entry/commercial)
 "bOq" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12923,7 +13214,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "bOF" = (
@@ -12948,7 +13241,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -13003,7 +13296,7 @@
 /area/hallway/secondary/entry/lounge)
 "bOU" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bOX" = (
@@ -13027,7 +13320,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/power/smes/full,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -13039,7 +13332,7 @@
 	},
 /area/medical/surgery/north)
 "bPk" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -13060,7 +13353,7 @@
 /area/maintenance/fore)
 "bPr" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -13084,7 +13377,9 @@
 	},
 /area/security/customs)
 "bPw" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -13128,7 +13423,7 @@
 /turf/space,
 /area/solar/auxstarboard)
 "bPD" = (
-/obj/effect/decal/warning_stripes/blue,
+/obj/effect/turf_decal/delivery/blue,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -13147,7 +13442,7 @@
 	},
 /area/aisat/maintenance)
 "bPK" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -13191,7 +13486,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/power/emitter/welded{
 	dir = 1
 	},
@@ -13217,7 +13512,9 @@
 /turf/space,
 /area/space)
 "bPV" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "bPW" = (
@@ -13236,7 +13533,9 @@
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "bQa" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/trinary/tvalve/digital/flipped/bypass,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -13266,7 +13565,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "bQh" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/camera{
 	c_tag = "Engineering Access";
 	dir = 4;
@@ -13356,15 +13657,19 @@
 /area/engineering/hardsuitstorage)
 "bQu" = (
 /obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bQw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "bQB" = (
@@ -13398,7 +13703,9 @@
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "bQL" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/suit_storage_unit/atmos,
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -13406,7 +13713,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
@@ -13424,7 +13733,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -13450,7 +13759,7 @@
 /area/security/nuke_storage)
 "bQT" = (
 /obj/machinery/floodlight,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/light_switch/directional/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -13530,8 +13839,6 @@
 /area/medical/cmo)
 "bRn" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -13681,14 +13988,16 @@
 "bRZ" = (
 /obj/machinery/light/small,
 /obj/structure/closet/radiation,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "bSc" = (
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
@@ -13737,7 +14046,7 @@
 /area/aisat/maintenance)
 "bSt" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -13745,12 +14054,14 @@
 	},
 /area/hallway/primary/port)
 "bSw" = (
-/obj/structure/plasticflaps,
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "bSy" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -13781,7 +14092,7 @@
 /area/crew_quarters/heads/hop)
 "bSH" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -13831,7 +14142,7 @@
 /area/crew_quarters/captain/bedroom)
 "bTo" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -13839,7 +14150,9 @@
 /area/crew_quarters/kitchen)
 "bTs" = (
 /obj/machinery/computer/monitor,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Minisat Maintenance Room";
@@ -13854,7 +14167,9 @@
 /area/aisat/maintenance)
 "bTt" = (
 /obj/machinery/cryopod/robot,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/computer/cryopod/robot{
 	pixel_y = -28
 	},
@@ -13996,7 +14311,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "bUe" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel,
@@ -14016,13 +14331,13 @@
 /area/quartermaster/storage)
 "bUg" = (
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "bUh" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "bUk" = (
@@ -14154,7 +14469,7 @@
 /area/crew_quarters/locker)
 "bUN" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14250,7 +14565,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -14382,13 +14697,22 @@
 /turf/space,
 /area/solar/auxstarboard)
 "bWd" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/item/extinguisher/mini,
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"bWe" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/bridge/vip)
 "bWf" = (
 /obj/vehicle/ridden/janicart{
 	dir = 4
@@ -14416,7 +14740,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -14548,10 +14874,10 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "bWS" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light,
 /obj/machinery/hydroponics/constructable,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -14621,8 +14947,10 @@
 	},
 /area/security/detectives_office)
 "bXr" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/alarm/directional/north,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -14653,7 +14981,7 @@
 /area/medical/virology/lab)
 "bXD" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -14705,7 +15033,9 @@
 	},
 /area/quartermaster/storage)
 "bXN" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/effect/landmark/start/cargo_technician,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -14755,7 +15085,9 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/medical/psych)
 "bXY" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -14784,8 +15116,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Storage";
 	req_access = list(32)
@@ -14819,7 +15155,7 @@
 /turf/simulated/floor/engine/insulated,
 /area/maintenance/asmaint4)
 "bYg" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -14876,7 +15212,9 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "bYJ" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bYM" = (
@@ -14909,7 +15247,9 @@
 	name = "Chief Engineer Requests Console";
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -14934,55 +15274,42 @@
 "bZl" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "bZn" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "bZt" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "bZv" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -15142,7 +15469,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "cah" = (
@@ -15278,15 +15607,13 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/bar)
 "caL" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15294,7 +15621,9 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "caN" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "caP" = (
@@ -15325,7 +15654,9 @@
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "cbc" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cbg" = (
@@ -15337,16 +15668,16 @@
 /area/hallway/secondary/entry/lounge)
 "cbj" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cbk" = (
 /obj/machinery/vending/engivend,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -15423,7 +15754,7 @@
 /area/maintenance/bar)
 "cbx" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cbA" = (
@@ -15442,7 +15773,7 @@
 	name = "Janitoral Delivery";
 	req_access = list(26)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -15506,6 +15837,7 @@
 /turf/simulated/floor/engine/insulated,
 /area/maintenance/asmaint4)
 "cbW" = (
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -15525,7 +15857,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -15537,7 +15871,7 @@
 	},
 /obj/machinery/light_switch/directional/west,
 /obj/structure/closet/wardrobe/atmospherics_yellow,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "caution"
@@ -15562,11 +15896,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "ccg" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -15595,7 +15933,9 @@
 	},
 /area/atmos)
 "ccl" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -15726,7 +16066,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "ccY" = (
@@ -15853,7 +16195,9 @@
 	},
 /area/bridge)
 "cdQ" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
 	dir = 8;
@@ -15942,8 +16286,15 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
+"cej" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "redcorner"
+	},
+/area/hallway/primary/starboard/east)
 "cet" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -15956,7 +16307,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit/maint)
 "cev" = (
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -16034,8 +16385,6 @@
 /area/maintenance/fpmaint)
 "ceT" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16044,7 +16393,7 @@
 	},
 /area/security/permabrig)
 "ceY" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cfb" = (
@@ -16058,7 +16407,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -16086,10 +16437,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
@@ -16231,7 +16582,7 @@
 /area/medical/medbay)
 "cga" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "cge" = (
@@ -16296,7 +16647,9 @@
 /turf/space,
 /area/space)
 "cgD" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
@@ -16554,11 +16907,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "cik" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 4;
@@ -16687,7 +17044,9 @@
 "cjp" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 4;
@@ -16696,7 +17055,9 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cjs" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -16705,7 +17066,7 @@
 	},
 /area/chapel/main)
 "cjv" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/chair/sofa/bench/right,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -16726,8 +17087,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/hydroponics/constructable,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -16860,7 +17221,7 @@
 /obj/item/storage/pill_bottle/painkillers,
 /obj/item/reagent_containers/food/pill/patch/styptic,
 /obj/item/reagent_containers/food/pill/patch/silver_sulf,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/medical_wall{
 	pixel_x = -32
 	},
@@ -16890,7 +17251,9 @@
 	},
 /area/quartermaster/miningdock)
 "ckK" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -16913,7 +17276,7 @@
 	},
 /area/security/customs)
 "cli" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/power/energy_accumulator/tesla_coil,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -16943,7 +17306,9 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/clothing/glasses/welding/superior,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/item/flashlight/lamp{
 	layer = 4;
 	pixel_x = 5;
@@ -16969,7 +17334,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "clB" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "clF" = (
@@ -16983,7 +17348,7 @@
 /turf/simulated/floor/grass,
 /area/maintenance/fpmaint)
 "clG" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/gun/energy/ionrifle,
 /obj/structure/rack/gunrack,
 /turf/simulated/floor/plasteel{
@@ -16991,7 +17356,9 @@
 	},
 /area/security/securearmory)
 "clH" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17035,7 +17402,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "clQ" = (
-/obj/structure/plasticflaps/mining,
+/obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "QMLoad2"
@@ -17157,7 +17524,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -17203,7 +17570,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "cna" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/dispenser,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -17229,7 +17596,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -17317,8 +17684,8 @@
 	},
 /area/janitor)
 "cnM" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
@@ -17363,11 +17730,15 @@
 	},
 /area/turret_protected/ai)
 "cod" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cof" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "coh" = (
@@ -17441,7 +17812,9 @@
 	},
 /area/atmos)
 "coz" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -17551,13 +17924,16 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "neutral"
@@ -17570,14 +17946,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "cpi" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cpl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door_control{
 	id = "engstorage";
 	name = "Engineering Secure Storage Control";
@@ -17602,12 +17978,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "cpr" = (
 /obj/machinery/power/emitter,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -17741,7 +18117,9 @@
 	},
 /area/bridge/vip)
 "cqe" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -17801,7 +18179,7 @@
 /turf/simulated/wall,
 /area/quartermaster/miningdock)
 "cqJ" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -17812,8 +18190,6 @@
 /area/toxins/xenobiology)
 "cqQ" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -17821,7 +18197,7 @@
 	dir = 1;
 	network = list("Engineering","SS13")
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "cqT" = (
@@ -17832,7 +18208,7 @@
 /area/janitor)
 "cqU" = (
 /obj/machinery/pipedispenser/disposal,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "cqY" = (
@@ -17874,10 +18250,10 @@
 /obj/machinery/atmospherics/trinary/filter/n2{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -17974,7 +18350,7 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/maintenance/banya)
 "crI" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -17982,8 +18358,8 @@
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "crJ" = (
-/obj/structure/plasticflaps,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
@@ -17996,7 +18372,7 @@
 /area/hydroponics)
 "crK" = (
 /obj/machinery/vending/cola,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -18015,7 +18391,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/directional/west,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/crate/engineering{
 	desc = "В ящике хранится оборудование и ресурсы для осуществления ремонта станции гражданским персоналом в случае нужды или безработицы";
 	name = "Ящик оборудования для ремонта"
@@ -18071,7 +18447,9 @@
 /area/library)
 "csf" = (
 /obj/item/radio/intercom/directional/west,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "csj" = (
@@ -18087,7 +18465,7 @@
 /area/toxins/sm_test_chamber)
 "cso" = (
 /obj/machinery/power/emitter,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "csp" = (
@@ -18115,7 +18493,9 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "csG" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -18127,14 +18507,18 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "csH" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "csJ" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -18244,7 +18628,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "ctJ" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -18256,7 +18642,7 @@
 /area/engineering/controlroom)
 "ctP" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -18323,7 +18709,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -18331,7 +18717,7 @@
 "cun" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -18347,13 +18733,11 @@
 /turf/space,
 /area/space)
 "cup" = (
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding4"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18390,7 +18774,7 @@
 /area/quartermaster/storage)
 "cuB" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
@@ -18402,7 +18786,7 @@
 /area/maintenance/brig)
 "cuE" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/sign/radiation/rad_area{
 	pixel_y = 32
 	},
@@ -18452,7 +18836,9 @@
 	},
 /obj/structure/closet/radiation,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cva" = (
@@ -18484,7 +18870,9 @@
 /turf/simulated/floor/plating,
 /area/engineering/controlroom)
 "cvk" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
@@ -18507,6 +18895,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
 /obj/machinery/light_switch/directional/east,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -18610,10 +18999,10 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "cvX" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18637,14 +19026,16 @@
 	},
 /area/atmos)
 "cwf" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cwk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -18686,14 +19077,16 @@
 /area/quartermaster/miningdock)
 "cwy" = (
 /obj/machinery/vending/tool,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/engineering/hardsuitstorage)
 "cwz" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/rack,
 /obj/item/floor_painter{
 	pixel_x = -6;
@@ -18733,7 +19126,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -18854,17 +19246,17 @@
 /area/hallway/primary/central/se)
 "cxh" = (
 /obj/machinery/vending/hydronutrients,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/hydroponics)
 "cxk" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -18941,13 +19333,14 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -19027,7 +19420,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -19061,7 +19454,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "cxZ" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 8;
@@ -19070,7 +19465,9 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cya" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/binary/volume_pump{
 	desc = "Отправляет неотфильтрованные газы в отходы на повторную фильтрацию";
 	dir = 4;
@@ -19116,7 +19513,7 @@
 	},
 /area/storage/eva)
 "cyl" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -19161,7 +19558,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port/west)
 "cyw" = (
@@ -19330,7 +19727,9 @@
 /turf/simulated/floor/carpet/red,
 /area/maintenance/casino)
 "czw" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/field/generator/anchored,
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -19365,7 +19764,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "czE" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/binary/volume_pump{
 	desc = "Позволяет опустошить трубу дыхательной смеси, отправив её в отходы на повторную фильтрацию";
 	dir = 4;
@@ -19374,8 +19775,10 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "czG" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "czK" = (
@@ -19391,11 +19794,13 @@
 /area/maintenance/casino)
 "czQ" = (
 /obj/machinery/recharge_station,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "czR" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -19583,9 +19988,11 @@
 	},
 /area/hallway/primary/port/west)
 "cAD" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -19658,7 +20065,7 @@
 /area/blueshield)
 "cBk" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
 "cBo" = (
@@ -19727,7 +20134,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -19739,7 +20146,7 @@
 "cBI" = (
 /obj/machinery/light/small,
 /obj/effect/landmark/start/civilian,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/door_control{
 	desiredstate = 1;
 	id = "toilet1";
@@ -19758,7 +20165,9 @@
 	id_tag = "janitorshutters";
 	name = "Janitor Shutters"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
@@ -19792,8 +20201,10 @@
 /turf/space,
 /area/solar/auxport)
 "cCd" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
@@ -19812,7 +20223,7 @@
 	name = "Engineering Maintenance";
 	req_access = list(10)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/maintenance/engineering)
@@ -19834,6 +20245,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -19905,7 +20317,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -19969,7 +20383,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/binary/pump{
 	name = "Gas to Turbine"
 	},
@@ -19979,7 +20395,9 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "cCT" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -19996,7 +20414,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -20026,14 +20446,16 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "cDe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/vending/wallmed{
 	pixel_y = -32
 	},
@@ -20087,11 +20509,11 @@
 "cDv" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "cDx" = (
@@ -20140,7 +20562,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "cDF" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -20152,7 +20574,7 @@
 /area/engineering/controlroom)
 "cDG" = (
 /obj/machinery/vending/tool,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cDH" = (
@@ -20164,7 +20586,9 @@
 	},
 /area/turret_protected/ai)
 "cDI" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
@@ -20180,7 +20604,9 @@
 	id = "portsolar";
 	name = "South-West Solar Control"
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "cDO" = (
@@ -20190,10 +20616,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
@@ -20292,7 +20718,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -20306,7 +20732,6 @@
 	icon_state = "grass_edge_medium"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -20518,8 +20943,12 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/southwest,
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "cFG" = (
@@ -20584,7 +21013,6 @@
 	},
 /obj/item/reagent_containers/spray/waterflower,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -20592,10 +21020,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20632,7 +21060,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -20665,7 +21093,9 @@
 	dir = 8;
 	name = "Nitrogen to Loop"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "cGx" = (
@@ -20732,7 +21162,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cHb" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -20847,7 +21277,7 @@
 /area/bridge)
 "cHU" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "red"
@@ -20919,7 +21349,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -20976,7 +21408,7 @@
 	name = "Tech Storage";
 	req_access = list(23)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -21003,7 +21435,9 @@
 	},
 /area/engineering/break_room)
 "cIE" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -21017,7 +21451,9 @@
 /area/medical/chemistry)
 "cIG" = (
 /obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -21082,7 +21518,7 @@
 /obj/item/crowbar,
 /obj/item/wrench,
 /obj/item/gps,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "cJc" = (
@@ -21204,6 +21640,7 @@
 	},
 /area/maintenance/asmaint4)
 "cJD" = (
+/obj/effect/landmark/start/hangover,
 /obj/machinery/door/window/southleft{
 	name = "Bar Delivery";
 	req_access = list(25)
@@ -21244,11 +21681,15 @@
 	},
 /area/engineering/gravitygenerator)
 "cJI" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "cJJ" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "cJK" = (
@@ -21264,7 +21705,7 @@
 /area/toxins/sm_test_chamber)
 "cJL" = (
 /obj/machinery/power/port_gen/pacman,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "cJN" = (
@@ -21287,7 +21728,9 @@
 "cJY" = (
 /obj/machinery/light/small,
 /obj/structure/closet/radiation,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "cKb" = (
@@ -21305,7 +21748,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -21333,7 +21775,9 @@
 "cKf" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/south,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -21358,7 +21802,7 @@
 	},
 /area/storage/primary)
 "cKq" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -21391,7 +21835,7 @@
 /obj/structure/chair/comfy/red{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -21487,7 +21931,7 @@
 "cKW" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/double,
-/obj/effect/turf_decal/bot/right,
+/obj/effect/turf_decal/delivery/hollow/right,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -21526,7 +21970,9 @@
 	id = "QMLoad2";
 	name = "Download"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "cLj" = (
@@ -21563,7 +22009,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/rack,
 /obj/item/crowbar,
 /obj/item/storage/toolbox/mechanical,
@@ -21577,11 +22025,15 @@
 	},
 /area/maintenance/asmaint4)
 "cLC" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "cLF" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -21591,7 +22043,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -21608,7 +22062,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -21651,7 +22107,9 @@
 /area/hydroponics)
 "cMc" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cMi" = (
@@ -21678,7 +22136,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "cMp" = (
@@ -21761,6 +22219,17 @@
 	icon_state = "neutralfull"
 	},
 /area/storage/primary)
+"cMK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/medbay)
 "cML" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/cleanable/dirt,
@@ -21768,6 +22237,13 @@
 	icon_state = "white"
 	},
 /area/maintenance/asmaint)
+"cMO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/westarrival)
 "cMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -21844,6 +22320,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random_spawners/rodent,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whiteblue"
@@ -22072,7 +22549,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -22148,7 +22625,9 @@
 /obj/structure/chair/comfy/purp{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -22162,7 +22641,7 @@
 	},
 /area/maintenance/electrical)
 "cPg" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cautioncorner"
@@ -22191,10 +22670,10 @@
 /turf/simulated/floor/engine,
 /area/maintenance/turbine)
 "cPq" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
@@ -22269,7 +22748,7 @@
 	},
 /area/engineering/controlroom)
 "cPE" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/engine,
 /area/medical/chemistry)
@@ -22288,7 +22767,6 @@
 "cPG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -22315,7 +22793,7 @@
 	},
 /area/maintenance/banya)
 "cPK" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -22366,7 +22844,9 @@
 	},
 /area/medical/medbay2)
 "cPX" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -22478,8 +22958,8 @@
 	},
 /area/toxins/test_chamber)
 "cQB" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/plasticflaps,
+/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	location = "Mime"
@@ -22551,7 +23031,9 @@
 /obj/structure/chair/comfy/purp{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
@@ -22620,7 +23102,7 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
 /obj/item/lightreplacer,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -22676,7 +23158,7 @@
 	},
 /area/medical/chemistry)
 "cRj" = (
-/obj/effect/decal/warning_stripes/blue,
+/obj/effect/turf_decal/delivery/blue,
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
@@ -22784,12 +23266,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "cRK" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -22797,8 +23281,10 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "cRU" = (
-/obj/effect/decal/warning_stripes/northeast,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/window/plasmareinforced{
 	dir = 1
 	},
@@ -22842,7 +23328,7 @@
 	},
 /area/toxins/test_chamber)
 "cSb" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "browncorner"
 	},
@@ -22859,14 +23345,14 @@
 "cSd" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/chocolate,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
 /area/medical/research/restroom)
 "cSe" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -22879,7 +23365,7 @@
 	},
 /area/quartermaster/storage)
 "cSh" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "cSo" = (
@@ -22904,10 +23390,10 @@
 /area/maintenance/asmaint2)
 "cSx" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -22971,13 +23457,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "cSI" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/biogenerator,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -23142,7 +23630,7 @@
 	},
 /area/maintenance/tourist)
 "cTM" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/drone_fabricator,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -23158,7 +23646,7 @@
 	},
 /area/toxins/xenobiology)
 "cTR" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -23179,7 +23667,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/computer/rdconsole/core,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -23189,7 +23679,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "cTZ" = (
@@ -23362,7 +23852,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/flashlight,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -23391,7 +23881,7 @@
 /area/hallway/primary/fore)
 "cUQ" = (
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "cUS" = (
@@ -23414,7 +23904,7 @@
 "cUW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -23426,7 +23916,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -23438,7 +23930,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/r_n_d/protolathe{
 	pixel_y = 2
 	},
@@ -23489,7 +23983,7 @@
 	},
 /area/atmos)
 "cVs" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -23505,7 +23999,7 @@
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/effect/decal/warning_stripes/blue,
+/obj/effect/turf_decal/delivery/blue,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -23560,7 +24054,7 @@
 	},
 /area/medical/chemistry)
 "cVO" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -23631,7 +24125,7 @@
 /area/crew_quarters/sleep)
 "cVZ" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -23680,7 +24174,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "cWn" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -23704,7 +24198,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -23773,7 +24267,7 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "cWJ" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
@@ -23914,6 +24408,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -23975,15 +24470,17 @@
 	network = list("Engineering","SS13");
 	pixel_y = -22
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/computer/card/minor/ce,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/crew_quarters/chief)
 "cXT" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/plasticflaps,
+/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	location = "Clown"
@@ -24110,6 +24607,13 @@
 	icon_state = "darkred"
 	},
 /area/security/evidence)
+"cYt" = (
+/obj/structure/chair,
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/aisat/aihallway)
 "cYw" = (
 /mob/living/simple_animal/mouse/white{
 	desc = "Близкий друг психиатра. Не подпускать к Рантайму.";
@@ -24246,7 +24750,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -24286,7 +24790,7 @@
 /area/hallway/secondary/entry)
 "cZl" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -24339,14 +24843,14 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/storage/tech)
 "cZr" = (
-/obj/effect/decal/warning_stripes/arrow,
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/turf_decal/arrows/black,
+/obj/effect/turf_decal/delivery/partial,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "purple"
@@ -24354,7 +24858,9 @@
 /area/hallway/primary/aft)
 "cZu" = (
 /obj/machinery/computer/rdconsole/core,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -24376,7 +24882,9 @@
 	name = "Research Division Access";
 	req_access = list(47)
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "cZE" = (
@@ -24842,7 +25350,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "dcB" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/window/reinforced,
 /obj/effect/spawner/random_spawners/security_ballistics,
 /turf/simulated/floor/plasteel{
@@ -24896,6 +25404,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/plasticflaps/kitchen,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -24976,7 +25485,7 @@
 /area/toxins/xenobiology)
 "ddb" = (
 /obj/structure/closet/bombcloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -25038,7 +25547,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/computer/security/engineering,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25055,6 +25566,7 @@
 	},
 /area/medical/research/nhallway)
 "ddr" = (
+/obj/effect/landmark/start/hangover,
 /obj/structure/railing{
 	dir = 4
 	},
@@ -25075,7 +25587,9 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "ddx" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
@@ -25136,8 +25650,14 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
+"ddN" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/bridge/vip)
 "ddO" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "ddR" = (
@@ -25217,9 +25737,11 @@
 /turf/space,
 /area/space)
 "dex" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	hackProof = 1;
 	id_tag = "emergency_home";
@@ -25257,8 +25779,10 @@
 	},
 /area/crew_quarters/theatre)
 "deF" = (
-/obj/effect/decal/warning_stripes/southeast,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /obj/structure/window/plasmareinforced,
@@ -25376,7 +25900,7 @@
 /turf/simulated/floor/wood,
 /area/maintenance/tourist)
 "dfa" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -25386,7 +25910,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "dff" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -25405,7 +25931,9 @@
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
 "dfj" = (
@@ -25420,7 +25948,7 @@
 /area/toxins/test_chamber)
 "dfk" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -25430,7 +25958,7 @@
 /turf/simulated/wall/r_wall,
 /area/assembly/chargebay)
 "dfn" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -25511,8 +26039,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/door_control{
 	id = "xeno7";
 	name = "Containment Control";
@@ -25526,8 +26056,12 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "dfQ" = (
@@ -25594,11 +26128,15 @@
 /obj/machinery/portable_atmospherics/canister/air{
 	filled = 0.05
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "dfY" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/chair/office/light{
 	dir = 4;
 	pixel_y = 3
@@ -25649,7 +26187,7 @@
 /area/maintenance/asmaint3)
 "dge" = (
 /obj/structure/table,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/light,
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
@@ -25662,7 +26200,8 @@
 	frequency = 1379;
 	id_tag = "engineering_west_pump"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/walllocker/emerglocker/directional/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "dgk" = (
@@ -25828,7 +26367,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -25947,12 +26485,21 @@
 	icon_state = "neutralfull"
 	},
 /area/engineering/engine/monitor)
+"dht" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/west)
 "dhu" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/firealarm/directional/east,
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel{
@@ -25976,8 +26523,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -26084,7 +26635,6 @@
 	icon_state = "grass_edge_medium_corner"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -26128,7 +26678,9 @@
 	},
 /area/hallway/primary/aft)
 "dio" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -26148,7 +26700,7 @@
 /area/chapel/main)
 "dis" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atm{
 	pixel_y = 32
 	},
@@ -26212,7 +26764,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -26246,7 +26798,9 @@
 	},
 /area/maintenance/asmaint4)
 "diQ" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -26284,8 +26838,12 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "djb" = (
@@ -26344,7 +26902,7 @@
 /area/atmos)
 "djt" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -26352,7 +26910,7 @@
 	},
 /area/toxins/mixing)
 "dju" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/dispenser,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -26360,7 +26918,9 @@
 	},
 /area/toxins/mixing)
 "djw" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
 	},
@@ -26369,7 +26929,9 @@
 	},
 /area/toxins/mixing)
 "djx" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
@@ -26418,7 +26980,9 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "djT" = (
-/obj/effect/decal/warning_stripes/northeastsouth,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
 /obj/vehicle/ridden/ambulance{
 	dir = 4
 	},
@@ -26529,6 +27093,12 @@
 	icon_state = "white"
 	},
 /area/medical/cmo)
+"dkm" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/crew_quarters/locker)
 "dkn" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -26548,7 +27118,7 @@
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
 "dkt" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -26577,7 +27147,7 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/maintenance/asmaint3)
 "dkw" = (
-/obj/structure/plasticflaps/mining,
+/obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "QMLoad"
@@ -26606,7 +27176,9 @@
 	},
 /area/toxins/xenobiology)
 "dkF" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
@@ -26624,7 +27196,7 @@
 	pixel_x = -30;
 	pixel_y = -2
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/papershredder,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
@@ -26633,12 +27205,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/mecha,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "dkP" = (
 /obj/structure/table,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/folder/blue{
 	pixel_x = 5
 	},
@@ -26669,7 +27241,9 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/serviceyard)
 "dkS" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "dkX" = (
@@ -26696,7 +27270,9 @@
 /obj/machinery/photocopier/faxmachine/longrange{
 	department = "Chief Engineer's Office"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -26707,7 +27283,7 @@
 	name = "Kitchen Delivery";
 	req_access = list(28)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
 "dle" = (
@@ -26912,7 +27488,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/computer/robotics,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
@@ -26926,11 +27502,11 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Singularity";
 	name = "Singularity Blast Doors"
@@ -26961,6 +27537,26 @@
 "dmq" = (
 /turf/simulated/wall,
 /area/quartermaster/storage)
+"dmr" = (
+/obj/machinery/optable,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/shower{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/medical/surgery/north)
 "dms" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -27081,7 +27677,7 @@
 	layer = 3.3;
 	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -27161,7 +27757,9 @@
 	pixel_y = 25;
 	req_access = list(32)
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "dmU" = (
@@ -27215,7 +27813,9 @@
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "dnn" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
 	},
@@ -27250,7 +27850,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -27265,7 +27867,7 @@
 	name = "Atmospherics Access";
 	req_access = list(24)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -27298,7 +27900,9 @@
 	},
 /area/medical/genetics)
 "dnI" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -27373,7 +27977,9 @@
 /area/crew_quarters/heads/hop)
 "dog" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/item/rcd_ammo,
 /obj/item/rcd_ammo,
 /obj/item/rcd_ammo,
@@ -27416,7 +28022,9 @@
 /area/maintenance/detectives_office)
 "dom" = (
 /obj/machinery/computer/sm_monitor,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -27453,7 +28061,7 @@
 /area/crew_quarters/chief)
 "doy" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -27612,7 +28220,6 @@
 "dpg" = (
 /obj/structure/statue/tranquillite/mime/unique,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -27764,8 +28371,12 @@
 	},
 /area/quartermaster/office)
 "dpY" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "roboticsshutters";
@@ -27848,7 +28459,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/delivery)
 "dqw" = (
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
 /turf/simulated/floor/plasteel{
@@ -27856,7 +28467,7 @@
 	},
 /area/quartermaster/storage)
 "dqx" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	dir = 4;
@@ -27951,7 +28562,9 @@
 /area/crew_quarters/courtroom)
 "dri" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "drl" = (
@@ -27997,13 +28610,15 @@
 	},
 /area/medical/research/nhallway)
 "drv" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "drC" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -28059,7 +28674,7 @@
 	req_access = list(29)
 	},
 /obj/machinery/door/window/eastleft,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "RoboDesk";
 	name = "Robotics Privacy Shutter"
@@ -28141,7 +28756,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "dsk" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	dir = 8;
@@ -28187,14 +28802,16 @@
 	},
 /area/aisat/aihallway)
 "dsE" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "dsG" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -28497,7 +29114,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28505,7 +29124,9 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "duf" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "duh" = (
@@ -28522,7 +29143,7 @@
 	amount = 50
 	},
 /obj/machinery/alarm/directional/west,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/stack/sheet/metal{
 	amount = 10
 	},
@@ -28555,7 +29176,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -28611,7 +29232,7 @@
 /area/crew_quarters/trading)
 "duN" = (
 /obj/machinery/smartfridge/drying_rack,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -28693,7 +29314,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "dvg" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/machine{
 	pixel_x = 4;
@@ -28784,9 +29405,8 @@
 /area/medical/morgue)
 "dvA" = (
 /obj/machinery/power/terminal,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -28865,7 +29485,6 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -28902,7 +29521,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -28944,11 +29565,11 @@
 /area/engineering/engine)
 "dwt" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "dwu" = (
@@ -28972,7 +29593,9 @@
 	},
 /area/medical/morgue)
 "dwv" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -28996,6 +29619,13 @@
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
+"dwx" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/wood,
+/area/library)
 "dwy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29131,6 +29761,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/lounge)
 "dwW" = (
@@ -29142,12 +29773,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/telepad_cargo,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -29166,6 +29797,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/plasticflaps/kitchen,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -29202,11 +29834,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -29242,7 +29874,7 @@
 	},
 /area/tcommsat/chamber)
 "dxu" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/westleft{
 	dir = 4;
 	name = "Robotic Delivery";
@@ -29378,7 +30010,7 @@
 	network = list("Research","SS13");
 	pixel_y = -22
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
@@ -29397,8 +30029,12 @@
 "dyv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "dyy" = (
@@ -29433,7 +30069,9 @@
 /turf/simulated/floor/bluegrid/telecomms/mainframe/gcircuit,
 /area/toxins/server)
 "dyI" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "dza" = (
@@ -29449,18 +30087,20 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/maintenance/turbine)
 "dzf" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	location = "Chemistry"
 	},
-/obj/structure/plasticflaps,
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -29486,7 +30126,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -29583,8 +30223,8 @@
 /area/engineering/controlroom)
 "dzA" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "caution"
@@ -29592,23 +30232,27 @@
 /area/toxins/storage)
 "dzC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "dzD" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "escape"
 	},
 /area/toxins/storage)
 "dzE" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
@@ -29630,7 +30274,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "dzQ" = (
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/turf_decal/delivery/partial,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -29664,7 +30308,9 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
@@ -29728,8 +30374,10 @@
 /turf/simulated/floor/engine/co2,
 /area/atmos)
 "dAN" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/item/extinguisher/mini,
@@ -29779,7 +30427,7 @@
 	},
 /area/medical/genetics)
 "dAZ" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
@@ -29857,29 +30505,25 @@
 /area/medical/virology/lab)
 "dBt" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/start/engineer,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "dBu" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/sign/electricshock{
 	pixel_x = 32
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -29895,7 +30539,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "dBB" = (
@@ -29918,7 +30562,9 @@
 	},
 /area/library/game_zone)
 "dBF" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -29950,7 +30596,9 @@
 /area/library)
 "dBN" = (
 /obj/machinery/firealarm/directional/north,
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -29987,7 +30635,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "dCc" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -30261,7 +30909,9 @@
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/hop)
 "dDn" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/chem_master,
 /turf/simulated/floor/engine,
 /area/medical/chemistry)
@@ -30277,7 +30927,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
@@ -30290,7 +30942,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "dDv" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -30325,7 +30979,9 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "dDO" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -30335,11 +30991,11 @@
 /area/atmos)
 "dDP" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "dDQ" = (
@@ -30416,7 +31072,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "dEm" = (
@@ -30452,7 +31110,7 @@
 /area/maintenance/fpmaint)
 "dEH" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "bluefull"
 	},
@@ -30722,8 +31380,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -30758,7 +31418,7 @@
 /area/maintenance/fpmaint)
 "dGe" = (
 /obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
 "dGi" = (
@@ -30821,7 +31481,9 @@
 	},
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "dGB" = (
@@ -30860,7 +31522,9 @@
 	},
 /area/quartermaster/storage)
 "dGQ" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "dGR" = (
@@ -30956,7 +31620,7 @@
 	layer = 2.9
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/random/toolbox,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -30964,16 +31628,22 @@
 	},
 /area/maintenance/brig)
 "dHp" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "dHq" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "dHr" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "dHs" = (
@@ -31146,7 +31816,7 @@
 	},
 /area/solar/starboard)
 "dHZ" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -31180,7 +31850,6 @@
 	},
 /obj/item/soap/homemade_banana,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
@@ -31364,7 +32033,9 @@
 /area/maintenance/turbine)
 "dJi" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "dJk" = (
@@ -31379,10 +32050,10 @@
 	},
 /area/atmos)
 "dJl" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
 /obj/effect/landmark/start/shaft_miner,
@@ -31462,7 +32133,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
 "dJW" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -31497,8 +32168,10 @@
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/secondary/exit)
 "dKm" = (
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/item/extinguisher/mini,
@@ -31557,7 +32230,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -31818,9 +32491,8 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "dLM" = (
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -31839,7 +32511,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31900,7 +32572,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitegreencorner"
@@ -31961,7 +32633,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit/maint)
 "dMn" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -32059,7 +32731,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "dMK" = (
@@ -32143,7 +32815,7 @@
 	dir = 8
 	},
 /obj/item/wirecutters,
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -32152,7 +32824,9 @@
 	},
 /area/security/permabrig)
 "dNr" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "dNt" = (
@@ -32174,7 +32848,6 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -32309,7 +32982,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/hop)
 "dNP" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -32335,7 +33008,9 @@
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper/precision,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -32343,7 +33018,9 @@
 /area/medical/virology/lab)
 "dNX" = (
 /obj/structure/table/glass,
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /obj/item/paper_bin,
 /obj/item/pen/red,
 /obj/structure/window/reinforced/polarized{
@@ -32518,13 +33195,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "dOZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "dPa" = (
@@ -32647,7 +33323,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "dPO" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/flasher{
 	id = "hopflash";
 	pixel_x = 58
@@ -32675,7 +33351,7 @@
 /area/hallway/secondary/entry/lounge)
 "dPX" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -32787,7 +33463,9 @@
 	},
 /area/turret_protected/ai)
 "dQq" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -32809,7 +33487,9 @@
 	},
 /area/hallway/secondary/entry)
 "dQy" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "dQz" = (
@@ -33046,7 +33726,7 @@
 	id_tag = "eva-shutters";
 	name = "E.V.A. Storage Shutters"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -33090,7 +33770,7 @@
 /area/security/permabrig)
 "dSc" = (
 /obj/structure/closet/coffin,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -33177,7 +33857,9 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "dSB" = (
@@ -33204,7 +33886,9 @@
 	},
 /area/medical/research/nhallway)
 "dSF" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -33350,7 +34034,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1379;
@@ -33411,7 +34095,7 @@
 /area/turret_protected/ai)
 "dTO" = (
 /obj/machinery/newscaster/directional/east,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -33444,7 +34128,7 @@
 	locked = 1;
 	name = "Arrivals External Access"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
 "dUc" = (
@@ -33536,7 +34220,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/power/apc/directional/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
@@ -33587,7 +34273,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "dUI" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "dUJ" = (
@@ -33651,7 +34337,9 @@
 	},
 /area/atmos)
 "dVa" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -33677,7 +34365,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "dVi" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 4;
@@ -33709,7 +34399,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -33758,7 +34448,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/junction/reversed{
@@ -33859,7 +34549,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil/random,
 /obj/item/reagent_containers/spray/cleaner{
@@ -33881,7 +34571,7 @@
 	},
 /area/hydroponics)
 "dWc" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "dWd" = (
@@ -33897,7 +34587,7 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/xenobiology)
 "dWh" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/requests_console{
 	department = "Hydroponics";
 	departmentType = 2;
@@ -33906,7 +34596,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/smartfridge/disks,
-/obj/effect/decal/warning_stripes/green,
+/obj/effect/turf_decal/delivery/green,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -33929,7 +34619,7 @@
 /area/hallway/primary/aft)
 "dWk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -33986,7 +34676,9 @@
 /area/bridge/vip)
 "dWy" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dWz" = (
@@ -34018,7 +34710,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "dWE" = (
@@ -34073,7 +34767,7 @@
 	},
 /area/medical/cryo)
 "dWQ" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -34197,7 +34891,7 @@
 /area/solar/auxstarboard)
 "dXr" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light_switch/directional/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -34231,7 +34925,9 @@
 	req_access = list(13)
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "dXx" = (
@@ -34245,7 +34941,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "dXy" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
 "dXz" = (
@@ -34409,8 +35105,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -34471,7 +35169,9 @@
 	},
 /area/crew_quarters/theatre)
 "dYt" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
@@ -34491,7 +35191,7 @@
 	},
 /area/aisat/aihallway)
 "dYz" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	name = "Труба обработки"
@@ -34514,7 +35214,7 @@
 	},
 /area/turret_protected/ai)
 "dYE" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	dir = 4;
@@ -34523,7 +35223,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dYJ" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 6;
@@ -34585,7 +35285,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "dYY" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 4;
@@ -34600,7 +35300,7 @@
 	},
 /area/crew_quarters/fitness)
 "dZb" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "dZc" = (
@@ -34678,7 +35378,9 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Airlock"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "dZq" = (
@@ -34706,7 +35408,7 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/clothing/glasses/hud/hydroponic,
 /obj/item/clothing/glasses/hud/hydroponic,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/sign/botany{
 	pixel_y = -32
 	},
@@ -34727,7 +35429,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -34738,7 +35440,7 @@
 /obj/item/paper/pamphlet,
 /obj/item/paper/pamphlet,
 /obj/item/paper/pamphlet,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -34822,7 +35524,9 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "dZM" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -34852,7 +35556,9 @@
 	},
 /area/atmos)
 "dZU" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -34903,7 +35609,9 @@
 	},
 /area/medical/sleeper)
 "eap" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -34946,7 +35654,7 @@
 	},
 /area/medical/virology/lab)
 "eaC" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/bombcloset,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -35031,6 +35739,18 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
+"ebC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/central/se)
 "ebI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35075,10 +35795,10 @@
 	},
 /area/hallway/secondary/exit)
 "ebV" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -35107,7 +35827,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -35124,8 +35844,6 @@
 "eci" = (
 /obj/effect/landmark/start/engineer,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -35165,7 +35883,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitehall"
@@ -35180,7 +35900,9 @@
 	},
 /area/maintenance/consarea_virology)
 "edj" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -35301,7 +36023,6 @@
 	icon_state = "grass_edge_medium_corner"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -35321,6 +36042,7 @@
 	dir = 10;
 	initialize_directions = 10
 	},
+/obj/structure/plasticflaps/kitchen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -35333,7 +36055,7 @@
 /turf/simulated/floor/engine/air,
 /area/atmos)
 "eeG" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -35382,8 +36104,6 @@
 /area/security/permabrig)
 "efA" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
@@ -35505,7 +36225,9 @@
 "egU" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/storage/box/masks,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
 	dir = 1;
@@ -35624,7 +36346,7 @@
 /area/medical/virology/lab)
 "ehV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -35694,7 +36416,9 @@
 	},
 /area/security/permabrig)
 "eiw" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -35724,7 +36448,7 @@
 	},
 /area/maintenance/bar)
 "eiO" = (
-/obj/structure/plasticflaps,
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "cargodelivery"
@@ -35765,7 +36489,7 @@
 	},
 /area/hallway/primary/fore)
 "ejf" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -35808,13 +36532,9 @@
 /area/security/prison/cell_block/A)
 "ejp" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
@@ -35822,7 +36542,9 @@
 	},
 /area/engineering/engine)
 "ejB" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -35887,7 +36609,7 @@
 	dir = 1;
 	req_access = list(10)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "ekj" = (
@@ -36028,7 +36750,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -36039,7 +36763,9 @@
 	},
 /area/medical/morgue)
 "ely" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -36064,6 +36790,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -36205,7 +36932,9 @@
 	},
 /area/maintenance/asmaint4)
 "enO" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	name = "Труба обработки"
@@ -36250,7 +36979,7 @@
 /obj/item/wrench,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light_switch/directional/south,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/paper/gravity_gen,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -36259,8 +36988,8 @@
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/machinery/newscaster/directional/south,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "eoB" = (
@@ -36335,7 +37064,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/serviceyard)
 "eoV" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -36365,7 +37094,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -36458,7 +37189,9 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "eqN" = (
@@ -36479,7 +37212,9 @@
 	},
 /area/quartermaster/office)
 "eqO" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -36601,7 +37336,7 @@
 /obj/item/tank/jetpack/oxygen,
 /obj/item/tank/internals/oxygen,
 /obj/item/clothing/shoes/magboots,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/alarm/directional/south,
 /obj/machinery/camera{
 	c_tag = "Brig Pilot Office";
@@ -36621,7 +37356,9 @@
 	c_tag = "Engine Room North";
 	network = list("Engineering","SS13")
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_y = 28
@@ -36686,7 +37423,9 @@
 /area/maintenance/kitchen)
 "esz" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36713,8 +37452,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -36791,10 +37530,13 @@
 	},
 /area/turret_protected/ai_upload)
 "etE" = (
+/obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
@@ -36833,7 +37575,7 @@
 /obj/item/seeds/carrot,
 /obj/item/seeds/carrot,
 /obj/item/seeds/carrot,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -36847,6 +37589,13 @@
 	icon_state = "wood-broken3"
 	},
 /area/maintenance/engineering)
+"euR" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/bridge/vip)
 "euY" = (
 /obj/structure/reflector/box/anchored{
 	dir = 4
@@ -36902,11 +37651,16 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin2)
 "ewi" = (
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurplecorner"
 	},
 /area/crew_quarters/hor)
+"ewn" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel,
+/area/quartermaster/miningdock)
 "ewp" = (
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
@@ -36946,7 +37700,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/securehallway)
 "ewF" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_y = -32
 	},
@@ -36956,7 +37710,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "exh" = (
@@ -37046,7 +37802,9 @@
 /area/chapel/office)
 "eyi" = (
 /obj/structure/morgue,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/effect/landmark/spawner/revenant,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -37207,11 +37965,11 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "eAm" = (
@@ -37250,7 +38008,7 @@
 	},
 /area/turret_protected/ai_upload)
 "eAH" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -37330,12 +38088,13 @@
 /obj/effect/decal/cleanable/dust,
 /obj/structure/grille/broken,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "eBF" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/door_control{
 	id = "engsm";
 	name = "Supermatter Blast Doors";
@@ -37458,7 +38217,9 @@
 	},
 /area/security/brig)
 "eDV" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -37482,8 +38243,10 @@
 /area/security/permabrig)
 "eEq" = (
 /obj/item/radio/intercom/directional/south,
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -37644,7 +38407,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "eGd" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/chair/office/light{
 	dir = 8
 	},
@@ -37666,7 +38431,7 @@
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
 	id_tag = "paramedic";
@@ -37681,7 +38446,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/effect/decal/warning_stripes/red/partial{
+/obj/effect/turf_decal/delivery/red/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -37723,7 +38488,7 @@
 "eGT" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -37738,6 +38503,13 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
+"eHt" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/red,
+/area/crew_quarters/bar/atrium)
 "eHI" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -37895,7 +38667,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /obj/item/tank/internals/emergency_oxygen/engi,
@@ -37924,7 +38698,7 @@
 /turf/simulated/wall/r_wall,
 /area/atmos)
 "eJl" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/rack,
 /obj/item/flashlight{
 	pixel_x = -6;
@@ -37959,7 +38733,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "eJs" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/binary/volume_pump/on{
 	desc = "Возвращает газ после обработки в трубу смешивания";
 	name = "Выход газа после обработки"
@@ -37990,11 +38764,11 @@
 "eJG" = (
 /obj/machinery/power/energy_accumulator/tesla_coil,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "eJH" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/clothing/glasses/meson{
 	pixel_x = -6;
 	pixel_y = 4
@@ -38200,7 +38974,9 @@
 	},
 /area/atmos)
 "eLT" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -38281,8 +39057,6 @@
 /area/atmos)
 "eMv" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -38308,7 +39082,7 @@
 	},
 /area/medical/virology/lab)
 "eMA" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
 	id = "garbage";
@@ -38341,7 +39115,7 @@
 	},
 /area/library)
 "eMM" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	dir = 6;
@@ -38405,7 +39179,7 @@
 	},
 /area/crew_quarters/locker)
 "eNs" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit/maint)
@@ -38486,7 +39260,9 @@
 	},
 /area/hallway/primary/central/sw)
 "eNZ" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -38525,7 +39301,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "eOC" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
@@ -38591,7 +39369,7 @@
 	},
 /area/medical/virology/lab)
 "ePl" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	name = "Труба на фильтрацию"
@@ -38636,11 +39414,9 @@
 	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "ePU" = (
@@ -38733,11 +39509,11 @@
 /turf/simulated/floor/plasteel,
 /area/security/permahallway)
 "eRa" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "eRh" = (
@@ -38766,15 +39542,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "eRN" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -38795,7 +39571,7 @@
 /area/maintenance/engineering)
 "eRU" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -38843,7 +39619,7 @@
 /area/maintenance/asmaint4)
 "eSQ" = (
 /obj/machinery/power/energy_accumulator/tesla_coil,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "eTb" = (
@@ -38858,7 +39634,7 @@
 /area/crew_quarters/serviceyard)
 "eTe" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -38953,7 +39729,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -39075,7 +39850,8 @@
 	},
 /area/maintenance/asmaint4)
 "eUJ" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/chair/sofa/bench,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -39130,7 +39906,9 @@
 /area/crew_quarters/locker)
 "eVB" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -39229,8 +40007,12 @@
 	},
 /area/crew_quarters/serviceyard)
 "eWC" = (
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
@@ -39242,14 +40024,16 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/west,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "eWN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -39318,7 +40102,7 @@
 /area/toxins/explab)
 "eXm" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -39331,7 +40115,9 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "eXx" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "eXz" = (
@@ -39379,7 +40165,7 @@
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/flashlight,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -39475,6 +40261,12 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/medbay)
+"eYM" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/bridge/meeting_room)
 "eYO" = (
 /obj/item/flag/nt,
 /obj/structure/cable{
@@ -39517,7 +40309,7 @@
 	},
 /area/quartermaster/office)
 "eYR" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel,
@@ -39652,7 +40444,9 @@
 	},
 /area/maintenance/electrical)
 "faG" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -39670,7 +40464,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -39697,7 +40491,7 @@
 /area/security/customs)
 "faZ" = (
 /obj/machinery/firealarm/directional/north,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -39731,7 +40525,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -39820,7 +40614,7 @@
 	},
 /area/crew_quarters/locker)
 "fcP" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -39937,7 +40731,7 @@
 	desc = "A machine used to process slimes and retrieve their extract.";
 	name = "Slime Processor"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light_switch/directional/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -39976,8 +40770,10 @@
 /area/medical/cmostore)
 "feE" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
@@ -40053,7 +40849,6 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/window/plasmareinforced{
@@ -40085,11 +40880,11 @@
 "ffP" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "ffQ" = (
@@ -40106,6 +40901,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/disposalpipe/junction/reversed,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -40161,7 +40957,7 @@
 /area/security/permabrig)
 "fgz" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -40217,8 +41013,10 @@
 	},
 /area/medical/medbay2)
 "fgG" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -40297,7 +41095,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -40368,7 +41166,7 @@
 	},
 /obj/structure/table,
 /obj/item/analyzer,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -40378,6 +41176,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
 /obj/machinery/light_switch/directional/east,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/hop)
 "fiS" = (
@@ -40393,7 +41192,7 @@
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "fiU" = (
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -40431,6 +41230,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "fjw" = (
+/obj/effect/landmark/start/hangover,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
@@ -40443,6 +41243,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/bridge/vip)
+"fjy" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/ne)
 "fjz" = (
 /obj/structure/kitchenspike,
 /turf/simulated/floor/plating,
@@ -40512,7 +41319,7 @@
 /area/crew_quarters/fitness)
 "fjY" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "fkf" = (
@@ -40524,7 +41331,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "fkh" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/closet/walllocker{
 	pixel_y = 28
 	},
@@ -40578,7 +41387,7 @@
 /obj/item/seeds/wheat/rice,
 /obj/item/seeds/wheat/rice,
 /obj/item/seeds/wheat/rice,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -40612,7 +41421,9 @@
 	},
 /area/aisat/aihallway)
 "fkX" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -40622,7 +41433,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/east,
 /obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/camera{
 	c_tag = "Toxins Gas Storage";
 	dir = 8;
@@ -40719,7 +41530,9 @@
 	},
 /area/aisat/aihallway)
 "fmF" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel{
@@ -40879,7 +41692,9 @@
 	c_tag = "Cargo Supply South";
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "fnY" = (
@@ -40916,7 +41731,9 @@
 /area/atmos)
 "fox" = (
 /obj/structure/cable/yellow,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -40942,11 +41759,12 @@
 /area/security/main)
 "foM" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -41001,7 +41819,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit/maint)
 "fpy" = (
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 8
 	},
 /obj/structure/chair/sofa/bench/right{
@@ -41036,7 +41854,9 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "fqf" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -41082,9 +41902,10 @@
 	},
 /area/atmos)
 "fqN" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/optable,
 /obj/item/radio/intercom/directional/south,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -41140,7 +41961,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -41177,8 +41997,12 @@
 /area/crew_quarters/kitchen)
 "fsc" = (
 /obj/structure/grille,
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -41247,7 +42071,7 @@
 "fsH" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/tea,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "greencorner"
@@ -41345,6 +42169,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "ftW" = (
@@ -41395,10 +42220,16 @@
 /obj/structure/reflector/box/anchored{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
-/obj/effect/decal/warning_stripes/northwestcorner,
-/obj/effect/decal/warning_stripes/northeastcorner,
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "fuE" = (
@@ -41435,7 +42266,9 @@
 	},
 /area/quartermaster/storage)
 "fuT" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/table/reinforced,
 /obj/machinery/alarm/directional/north,
 /obj/item/assembly/signaler,
@@ -41462,7 +42295,7 @@
 	name = "Toxins Launcher";
 	req_access = list(7)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plating,
 /area/toxins/launch)
 "fvt" = (
@@ -41513,13 +42346,15 @@
 /area/medical/research/restroom)
 "fvC" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "fvE" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -41604,7 +42439,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/sign/radiation/rad_area{
 	pixel_y = 32
 	},
@@ -41697,8 +42534,6 @@
 /area/maintenance/turbine)
 "fxD" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
@@ -41708,7 +42543,7 @@
 /turf/space,
 /area/space)
 "fxR" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/table/reinforced,
 /obj/item/melee/baton,
 /turf/simulated/floor/plasteel{
@@ -41783,7 +42618,7 @@
 /area/maintenance/bar)
 "fyt" = (
 /obj/structure/closet/coffin,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -41974,7 +42809,7 @@
 /area/crew_quarters/theatre)
 "fBI" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/sign/fire{
 	pixel_y = 32
 	},
@@ -42028,7 +42863,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/clothing/shoes/combat/riot,
 /obj/item/clothing/shoes/combat/riot,
 /obj/item/clothing/shoes/combat/riot,
@@ -42071,7 +42906,9 @@
 /area/security/warden)
 "fCH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "fCJ" = (
@@ -42098,7 +42935,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "neutral"
@@ -42106,7 +42946,9 @@
 /area/engineering/mechanic_workshop/expedition)
 "fDy" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "fDU" = (
@@ -42130,7 +42972,7 @@
 /area/maintenance/library)
 "fEb" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/apc_electronics,
 /obj/item/airlock_electronics,
 /obj/item/firelock_electronics,
@@ -42335,7 +43177,7 @@
 /area/turret_protected/ai)
 "fFz" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -42387,7 +43229,7 @@
 	},
 /area/toxins/launch)
 "fFR" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -42423,7 +43265,7 @@
 	},
 /area/bridge/vip)
 "fGp" = (
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
 /obj/structure/chair/sofa/bench/left{
@@ -42448,7 +43290,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -42488,7 +43330,9 @@
 	},
 /area/crew_quarters/locker)
 "fHp" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch for the pod doors.";
 	id = "secpilot";
@@ -42619,8 +43463,6 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
@@ -42720,7 +43562,7 @@
 /area/tcommsat/chamber)
 "fKI" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "red"
@@ -42755,6 +43597,7 @@
 "fLb" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
 "fLk" = (
@@ -42841,7 +43684,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -42860,7 +43705,9 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
 "fMo" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkblue"
@@ -42879,7 +43726,7 @@
 /area/chapel/main)
 "fMJ" = (
 /obj/effect/landmark/start/cyborg,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
 	},
@@ -42902,7 +43749,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/prison/cell_block/A)
 "fMY" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -42916,6 +43763,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -42928,7 +43776,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/camera{
 	c_tag = "Departure Lounge East";
 	dir = 8
@@ -42971,7 +43819,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "fNO" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel,
@@ -43014,13 +43862,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "fOr" = (
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding4"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43063,7 +43909,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "fPs" = (
@@ -43081,8 +43930,6 @@
 /area/toxins/sm_test_chamber)
 "fPA" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -43091,7 +43938,7 @@
 /area/engineering/engine)
 "fPF" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/light,
 /obj/item/spacepod_equipment/key{
 	id = 100000
@@ -43124,7 +43971,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
 "fQd" = (
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
 /obj/structure/chair/sofa/bench{
@@ -43140,12 +43987,11 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -43239,6 +44085,10 @@
 	icon_state = "dark"
 	},
 /area/crew_quarters/bar)
+"fRG" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel,
+/area/security/range)
 "fRH" = (
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes/farwacubes,
@@ -43434,6 +44284,7 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -43542,7 +44393,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
@@ -43661,7 +44512,9 @@
 	},
 /area/library)
 "fWg" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -43701,6 +44554,7 @@
 /turf/simulated/floor/plating,
 /area/security/hos)
 "fWs" = (
+/obj/effect/landmark/start/hangover,
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
@@ -43720,7 +44574,9 @@
 	},
 /area/security/permabrig)
 "fWD" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -43779,7 +44635,7 @@
 	},
 /area/hallway/primary/aft)
 "fWW" = (
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/door_control{
@@ -43847,21 +44703,25 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "fXK" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "fXL" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/power/emitter/welded{
 	dir = 8
 	},
@@ -43947,7 +44807,7 @@
 /area/atmos)
 "fYC" = (
 /obj/structure/table/glass,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -43985,8 +44845,10 @@
 	},
 /area/quartermaster/storage)
 "fZf" = (
-/obj/effect/decal/warning_stripes/yellow/partial,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/delivery/partial,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -44140,7 +45002,7 @@
 /area/maintenance/asmaint4)
 "gbc" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -44177,7 +45039,6 @@
 	network = list("SS13","Medical");
 	pixel_x = 30
 	},
-/obj/machinery/defibrillator_mount/loaded,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -44220,12 +45081,14 @@
 	},
 /area/quartermaster/office)
 "gca" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "gcg" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -44274,7 +45137,9 @@
 	},
 /area/maintenance/kitchen)
 "gcY" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -44288,7 +45153,7 @@
 	},
 /area/medical/cloning)
 "gds" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -44324,7 +45189,7 @@
 /area/crew_quarters/sleep)
 "gdQ" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -44357,7 +45222,7 @@
 /area/bridge/vip)
 "geP" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -44403,7 +45268,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -44493,7 +45357,7 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "ghI" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -44584,7 +45448,7 @@
 /obj/item/cartridge/signal/toxins{
 	pixel_y = 6
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/lighter/zippo/rd,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
@@ -44610,7 +45474,9 @@
 	},
 /area/medical/research/restroom)
 "gjM" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "gjR" = (
@@ -44643,7 +45509,7 @@
 	},
 /area/medical/paramedic)
 "gko" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -44652,6 +45518,16 @@
 	icon_state = "darkred"
 	},
 /area/security/podbay)
+"gkp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/library/game_zone)
 "gku" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -44666,6 +45542,12 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
+"gkB" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "cmo"
+	},
+/area/medical/ward)
 "gkD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9;
@@ -44675,7 +45557,7 @@
 	pixel_x = 32
 	},
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint3)
 "gkQ" = (
@@ -44728,7 +45610,9 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "glv" = (
@@ -44766,7 +45650,7 @@
 	},
 /area/hallway/primary/central/north)
 "glA" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/rack,
 /obj/item/airlock_painter{
 	pixel_x = -6;
@@ -44837,15 +45721,15 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/medical/cloning)
 "gmf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -44881,7 +45765,7 @@
 /area/library)
 "gml" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/vending_refill/custom{
 	pixel_x = 3;
 	pixel_y = 5
@@ -44949,7 +45833,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
 "gnI" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -45024,6 +45908,12 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
+"gos" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/reception)
 "goz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45072,7 +45962,9 @@
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "goP" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -45320,7 +46212,6 @@
 "grb" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -45339,7 +46230,7 @@
 /area/bridge)
 "grl" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "grq" = (
@@ -45404,7 +46295,9 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
@@ -45469,7 +46362,7 @@
 	dir = 4;
 	pixel_x = -3
 	},
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -45497,6 +46390,15 @@
 	icon_state = "red"
 	},
 /area/security/processing)
+"gtk" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/bridge/meeting_room)
 "gto" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wrench,
@@ -45549,7 +46451,9 @@
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/serviceyard)
 "gtQ" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
@@ -45591,7 +46495,7 @@
 /obj/item/target/syndicate,
 /obj/item/target/syndicate,
 /obj/item/target/syndicate,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
 /area/security/range)
@@ -45613,7 +46517,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -45719,7 +46623,7 @@
 "gvo" = (
 /obj/machinery/newscaster/directional/west,
 /obj/structure/closet/bombcloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -45902,7 +46806,7 @@
 	pixel_x = 26;
 	req_access = list(18)
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -45929,7 +46833,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/clothing/gloves/combat/riot,
 /obj/item/clothing/gloves/combat/riot,
 /obj/item/clothing/gloves/combat/riot,
@@ -45993,7 +46897,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
 "gyP" = (
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/turf_decal/delivery/partial,
 /obj/structure/chair/sofa/bench,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -46014,6 +46918,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -46023,7 +46928,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/computer/card/minor/rd,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "gyZ" = (
@@ -46057,7 +46962,9 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "gzs" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -46071,7 +46978,6 @@
 	level = 1
 	},
 /obj/structure/cable/yellow{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/window/plasmareinforced{
@@ -46109,7 +47015,9 @@
 	},
 /area/chapel/office)
 "gzM" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -46136,8 +47044,8 @@
 /area/crew_quarters/theatre)
 "gzR" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "gAw" = (
@@ -46402,7 +47310,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot,
@@ -46525,7 +47433,9 @@
 	},
 /area/security/prison/cell_block/A)
 "gES" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkred"
@@ -46545,8 +47455,6 @@
 /area/chapel/main)
 "gFc" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -46596,7 +47504,7 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/sorting)
 "gFm" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -46632,8 +47540,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -46660,7 +47572,9 @@
 	},
 /area/bridge)
 "gGh" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "gGp" = (
@@ -46681,7 +47595,9 @@
 	},
 /area/hallway/primary/aft)
 "gGx" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/binary/pump{
 	desc = "Позволяет пропустить смесь не загружая её в хранилище";
 	name = "Смесь в обход хранилища";
@@ -46746,11 +47662,11 @@
 "gHc" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "gHn" = (
@@ -46779,8 +47695,6 @@
 /area/library)
 "gHz" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/table/reinforced,
@@ -46810,7 +47724,7 @@
 	id_tag = "stationawaygate";
 	name = "Gateway Access Shutters"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Exp_lockdown";
@@ -46878,7 +47792,7 @@
 	id_tag = "stationawaygate";
 	name = "Gateway Access Shutters"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Exp_lockdown";
@@ -46908,7 +47822,9 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "gIq" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -46917,7 +47833,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "gIs" = (
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -46940,12 +47856,11 @@
 "gIy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
 "gIA" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 1;
@@ -46990,7 +47905,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "gJA" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	name = "Труба на фильтрацию"
@@ -47083,7 +47998,9 @@
 	},
 /area/security/permabrig)
 "gKs" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47197,7 +48114,7 @@
 	},
 /area/medical/cryo)
 "gLG" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/consarea_virology)
@@ -47239,7 +48156,7 @@
 /area/space)
 "gMa" = (
 /obj/machinery/vending/hydronutrients,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/maintenance/garden)
 "gMf" = (
@@ -47299,7 +48216,7 @@
 /area/chapel/office)
 "gNb" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "gNg" = (
@@ -47349,7 +48266,9 @@
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "gNy" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "gNz" = (
@@ -47415,7 +48334,7 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
 	},
@@ -47443,7 +48362,9 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/plasteel,
@@ -47490,7 +48411,9 @@
 	},
 /area/security/permabrig)
 "gOv" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "gOx" = (
@@ -47522,7 +48445,7 @@
 /obj/effect/turf_decal/caution/red{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/red/partial{
+/obj/effect/turf_decal/delivery/red/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -47561,7 +48484,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/lootdrop/maintenance/double,
 /turf/simulated/floor/plasteel{
@@ -47611,7 +48534,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -47645,13 +48570,24 @@
 	},
 /area/security/permabrig)
 "gQj" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/alarm/directional/south,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
+"gQl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel,
+/area/bridge/vip)
 "gQw" = (
 /obj/machinery/atmospherics/unary/thermomachine/heater{
 	dir = 1
@@ -47747,7 +48683,7 @@
 "gRa" = (
 /obj/machinery/light,
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "gRb" = (
@@ -47772,7 +48708,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/clothing/suit/armor/riot,
 /obj/item/clothing/suit/armor/riot,
 /obj/item/clothing/suit/armor/riot,
@@ -47823,6 +48759,13 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai)
+"gSr" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/aft)
 "gSE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -47908,7 +48851,9 @@
 	},
 /area/maintenance/asmaint4)
 "gTl" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -47928,7 +48873,9 @@
 /area/atmos)
 "gTx" = (
 /obj/machinery/chem_dispenser,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -47950,7 +48897,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -48052,7 +48999,7 @@
 	},
 /area/toxins/launch)
 "gVd" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastright{
 	name = "Hydroponics Delivery";
 	req_access = list(35)
@@ -48066,7 +49013,7 @@
 /area/hydroponics)
 "gVo" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
@@ -48134,8 +49081,8 @@
 	},
 /area/hallway/secondary/exit)
 "gVN" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/plasticflaps,
+/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
 	dir = 1;
@@ -48184,7 +49131,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -48205,7 +49151,7 @@
 /area/crew_quarters/serviceyard)
 "gWH" = (
 /obj/machinery/chem_master,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -48224,7 +49170,7 @@
 /obj/item/ai_module/reset,
 /obj/item/flash,
 /obj/item/flash,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/requests_console{
 	department = "Tech Storage";
 	name = "Tech Storage Requests Console";
@@ -48251,6 +49197,7 @@
 	},
 /area/crew_quarters/kitchen)
 "gXf" = (
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "gXh" = (
@@ -48279,7 +49226,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -48378,20 +49325,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/medical/medbay)
 "gYo" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
@@ -48443,7 +49386,7 @@
 /area/crew_quarters/fitness)
 "gZb" = (
 /obj/structure/weightmachine/weightlifter,
-/obj/effect/decal/warning_stripes/white/hollow,
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -48487,13 +49430,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "gZC" = (
 /obj/structure/morgue,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/effect/landmark/spawner/revenant,
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -48504,7 +49448,6 @@
 /obj/effect/landmark/start/mime,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -48529,7 +49472,9 @@
 	id = "auxsolareast";
 	name = "North-East Solar Control"
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "haf" = (
@@ -48578,6 +49523,12 @@
 	icon_state = "purple"
 	},
 /area/quartermaster/miningdock)
+"hbn" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/westarrival)
 "hbA" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -48741,7 +49692,7 @@
 /area/lawoffice)
 "hdV" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "KPPS"
 	},
@@ -48802,7 +49753,9 @@
 /area/hydroponics)
 "hev" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -48870,7 +49823,9 @@
 	},
 /area/medical/reception)
 "hfl" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -48888,7 +49843,6 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -48897,7 +49851,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -48959,6 +49913,13 @@
 	icon_state = "darkred"
 	},
 /area/security/warden)
+"hgj" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/hallway/secondary/entry/commercial)
 "hgs" = (
 /obj/structure/sign/doors,
 /turf/simulated/wall,
@@ -49070,8 +50031,10 @@
 /area/teleporter)
 "hhg" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -49135,7 +50098,7 @@
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
 /obj/item/radio,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -49295,7 +50258,9 @@
 /turf/simulated/floor/plating,
 /area/security/podbay)
 "hkF" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -49340,7 +50305,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "hlF" = (
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /obj/structure/closet/crate/secure/blood/xeno,
 /obj/item/reagent_containers/iv_bag/blood/wryn,
 /obj/item/reagent_containers/iv_bag/blood/vulpkanin,
@@ -49359,7 +50324,9 @@
 	},
 /area/medical/sleeper)
 "hlG" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -49375,6 +50342,7 @@
 "hlX" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/hydroponics/soil,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "hmb" = (
@@ -49495,6 +50463,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/confetti,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -49528,14 +50497,16 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "hoo" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/status_display/supply_display{
 	layer = 3.25;
 	pixel_y = 32
@@ -49608,13 +50579,15 @@
 /area/maintenance/starboard)
 "hoJ" = (
 /obj/machinery/chem_heater,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
 /turf/simulated/floor/engine,
 /area/medical/chemistry)
 "hoM" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -49676,6 +50649,7 @@
 	pixel_y = 24;
 	req_access = list(58)
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -49794,7 +50768,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -49814,7 +50790,7 @@
 /area/medical/virology/lab)
 "hqC" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -49875,7 +50851,9 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "hrk" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -49894,7 +50872,7 @@
 /area/bridge)
 "hrt" = (
 /obj/structure/chair/stool,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/driver_button{
 	id_tag = "trash";
 	name = "Trash Ejector Button";
@@ -49933,13 +50911,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"hrS" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/warning_stripes/west,
-/turf/simulated/floor/plating,
-/area/engineering/engine)
 "hrX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -50050,7 +51021,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "htt" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/purple,
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel{
@@ -50064,7 +51035,7 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/mirror{
 	pixel_x = -26
 	},
@@ -50079,13 +51050,14 @@
 	pixel_y = -28
 	},
 /obj/item/radio/intercom/locked/prison/directional/south,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "htC" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -50211,7 +51183,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -50226,7 +51198,9 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "hvI" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 10;
@@ -50239,12 +51213,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "hvP" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "hvU" = (
@@ -50288,6 +51268,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/sw)
+"hwb" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/crew_quarters/locker)
 "hwf" = (
 /obj/machinery/vending/chinese,
 /turf/simulated/floor/carpet/green,
@@ -50382,7 +51369,9 @@
 /turf/simulated/wall/r_wall/rust,
 /area/toxins/sm_test_chamber)
 "hxp" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/vending/plasmaresearch,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -50473,8 +51462,6 @@
 "hyv" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -50510,7 +51497,9 @@
 	name = "Chapel Launcher Door";
 	protected = 0
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
@@ -50559,15 +51548,26 @@
 /area/maintenance/starboard)
 "hzX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/south)
+"hAp" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/fore)
 "hAw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "hAy" = (
@@ -50597,7 +51597,7 @@
 	},
 /area/quartermaster/miningdock)
 "hAQ" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -50626,6 +51626,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -50671,7 +51672,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "hBX" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -50685,13 +51688,11 @@
 	},
 /area/crew_quarters/locker)
 "hCl" = (
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding4"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding1"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -50755,7 +51756,7 @@
 	},
 /area/hallway/primary/central/south)
 "hDg" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastright{
 	dir = 8;
 	name = "Clown Delivery";
@@ -50774,7 +51775,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -50815,14 +51815,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/port)
 "hEe" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
 	},
@@ -50939,7 +51939,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -50948,7 +51948,7 @@
 /area/hallway/primary/central/nw)
 "hFn" = (
 /obj/effect/landmark/start/cyborg,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "purple"
@@ -51104,7 +52104,7 @@
 /area/hallway/primary/central/north)
 "hHo" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
@@ -51141,15 +52141,15 @@
 /area/hallway/primary/central/east)
 "hHu" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space)
 "hHy" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -51199,14 +52199,6 @@
 	icon_state = "grimy"
 	},
 /area/chapel/main)
-"hIt" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/closet/secure_closet/engineering_welding,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/glasses/welding,
-/turf/simulated/floor/plasteel,
-/area/engineering/engine)
 "hIA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -51250,7 +52242,7 @@
 /area/crew_quarters/fitness)
 "hJr" = (
 /obj/machinery/power/terminal,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -51278,7 +52270,7 @@
 	name = "Creature Pen";
 	req_access = list(47)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -51288,7 +52280,7 @@
 /area/toxins/xenobiology)
 "hJO" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler{
 	pixel_x = -8;
@@ -51314,7 +52306,9 @@
 	id_tag = "admin_home";
 	locked = 1
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "hJW" = (
@@ -51327,7 +52321,7 @@
 	},
 /area/toxins/sm_test_chamber)
 "hJX" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -51364,6 +52358,7 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "hKh" = (
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -51386,7 +52381,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -51395,8 +52390,10 @@
 	},
 /area/hallway/primary/central/ne)
 "hKt" = (
-/obj/effect/decal/warning_stripes/southwest,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/chem_dispenser,
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
@@ -51453,7 +52450,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -51548,7 +52544,7 @@
 /area/crew_quarters/theatre)
 "hMh" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "KPPN"
 	},
@@ -51632,6 +52628,26 @@
 	icon_state = "red"
 	},
 /area/security/lobby)
+"hNt" = (
+/obj/machinery/optable,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/shower{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/medical/surgery/south)
 "hNA" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Holding Area";
@@ -51714,7 +52730,7 @@
 /turf/simulated/floor/carpet/black,
 /area/quartermaster/storage)
 "hOs" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -51731,7 +52747,7 @@
 	},
 /area/hallway/primary/port/west)
 "hOy" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -51751,7 +52767,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -51805,7 +52821,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "hPr" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/computer/supplycomp/public{
 	dir = 8
 	},
@@ -51875,7 +52891,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -51901,7 +52917,7 @@
 	},
 /area/security/hos)
 "hQl" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/radiation,
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
@@ -51980,7 +52996,7 @@
 /area/crew_quarters/theatre)
 "hQU" = (
 /obj/structure/cable/yellow,
-/obj/effect/decal/warning_stripes/eastsouthwest,
+/obj/effect/turf_decal/stripes/end,
 /obj/machinery/power/emitter/welded,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
@@ -52124,11 +53140,11 @@
 	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -52154,13 +53170,11 @@
 	},
 /area/medical/medbay)
 "hTb" = (
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding1"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52245,7 +53259,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/hatdispenser,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -52307,6 +53320,12 @@
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin2)
+"hUV" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/north)
 "hVa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52315,6 +53334,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -52337,7 +53357,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -52408,8 +53427,6 @@
 	pixel_y = -34
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -52463,18 +53480,25 @@
 	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry/lounge)
+"hWK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/commercial)
 "hWL" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "hWX" = (
@@ -52532,7 +53556,7 @@
 	},
 /area/toxins/lab)
 "hXt" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/double,
 /turf/simulated/floor/plasteel{
@@ -52571,7 +53595,7 @@
 /obj/item/mop,
 /obj/item/caution,
 /obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/mop,
 /obj/item/mop,
 /turf/simulated/floor/plasteel{
@@ -52588,7 +53612,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -52602,7 +53626,9 @@
 /area/crew_quarters/courtroom)
 "hYw" = (
 /obj/machinery/shieldgen,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "hYL" = (
@@ -52732,7 +53758,7 @@
 /area/toxins/xenobiology)
 "iao" = (
 /obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -52750,7 +53776,9 @@
 	},
 /area/maintenance/asmaint4)
 "iaH" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -52774,7 +53802,7 @@
 /turf/simulated/floor/plating,
 /area/security/processing)
 "ibu" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -52836,16 +53864,16 @@
 	dir = 1
 	},
 /obj/structure/displaycase/labcage,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "ibT" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "ibW" = (
@@ -52895,7 +53923,7 @@
 /area/security/main)
 "ics" = (
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -52905,12 +53933,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "icz" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "icF" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
@@ -52957,7 +53987,7 @@
 "idu" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/coffin,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/door/window/eastleft{
 	dir = 8;
 	name = "Coffin Storage";
@@ -53042,7 +54072,7 @@
 /obj/item/seeds/chili,
 /obj/item/seeds/chili,
 /obj/item/seeds/chili,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -53070,7 +54100,7 @@
 /obj/item/toy/figure/rd{
 	pixel_x = -7
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
@@ -53100,7 +54130,7 @@
 /area/medical/research/nhallway)
 "ifD" = (
 /obj/machinery/space_heater,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "ifK" = (
@@ -53124,7 +54154,7 @@
 /obj/machinery/atmospherics/unary/thermomachine/freezer{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/eastsouthwest,
+/obj/effect/turf_decal/stripes/end,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
@@ -53163,7 +54193,7 @@
 	pixel_y = -27
 	},
 /obj/machinery/vending/department_clothesmate/cargo,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -53189,7 +54219,7 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -53398,7 +54428,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -53406,7 +54438,9 @@
 /area/maintenance/asmaint2)
 "ijw" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -53488,18 +54522,21 @@
 /area/toxins/explab)
 "ikr" = (
 /obj/machinery/suit_storage_unit/security/hos,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/hos)
 "iku" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
+	icon_state = "crate_open";
 	opened = 1
 	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -53562,7 +54599,9 @@
 	},
 /area/engineering/break_room)
 "ikN" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 5;
@@ -53622,8 +54661,8 @@
 /area/medical/cloning)
 "ilx" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
@@ -53659,13 +54698,17 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/northwestsouth,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
 /area/atmos)
 "iml" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -53738,7 +54781,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "imJ" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
@@ -53817,7 +54862,9 @@
 	},
 /area/quartermaster/storage)
 "inw" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
@@ -53825,7 +54872,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "inx" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastleft{
 	dir = 2;
 	name = "Chapel Delivery";
@@ -53839,7 +54886,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
@@ -53921,7 +54970,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "iof" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
@@ -54052,8 +55103,10 @@
 /area/maintenance/asmaint2)
 "iqD" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/northwestsouth,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "iqN" = (
@@ -54096,7 +55149,7 @@
 /area/maintenance/detectives_office)
 "iqZ" = (
 /obj/effect/landmark/start/civilian,
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
 /obj/structure/chair/sofa/bench{
@@ -54131,7 +55184,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -54181,10 +55234,10 @@
 /turf/simulated/floor/glass,
 /area/maintenance/consarea_virology)
 "irZ" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -54203,8 +55256,6 @@
 /area/maintenance/fpmaint)
 "isc" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
@@ -54291,13 +55342,11 @@
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "itk" = (
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding1"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -54337,8 +55386,12 @@
 /area/space)
 "iuh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "iui" = (
@@ -54365,7 +55418,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "ium" = (
@@ -54379,7 +55432,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/landmark/lightsout,
 /turf/simulated/floor/plasteel{
@@ -54536,8 +55589,12 @@
 /area/bridge/checkpoint/south)
 "ivy" = (
 /obj/structure/grille,
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -54592,7 +55649,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
@@ -54601,7 +55658,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -54795,13 +55854,14 @@
 /obj/machinery/atm{
 	pixel_y = -32
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry/commercial)
 "iyh" = (
 /obj/structure/closet/coffin,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "vault"
@@ -54856,7 +55916,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -55096,7 +56156,7 @@
 /area/medical/research)
 "iCV" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
 	},
@@ -55153,7 +56213,7 @@
 /obj/item/target,
 /obj/item/target,
 /obj/item/target,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "iDE" = (
@@ -55191,7 +56251,7 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "iEu" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/alarm/directional/north,
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plasteel,
@@ -55229,7 +56289,7 @@
 	},
 /area/quartermaster/miningdock)
 "iEY" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/disposal,
 /obj/structure/window/reinforced,
 /obj/structure/disposalpipe/trunk{
@@ -55261,12 +56321,11 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -55330,7 +56389,7 @@
 	},
 /area/crew_quarters/theatre)
 "iFG" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/table,
 /obj/item/plant_analyzer,
 /obj/item/hatchet,
@@ -55348,7 +56407,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -55477,8 +56536,6 @@
 	network = list("SS13","Engineering")
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -55606,11 +56663,9 @@
 /area/crew_quarters/heads/hop)
 "iIm" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "iIq" = (
@@ -55662,7 +56717,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -55673,7 +56730,9 @@
 /turf/simulated/floor/carpet/black,
 /area/maintenance/casino)
 "iJw" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -55691,7 +56750,9 @@
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "iJN" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
 /obj/item/clothing/glasses/sunglasses/blindfold/black,
@@ -55702,6 +56763,7 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -55709,7 +56771,9 @@
 /area/medical/morgue)
 "iJV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -55754,7 +56818,9 @@
 	},
 /area/crew_quarters/fitness)
 "iKq" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
@@ -55762,7 +56828,9 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -55800,7 +56868,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/theatre)
 "iKW" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
@@ -55812,7 +56880,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/closet/emcloset,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -55886,7 +56954,7 @@
 /area/maintenance/asmaint3)
 "iLK" = (
 /obj/machinery/portable_atmospherics/scrubber/huge/stationary,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -55903,7 +56971,9 @@
 	},
 /area/hallway/primary/starboard/east)
 "iMh" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -55925,7 +56995,7 @@
 	},
 /area/bridge)
 "iMj" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -55943,7 +57013,7 @@
 	},
 /area/atmos)
 "iMP" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/gibber,
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel,
@@ -55971,7 +57041,7 @@
 	pixel_y = -30
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "iNi" = (
@@ -56083,7 +57153,7 @@
 /area/maintenance/starboard)
 "iOk" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
@@ -56097,7 +57167,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -56206,7 +57275,7 @@
 "iPh" = (
 /obj/structure/dispenser/oxygen,
 /obj/item/radio/intercom/directional/east,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "iPo" = (
@@ -56231,7 +57300,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northeastsouth,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "iQf" = (
@@ -56341,7 +57412,7 @@
 /area/toxins/xenobiology)
 "iRA" = (
 /obj/machinery/seed_extractor,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -56365,7 +57436,7 @@
 /obj/machinery/atm{
 	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -56390,7 +57461,6 @@
 	icon_state = "grass_edge_medium_corner"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -56422,12 +57492,16 @@
 /area/storage/eva)
 "iSY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "iTe" = (
-/obj/effect/decal/warning_stripes/blue,
+/obj/effect/turf_decal/delivery/blue,
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
@@ -56475,8 +57549,8 @@
 /obj/machinery/seed_extractor{
 	pixel_y = -1
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/green,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/delivery/green,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -56510,7 +57584,7 @@
 /obj/structure/table/reinforced,
 /obj/item/paicard,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "iUX" = (
@@ -56608,7 +57682,6 @@
 /area/crew_quarters/hor)
 "iWm" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
@@ -56629,7 +57702,9 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
 "iWB" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/autolathe,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -56671,7 +57746,7 @@
 	},
 /area/hallway/primary/port/west)
 "iWO" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -56685,7 +57760,7 @@
 /area/maintenance/electrical)
 "iXb" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -56712,10 +57787,10 @@
 	},
 /area/toxins/mixing)
 "iXh" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -56815,7 +57890,7 @@
 /obj/machinery/sleeper{
 	pixel_x = 3
 	},
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /obj/machinery/alarm/directional/north,
 /obj/machinery/camera{
 	c_tag = "Medbay Exam Room North";
@@ -56884,11 +57959,11 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "iYC" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -57033,7 +58108,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -57053,7 +58128,9 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "jbb" = (
@@ -57075,19 +58152,21 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "jby" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "jbE" = (
-/obj/effect/decal/warning_stripes/blue,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/delivery/blue,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/shower{
 	dir = 4;
 	pixel_y = 4
@@ -57210,6 +58289,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/reception)
+"jdb" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/crew_quarters/locker)
 "jdc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dust,
@@ -57229,8 +58315,8 @@
 	},
 /area/maintenance/banya)
 "jde" = (
-/obj/structure/plasticflaps,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -57291,7 +58377,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -57330,7 +58416,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "jeg" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/roboticist,
 /obj/item/radio/headset/headset_sci{
 	pixel_x = -3
@@ -57355,7 +58441,9 @@
 /area/maintenance/engineering)
 "jeu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -57416,7 +58504,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -57461,7 +58549,7 @@
 "jfk" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/monkey_recycler,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -57538,14 +58626,14 @@
 "jfX" = (
 /obj/machinery/vending/tool,
 /obj/item/radio/intercom/directional/west,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "jfY" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -57554,7 +58642,9 @@
 /area/quartermaster/storage)
 "jgf" = (
 /obj/machinery/chem_master,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/reagent_dispensers/fueltank/chem{
 	pixel_x = 32
@@ -57605,7 +58695,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/directional/north,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "jgL" = (
@@ -57637,7 +58729,9 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
 "jhm" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "jhv" = (
@@ -57680,7 +58774,6 @@
 /obj/machinery/vending/autodrobe,
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -57703,7 +58796,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -57729,7 +58822,7 @@
 /area/medical/psych)
 "jiL" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -57804,7 +58897,9 @@
 	},
 /area/medical/virology)
 "jjc" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -57904,7 +58999,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -58027,8 +59122,12 @@
 	},
 /area/security/processing)
 "jme" = (
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "jmj" = (
@@ -58037,7 +59136,9 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
@@ -58048,7 +59149,7 @@
 /area/maintenance/asmaint3)
 "jmo" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -58104,7 +59205,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -58160,7 +59261,6 @@
 /obj/structure/closet/cardboard,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -58179,7 +59279,7 @@
 /area/chapel/main)
 "jnA" = (
 /obj/machinery/firealarm/directional/west,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/rack,
 /obj/item/gps{
 	pixel_x = -6;
@@ -58263,7 +59363,9 @@
 /area/maintenance/brig)
 "job" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58328,7 +59430,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -58500,7 +59601,7 @@
 /turf/simulated/wall,
 /area/maintenance/casino)
 "jqx" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/camera{
 	c_tag = "Secure Armory East";
 	dir = 8;
@@ -58623,7 +59724,9 @@
 	},
 /area/atmos)
 "jrU" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/chair/stool{
 	dir = 8
 	},
@@ -58674,7 +59777,9 @@
 	},
 /area/bridge/checkpoint/south)
 "jso" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -58716,7 +59821,9 @@
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "jsz" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "jsC" = (
@@ -58734,15 +59841,17 @@
 /area/hallway/secondary/exit)
 "jsU" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "jtd" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/atmospherics/binary/valve/digital/open{
 	desc = "Позволяет отключить подачу дыхательной смеси на станцию, не отключая саму закачку газа. (Например, если требуется подать только смесь из оранжевых труб)";
 	dir = 4;
@@ -58848,11 +59957,11 @@
 /area/security/brigstaff)
 "jtS" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "jub" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 1;
@@ -58875,7 +59984,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/clothing/head/helmet/alt,
 /obj/item/clothing/head/helmet/alt,
 /obj/item/clothing/head/helmet/alt,
@@ -58920,7 +60029,7 @@
 /obj/structure/railing{
 	dir = 5
 	},
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluefull"
 	},
@@ -58962,12 +60071,16 @@
 	},
 /area/quartermaster/delivery)
 "jvi" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "jvq" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -59073,7 +60186,9 @@
 	name = "Privacy Shutters";
 	pixel_x = 24
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/chief)
@@ -59130,8 +60245,12 @@
 /area/engineering/engine)
 "jwR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -59172,7 +60291,7 @@
 	},
 /area/crew_quarters/theatre)
 "jxu" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	name = "Труба дыхательной смеси"
@@ -59217,7 +60336,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "jxO" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/walllocker{
 	pixel_y = -28
 	},
@@ -59436,6 +60555,7 @@
 	c_tag = "Mr. Chang's";
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/mrchangs)
 "jAi" = (
@@ -59499,7 +60619,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -59513,13 +60635,12 @@
 	},
 /area/bridge/checkpoint/north)
 "jAF" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastright{
 	name = "Mime Delivery";
 	req_access = list(46)
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -59541,7 +60662,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
@@ -59582,7 +60703,7 @@
 "jBw" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "bluefull"
 	},
@@ -59786,7 +60907,7 @@
 /area/hallway/primary/fore)
 "jEe" = (
 /obj/machinery/newscaster/directional/north,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -59810,7 +60931,7 @@
 /area/security/prison/cell_block/A)
 "jEw" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -59824,7 +60945,7 @@
 /area/quartermaster/office)
 "jEA" = (
 /obj/machinery/biogenerator,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -59909,7 +61030,7 @@
 	},
 /area/toxins/xenobiology)
 "jFS" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -59942,11 +61063,9 @@
 /area/maintenance/consarea_virology)
 "jGo" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -59975,14 +61094,14 @@
 	},
 /obj/item/flashlight,
 /obj/item/radio/intercom/directional/west,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
 	},
 /area/engineering/engine)
 "jGR" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -60043,14 +61162,17 @@
 	network = list("SS13","Engineering")
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/closet/walllocker/emerglocker/directional/east,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "jHC" = (
 /turf/simulated/wall/r_wall/rust,
 /area/toxins/launch)
 "jHF" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -60125,8 +61247,8 @@
 	},
 /area/hallway/primary/central/sw)
 "jIl" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/plasticflaps,
+/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	location = "Chapel"
@@ -60161,10 +61283,13 @@
 	},
 /area/bridge)
 "jIA" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "jIF" = (
@@ -60236,8 +61361,9 @@
 /turf/simulated/floor/glass/reinforced,
 /area/maintenance/asmaint4)
 "jJc" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/reagent_containers/food/drinks/mug/eng,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "jJj" = (
@@ -60279,7 +61405,9 @@
 	name = "Research Division Access";
 	req_access = list(47)
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -60313,13 +61441,14 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "jJQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
 /turf/simulated/floor/plasteel{
@@ -60360,7 +61489,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -60413,7 +61542,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "jKV" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/driver_button{
 	id_tag = "toxinsdriver";
 	pixel_x = 26
@@ -60462,8 +61591,10 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/locker)
 "jLs" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -60575,7 +61706,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/directional/east,
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -60676,6 +61807,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -32
+	},
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -60683,9 +61817,9 @@
 /area/medical/sleeper)
 "jOX" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/firealarm/directional/south,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -60701,7 +61835,9 @@
 	},
 /area/bridge)
 "jPf" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/newscaster/directional/north,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
@@ -60894,7 +62030,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -60920,6 +62056,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -61034,8 +62171,6 @@
 "jUa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -61055,7 +62190,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "jUu" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -61174,8 +62309,10 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "jVF" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/camera{
 	c_tag = "EVA West"
 	},
@@ -61200,7 +62337,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "jWe" = (
@@ -61238,11 +62375,11 @@
 /area/maintenance/fore)
 "jWR" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /obj/structure/closet/walllocker/emerglocker/directional/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -61435,7 +62572,7 @@
 	pixel_x = 30
 	},
 /obj/machinery/reagentgrinder,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "jYS" = (
@@ -61601,6 +62738,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -61637,7 +62775,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -61707,7 +62845,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wardrobe/pjs,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
@@ -61792,7 +62929,7 @@
 /area/security/securehallway)
 "keJ" = (
 /obj/machinery/recharge_station,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -61802,11 +62939,11 @@
 "keL" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "keU" = (
@@ -61825,7 +62962,7 @@
 	},
 /area/security/execution)
 "keY" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/recharge_station,
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32
@@ -61902,7 +63039,9 @@
 /area/security/permabrig)
 "kfB" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -61968,6 +63107,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/lawoffice)
+"kgU" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/simulated/floor/plasteel,
+/area/engineering/engine)
 "khe" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -62045,14 +63189,16 @@
 	},
 /area/turret_protected/ai)
 "khT" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "khY" = (
@@ -62081,7 +63227,7 @@
 	name = "Mining Desk";
 	req_access = list(48)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_cargo";
 	name = "Cargo Lockdown"
@@ -62094,6 +63240,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
+"kiD" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/east)
 "kiG" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -62109,7 +63261,7 @@
 /area/turret_protected/ai)
 "kjk" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -62156,7 +63308,7 @@
 	},
 /obj/item/beacon,
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -62270,7 +63422,7 @@
 /area/maintenance/fpmaint)
 "klb" = (
 /obj/structure/grille,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "klj" = (
@@ -62291,8 +63443,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -62322,11 +63476,9 @@
 	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "klB" = (
@@ -62407,6 +63559,12 @@
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
+"kma" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/medical/research/restroom)
 "kmb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -62422,7 +63580,9 @@
 	},
 /area/quartermaster/office)
 "kmh" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -62435,18 +63595,22 @@
 	},
 /obj/structure/closet/firecloset,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "kmA" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/atmos)
 "kmD" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	name = "Труба обработки"
@@ -62509,7 +63673,7 @@
 	},
 /area/medical/research)
 "knl" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
@@ -62539,7 +63703,7 @@
 /area/maintenance/asmaint4)
 "knB" = (
 /obj/machinery/telepad_cargo,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -62553,7 +63717,7 @@
 	dir = 4;
 	network = list("Toxins","Research","SS13")
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/airless/indestructible,
 /area/toxins/test_area)
 "knS" = (
@@ -62569,7 +63733,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "knU" = (
@@ -62668,13 +63834,15 @@
 /area/bridge/vip)
 "kpn" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
 "kpq" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -62713,7 +63881,7 @@
 	},
 /area/medical/medbay)
 "kpL" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -62739,7 +63907,7 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 5
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -62833,7 +64001,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -62919,6 +64087,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
+"krZ" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/starboard/east)
 "kse" = (
 /obj/machinery/light{
 	dir = 4
@@ -62988,7 +64163,7 @@
 /obj/item/seeds/orange,
 /obj/item/seeds/orange,
 /obj/item/seeds/orange,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -63209,13 +64384,14 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable/yellow{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "kwN" = (
@@ -63265,7 +64441,9 @@
 /area/security/interrogation)
 "kxn" = (
 /obj/machinery/firealarm/directional/south,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/aisat/maintenance)
@@ -63283,7 +64461,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "kxu" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -63406,12 +64584,12 @@
 /area/bridge/checkpoint/south)
 "kyz" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -63576,7 +64754,9 @@
 "kAo" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
@@ -63593,7 +64773,7 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/break_room)
 "kAV" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Singularity North-East";
 	dir = 8;
@@ -63609,7 +64789,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/spawner/xeno,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -63624,7 +64806,9 @@
 	},
 /area/atmos/control)
 "kBk" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/item/restraints/handcuffs/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -63705,9 +64889,9 @@
 /area/toxins/xenobiology)
 "kCr" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light_switch/directional/south,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -63738,7 +64922,9 @@
 /turf/space,
 /area/solar/starboard)
 "kCD" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -63787,7 +64973,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "kDa" = (
@@ -63868,7 +65056,7 @@
 /area/toxins/xenobiology)
 "kEg" = (
 /obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -63919,8 +65107,8 @@
 /area/maintenance/fpmaint)
 "kEM" = (
 /obj/machinery/floodlight,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -63978,14 +65166,22 @@
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/maintenance/fpmaint)
+"kFq" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/mixing)
 "kFz" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "kFO" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
@@ -64123,8 +65319,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -64168,7 +65364,9 @@
 	},
 /area/hydroponics)
 "kIb" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -64236,7 +65434,7 @@
 "kJs" = (
 /obj/structure/window/reinforced,
 /obj/machinery/vending/cola,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -64254,12 +65452,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/plasticflaps,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "kJL" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -64283,7 +65481,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /obj/machinery/newscaster/directional/south,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/photocopier/faxmachine/longrange{
 	department = "Research Director's Office"
 	},
@@ -64377,7 +65575,7 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/effect/decal/warning_stripes/white,
+/obj/effect/turf_decal/delivery/white,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -64426,7 +65624,9 @@
 /area/space)
 "kLx" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "kLF" = (
@@ -64442,7 +65642,7 @@
 /turf/simulated/wall,
 /area/atmos)
 "kLY" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "kLZ" = (
@@ -64457,8 +65657,8 @@
 	},
 /area/hallway/primary/fore)
 "kMb" = (
-/obj/structure/plasticflaps,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	dir = 1;
@@ -64468,7 +65668,9 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "kMe" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/r_n_d/circuit_imprinter{
 	pixel_x = -1;
 	pixel_y = 3
@@ -64737,7 +65939,7 @@
 	},
 /area/maintenance/detectives_office)
 "kPe" = (
-/obj/structure/plasticflaps,
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/siding/green/corner{
 	color = "";
 	dir = 4;
@@ -64789,7 +65991,7 @@
 /obj/item/extinguisher,
 /obj/item/clothing/mask/gas,
 /obj/item/grenade/chem_grenade/firefighting,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
@@ -64832,8 +66034,8 @@
 	},
 /area/medical/cmo)
 "kQH" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/plasticflaps,
+/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	location = "Bar"
@@ -64934,7 +66136,9 @@
 	id_tag = "admin_home";
 	locked = 1
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "kSQ" = (
@@ -65054,10 +66258,11 @@
 /area/hallway/secondary/exit)
 "kUO" = (
 /obj/structure/cable/yellow{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/decal/warning_stripes/eastnorthwest,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
 /obj/machinery/power/emitter/welded{
 	dir = 1
 	},
@@ -65119,7 +66324,7 @@
 /area/medical/research/nhallway)
 "kVH" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -65208,7 +66413,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/clothing/gloves/color/black/ballistic,
 /obj/item/clothing/gloves/color/black/ballistic,
 /obj/item/clothing/gloves/color/black/ballistic,
@@ -65238,7 +66443,7 @@
 	name = "Research Division Access";
 	req_access = list(47)
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -65331,7 +66536,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -65437,6 +66641,12 @@
 	icon_state = "whitehall"
 	},
 /area/toxins/xenobiology)
+"laJ" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/starboard/east)
 "lbg" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -65648,7 +66858,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "ldk" = (
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
 /obj/structure/chair/sofa/bench/right{
@@ -65675,8 +66885,12 @@
 /area/crew_quarters/fitness)
 "ldN" = (
 /obj/structure/grille,
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "ldR" = (
@@ -65724,9 +66938,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint2)
+"leu" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whiteblue"
+	},
+/area/medical/medbay)
 "lev" = (
 /obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whitepurple"
@@ -66085,7 +67306,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "lij" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -66273,6 +67496,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
+"lkw" = (
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/carpet/green,
+/area/crew_quarters/serviceyard)
 "lkA" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -66291,6 +67521,12 @@
 	icon_state = "neutralfull"
 	},
 /area/engineering/gravitygenerator)
+"lkG" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/nw)
 "lkL" = (
 /obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel{
@@ -66345,7 +67581,9 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/supermatter)
 "llx" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -66443,7 +67681,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/directional/east,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "lmx" = (
@@ -66465,8 +67703,12 @@
 /area/turret_protected/ai)
 "lnn" = (
 /obj/structure/grille,
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "lnt" = (
@@ -66482,7 +67724,7 @@
 "lnx" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "yellow"
@@ -66560,7 +67802,9 @@
 /turf/simulated/wall,
 /area/crew_quarters/cabin4)
 "lox" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "loC" = (
@@ -66589,7 +67833,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "loL" = (
@@ -66597,6 +67843,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -66645,7 +67892,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "lpd" = (
@@ -66707,7 +67954,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "lpO" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 8;
@@ -66722,7 +67971,9 @@
 	network = list("Engineering","SS13");
 	pixel_y = -22
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
@@ -66737,13 +67988,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "lqa" = (
 /obj/machinery/biogenerator,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "green"
@@ -66756,7 +68007,7 @@
 "lqd" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -66778,11 +68029,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "lqn" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "lqA" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/binary/valve/digital{
 	desc = "Открывает газу путь к нагревателям, холодильникам и фильтрам";
 	dir = 4;
@@ -66838,7 +68091,7 @@
 	},
 /area/maintenance/starboard)
 "lqQ" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -66852,7 +68105,7 @@
 	},
 /area/maintenance/consarea_virology)
 "lrb" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 1;
@@ -66893,7 +68146,7 @@
 /turf/space,
 /area/maintenance/consarea_virology)
 "lrz" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 4;
@@ -66906,13 +68159,15 @@
 /obj/machinery/r_n_d/destructive_analyzer{
 	pixel_y = 2
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/toxins/lab)
 "lrN" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 4;
@@ -66922,7 +68177,9 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "lrR" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 1;
@@ -66932,7 +68189,7 @@
 /area/atmos)
 "lsc" = (
 /obj/machinery/recharge_station,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
 	},
@@ -66955,8 +68212,10 @@
 /area/lawoffice)
 "lsz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "lsA" = (
@@ -67060,7 +68319,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/power/emitter/welded{
 	dir = 4
 	},
@@ -67092,7 +68351,9 @@
 	},
 /area/security/main)
 "luo" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/sign/poster/official/help_others{
@@ -67147,7 +68408,7 @@
 	},
 /area/medical/ward)
 "luK" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/lootdrop/maintenance/double,
 /turf/simulated/floor/plasteel{
@@ -67167,7 +68428,7 @@
 "luV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/multitool,
 /obj/item/multitool,
 /obj/item/clothing/glasses/welding,
@@ -67175,6 +68436,18 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
+"lvi" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research/nhallway)
 "lvk" = (
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
@@ -67240,7 +68513,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
 "lwc" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
 	dir = 4
@@ -67276,7 +68549,7 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/clothing/glasses/hud/hydroponic,
 /obj/item/clothing/glasses/hud/hydroponic,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -67410,10 +68683,9 @@
 /area/security/customs)
 "lyX" = (
 /obj/structure/cable/yellow{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -67508,7 +68780,6 @@
 /obj/effect/spawner/random_spawners/rodent,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -67567,7 +68838,7 @@
 	},
 /area/toxins/test_chamber)
 "lBs" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -67587,6 +68858,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/cabin4)
 "lBB" = (
@@ -67610,7 +68882,9 @@
 "lBI" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/south,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "lBJ" = (
@@ -67674,8 +68948,8 @@
 	},
 /area/quartermaster/office)
 "lDj" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -67711,7 +68985,9 @@
 /area/crew_quarters/theatre)
 "lDA" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "lDJ" = (
@@ -67730,7 +69006,7 @@
 	},
 /area/medical/research/nhallway)
 "lEd" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "lEe" = (
@@ -67794,8 +69070,8 @@
 /area/maintenance/asmaint)
 "lEI" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/portable_atmospherics/pump,
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel,
@@ -67818,7 +69094,7 @@
 	},
 /area/hallway/primary/starboard/east)
 "lFc" = (
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 8
 	},
 /obj/structure/chair/sofa/bench/left{
@@ -67966,10 +69242,10 @@
 	},
 /area/medical/cmo)
 "lHc" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -68184,13 +69460,13 @@
 "lJF" = (
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/personal/mining,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/miningdock)
 "lJK" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/emcloset,
 /obj/machinery/vending/wallmed{
 	pixel_y = 30
@@ -68372,6 +69648,7 @@
 	network = list("SS13","Security")
 	},
 /obj/machinery/light_switch/directional/north,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -68446,7 +69723,7 @@
 /area/hallway/primary/central/nw)
 "lNp" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/window/reinforced{
 	color = "red";
 	dir = 4
@@ -68488,7 +69765,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -68623,7 +69900,9 @@
 	id_tag = "engstorage";
 	name = "Secure Storage Blast Doors"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -68884,20 +70163,20 @@
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "lTF" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "lTH" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/permabrig)
 "lTM" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -68921,7 +70200,9 @@
 "lUd" = (
 /obj/structure/morgue,
 /obj/item/radio/intercom/directional/west,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/camera{
 	c_tag = "Morgue";
 	dir = 4;
@@ -68980,7 +70261,9 @@
 	},
 /area/bridge)
 "lUS" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/toxins/launch)
 "lUZ" = (
@@ -69080,7 +70363,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -69096,7 +70379,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -69133,7 +70418,7 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -69144,7 +70429,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/consarea_virology)
@@ -69155,8 +70440,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
 "lXa" = (
-/obj/effect/decal/warning_stripes/northwest,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/window/plasmareinforced{
 	dir = 1
 	},
@@ -69181,8 +70468,10 @@
 /area/medical/surgery/north)
 "lXf" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -69253,7 +70542,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -69263,7 +70552,7 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -69296,7 +70585,7 @@
 	},
 /area/security/warden)
 "lYu" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -69363,7 +70652,7 @@
 	},
 /area/maintenance/detectives_office)
 "lZw" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -69408,8 +70697,10 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -69423,11 +70714,11 @@
 "mac" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/door/window/brigdoor,
 /turf/simulated/floor/plating,
 /area/toxins/sm_test_chamber)
@@ -69454,7 +70745,9 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "mal" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "man" = (
@@ -69487,7 +70780,9 @@
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "maB" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -69585,7 +70880,9 @@
 /turf/simulated/wall,
 /area/medical/research)
 "mcf" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -69634,9 +70931,9 @@
 /area/maintenance/asmaint2)
 "mdl" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/newscaster/directional/south,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -69668,7 +70965,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "mdx" = (
@@ -69677,7 +70976,7 @@
 	layer = 5;
 	pixel_y = -5
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/mirror{
 	pixel_y = -30
 	},
@@ -69756,7 +71055,7 @@
 /turf/simulated/floor/plating,
 /area/toxins/sm_test_chamber)
 "meq" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -69790,7 +71089,7 @@
 	},
 /area/medical/research/shallway)
 "meY" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/safe{
 	known_by = list("hos")
 	},
@@ -69801,7 +71100,9 @@
 /area/security/securearmory)
 "mfb" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -69897,8 +71198,8 @@
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 5;
@@ -69907,7 +71208,9 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "mfL" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -69970,7 +71273,9 @@
 	},
 /area/bridge/vip)
 "mgu" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -70071,14 +71376,14 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/library/game_zone)
 "mhL" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "mhO" = (
@@ -70094,7 +71399,7 @@
 	},
 /area/hallway/primary/fore)
 "mhS" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -70106,7 +71411,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -70116,7 +71421,7 @@
 /area/hallway/primary/fore)
 "mid" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -70124,7 +71429,10 @@
 	},
 /area/hallway/primary/fore)
 "mie" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -70145,13 +71453,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "miw" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "miO" = (
@@ -70195,7 +71504,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
@@ -70203,7 +71514,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -70313,7 +71626,9 @@
 	amount = 5
 	},
 /obj/structure/table/glass,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
 	id = "vir_work_zone1"
@@ -70332,6 +71647,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/launch)
+"mkz" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/chair/sofa/left,
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint4)
 "mkL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -70361,7 +71681,7 @@
 /turf/space,
 /area/solar/starboard)
 "mlh" = (
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/turf_decal/delivery/partial,
 /turf/simulated/floor/plating,
 /area/toxins/launch)
 "mln" = (
@@ -70400,7 +71720,7 @@
 "mlQ" = (
 /obj/item/radio/intercom/directional/north,
 /obj/structure/closet/secure_closet/security,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -70434,15 +71754,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "mmv" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 5
 	},
@@ -70535,7 +71859,9 @@
 	},
 /area/hallway/primary/port/west)
 "mnb" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/suit_storage_unit/atmos,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -70555,7 +71881,7 @@
 "mnk" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/lightsout,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=V4";
 	location = "V3"
@@ -70642,7 +71968,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -70653,7 +71981,7 @@
 	},
 /area/engineering/break_room)
 "mop" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/closet/secure_closet/pilot_sniper,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -70711,7 +72039,7 @@
 /turf/simulated/floor/engine/insulated,
 /area/maintenance/asmaint4)
 "moF" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
 	},
@@ -70722,7 +72050,6 @@
 /area/maintenance/fpmaint)
 "moK" = (
 /obj/structure/cable/yellow{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/generator/directional/east,
@@ -70736,6 +72063,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70988,14 +72316,16 @@
 /turf/simulated/floor/plating,
 /area/security/main)
 "mqY" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/engineering/hardsuitstorage)
 "mrf" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -71050,6 +72380,12 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/qm)
+"mrx" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "purple"
+	},
+/area/quartermaster/miningdock)
 "mrA" = (
 /obj/structure/chair{
 	dir = 4
@@ -71084,7 +72420,9 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "mrN" = (
@@ -71121,6 +72459,24 @@
 	icon_state = "dark"
 	},
 /area/aisat/aihallway)
+"msm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/central/north)
 "msn" = (
 /obj/effect/spawner/new_year/snow_machine,
 /turf/simulated/floor/plasteel{
@@ -71190,7 +72546,9 @@
 "mtD" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/directional/east,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/item/paper/monitorkey,
 /obj/item/paper/rnd_logs_key{
 	pixel_x = 6;
@@ -71314,7 +72672,7 @@
 /area/atmos)
 "muK" = (
 /obj/effect/spawner/window/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
 "muM" = (
@@ -71358,7 +72716,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -71383,6 +72741,15 @@
 	icon_state = "whitepurple"
 	},
 /area/medical/genetics)
+"mvB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/toxins/launch)
 "mvI" = (
 /obj/machinery/door_timer/cell_1{
 	dir = 1;
@@ -71513,13 +72880,13 @@
 /obj/item/wrench,
 /obj/item/crowbar,
 /obj/item/paicard,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "mxh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -71602,8 +72969,10 @@
 	},
 /area/crew_quarters/theatre)
 "mxZ" = (
-/obj/effect/decal/warning_stripes/southeast,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/chem_heater,
 /obj/structure/window/plasmareinforced{
 	dir = 4
@@ -71626,10 +72995,13 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "myK" = (
@@ -71640,14 +73012,18 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/maintenance/banya)
 "myZ" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/securearmory)
 "mzf" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -71701,7 +73077,9 @@
 	},
 /area/toxins/misc_lab)
 "mAl" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -71811,7 +73189,9 @@
 	},
 /area/engineering/hardsuitstorage)
 "mBa" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/chemist,
 /obj/structure/cable{
@@ -71934,7 +73314,7 @@
 /area/crew_quarters/bar)
 "mCe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -72042,7 +73422,7 @@
 	c_tag = "Primary Tool Storage";
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/janitorialcart,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -72050,7 +73430,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "mDe" = (
@@ -72362,6 +73742,24 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/engine,
 /area/toxins/explab)
+"mFX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/crew_quarters/locker)
 "mGb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -72422,14 +73820,17 @@
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
 "mHa" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor/closed,
 /turf/simulated/floor/plating,
 /area/maintenance/consarea_virology)
 "mHb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -72482,7 +73883,9 @@
 /turf/simulated/floor/noslip,
 /area/engineering/controlroom)
 "mHQ" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -72494,7 +73897,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/clothing/shoes/jackboots/armored,
 /obj/item/clothing/shoes/jackboots/armored,
 /obj/item/clothing/shoes/jackboots/armored,
@@ -72531,7 +73934,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "mIl" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -72629,10 +74032,10 @@
 	},
 /area/medical/medbay2)
 "mJD" = (
-/obj/effect/landmark/start/trainee_engineer,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -72674,7 +74077,7 @@
 "mJQ" = (
 /obj/structure/dispenser,
 /obj/item/radio/intercom/directional/north,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "mJT" = (
@@ -72835,7 +74238,7 @@
 /area/medical/research/nhallway)
 "mLd" = (
 /obj/machinery/vending/protein,
-/obj/effect/decal/warning_stripes/white,
+/obj/effect/turf_decal/delivery/white,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -73004,8 +74407,10 @@
 	pixel_x = -1;
 	pixel_y = 3
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -73067,7 +74472,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -73084,7 +74489,9 @@
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = 32
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "mMQ" = (
@@ -73133,7 +74540,7 @@
 /area/security/hos)
 "mNo" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "mNq" = (
@@ -73147,7 +74554,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "mNI" = (
@@ -73200,7 +74607,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -73277,7 +74684,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/electricshock{
 	pixel_y = -32
 	},
@@ -73287,7 +74694,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -73353,9 +74762,9 @@
 /area/maintenance/garden)
 "mQi" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -73475,9 +74884,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -73495,8 +74906,8 @@
 /area/bridge/checkpoint/south)
 "mRM" = (
 /obj/effect/landmark/start/shaft_miner,
-/obj/effect/decal/warning_stripes/yellow/partial,
-/obj/effect/decal/warning_stripes/arrow,
+/obj/effect/turf_decal/delivery/partial,
+/obj/effect/turf_decal/arrows/black,
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
 	},
@@ -73568,7 +74979,7 @@
 /area/hallway/primary/port/west)
 "mSo" = (
 /obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "mSE" = (
@@ -73592,6 +75003,7 @@
 /area/space)
 "mSK" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
 	},
@@ -73686,7 +75098,7 @@
 "mTR" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/newscaster/directional/south,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "mTS" = (
@@ -73759,7 +75171,7 @@
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "mUF" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/firecloset,
 /obj/machinery/camera{
 	c_tag = "Toxin Equipment Storage";
@@ -73823,7 +75235,6 @@
 	icon_state = "grass_edge_medium"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -73839,7 +75250,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm/directional/south,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -73944,11 +75355,11 @@
 /area/maintenance/fpmaint)
 "mWV" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Singularity";
 	name = "Singularity Blast Doors"
@@ -73981,7 +75392,7 @@
 /area/maintenance/detectives_office)
 "mXf" = (
 /obj/structure/closet/crate/freezer,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -74024,16 +75435,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/locker)
-"mXx" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/reagent_containers/food/drinks/mug/eng,
-/turf/simulated/floor/plasteel,
-/area/engineering/engine)
 "mXP" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/meter,
@@ -74093,12 +75499,14 @@
 	},
 /area/hallway/primary/central/south)
 "mYg" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/power/apc/directional/north,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "mYl" = (
@@ -74133,18 +75541,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "mYX" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "mZb" = (
@@ -74205,7 +75617,9 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -74256,6 +75670,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -74273,7 +75688,7 @@
 	pixel_x = 21;
 	pixel_y = -21
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint4)
@@ -74318,7 +75733,7 @@
 	id_tag = "sw_maint_sensor";
 	pixel_y = 33
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1379;
@@ -74334,7 +75749,7 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "naI" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
@@ -74444,12 +75859,14 @@
 "nbG" = (
 /obj/machinery/alarm/directional/west,
 /obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "nbI" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/westright{
 	dir = 4;
 	name = "Front Desk";
@@ -74466,7 +75883,7 @@
 /obj/structure/urinal{
 	pixel_y = 28
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
 "nbT" = (
@@ -74479,7 +75896,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -74537,7 +75954,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "ndm" = (
@@ -74701,7 +76118,7 @@
 	},
 /area/chapel/main)
 "nfj" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/rack/gunrack,
 /obj/structure/window/reinforced,
 /obj/item/gun/energy/gun{
@@ -74764,13 +76181,14 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/window/northleft,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	id_tag = "researchdesk1";
 	name = "Research Desk Shutters"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/toxins/lab)
 "nfV" = (
@@ -74828,7 +76246,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -74843,7 +76261,7 @@
 	icon_state = "grass_edge_medium"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/item/trash/cheesie,
 /turf/simulated/floor/plating,
@@ -74859,7 +76277,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating/airless,
 /area/medical/virology/lab)
@@ -74872,6 +76292,7 @@
 	pixel_y = 28
 	},
 /obj/item/radio/intercom/locked/prison/directional/north,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "redcorner"
@@ -75017,7 +76438,6 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -75054,7 +76474,7 @@
 	},
 /area/medical/cryo)
 "njv" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "njy" = (
@@ -75081,7 +76501,7 @@
 	id_tag = "paramedic";
 	name = "Paramedic Garage"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
@@ -75157,7 +76577,7 @@
 /area/toxins/xenobiology)
 "nkJ" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 6
@@ -75174,8 +76594,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/chem_dispenser/botanical,
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/green,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/delivery/green,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -75184,6 +76604,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -75219,7 +76640,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/delivery)
 "nlk" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
@@ -75262,7 +76683,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -75322,7 +76745,7 @@
 "nmp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -75362,7 +76785,9 @@
 /area/security/hos)
 "nnh" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -75371,7 +76796,9 @@
 "nnj" = (
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkblue"
@@ -75388,7 +76815,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -75452,7 +76879,7 @@
 	},
 /area/hallway/primary/central/south)
 "nom" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -75503,7 +76930,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "npi" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -75524,6 +76951,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "npD" = (
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -75547,7 +76975,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -75633,13 +77061,12 @@
 	pixel_y = -10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "nqB" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/eastleft{
 	name = "Hydroponics Desk";
@@ -75692,7 +77119,7 @@
 /area/hallway/primary/central/north)
 "nqI" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -75703,7 +77130,9 @@
 	id_tag = "engstorage";
 	name = "Secure Storage Blast Doors"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "nqM" = (
@@ -75767,7 +77196,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -75813,7 +77242,9 @@
 /obj/item/scalpel{
 	pixel_y = 8
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
@@ -75948,18 +77379,20 @@
 	pixel_x = -1;
 	pixel_y = 3
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/toxins/lab)
 "nsT" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "nsU" = (
@@ -75977,7 +77410,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "nta" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -76064,7 +77497,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -76115,7 +77548,9 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -76268,7 +77703,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -76320,7 +77754,7 @@
 /area/hallway/primary/central/north)
 "nwv" = (
 /obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light_switch/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -76332,12 +77766,14 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/crowbar,
 /obj/item/wrench,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "nwH" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/structure/closet/walllocker{
 	pixel_y = 28
 	},
@@ -76448,7 +77884,9 @@
 	},
 /area/library/game_zone)
 "nyX" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "nyZ" = (
@@ -76476,7 +77914,9 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
 "nzh" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "nzn" = (
@@ -76603,11 +78043,11 @@
 	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -76709,7 +78149,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "nCi" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Singularity";
 	name = "Singularity Blast Doors"
@@ -76721,7 +78161,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -76767,7 +78207,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
@@ -76830,7 +78272,7 @@
 	c_tag = "Secure Technical Storage";
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
@@ -76845,7 +78287,7 @@
 /area/maintenance/asmaint4)
 "nDF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -76887,7 +78329,9 @@
 /area/engineering/gravitygenerator)
 "nEb" = (
 /obj/machinery/chem_heater,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -76943,7 +78387,7 @@
 /obj/machinery/newscaster/directional/north,
 /obj/item/storage/belt/utility,
 /obj/item/weldingtool,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "nFe" = (
@@ -76957,7 +78401,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -77121,7 +78565,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -77155,7 +78599,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "nGY" = (
@@ -77233,7 +78677,9 @@
 	},
 /area/security/prison/cell_block/A)
 "nHQ" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -77270,7 +78716,9 @@
 	},
 /area/hallway/primary/central/north)
 "nIo" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -77292,8 +78740,8 @@
 /area/maintenance/starboard)
 "nIw" = (
 /obj/machinery/vending/hydroseeds,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -77353,7 +78801,6 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
@@ -77439,7 +78886,7 @@
 "nJD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "KPPS"
 	},
@@ -77453,8 +78900,10 @@
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/alarm/directional/west,
 /obj/machinery/mecha_part_fabricator,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -77492,7 +78941,7 @@
 /area/security/visiting_room)
 "nKf" = (
 /obj/structure/closet/secure_closet/personal/mining,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/alarm/directional/south,
 /obj/machinery/camera{
 	c_tag = "Mining West";
@@ -77550,13 +78999,13 @@
 	},
 /area/medical/research/nhallway)
 "nKJ" = (
-/obj/effect/turf_decal/bot/right,
+/obj/effect/turf_decal/delivery/hollow/right,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
 "nKR" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/plasteel,
@@ -77579,7 +79028,6 @@
 	},
 /obj/effect/spawner/random_spawners/grille_50,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -77654,7 +79102,9 @@
 	},
 /area/medical/research/nhallway)
 "nMG" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -77671,6 +79121,16 @@
 	icon_state = "vault"
 	},
 /area/storage/tech)
+"nMO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/crew_quarters/locker)
 "nMT" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -77693,7 +79153,7 @@
 /area/quartermaster/storage)
 "nNj" = (
 /obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "nNn" = (
@@ -77804,7 +79264,7 @@
 /area/maintenance/brig)
 "nOw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -77850,14 +79310,16 @@
 /area/hallway/primary/central/ne)
 "nPN" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "nPX" = (
 /obj/structure/chair/comfy/purp{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -78027,7 +79489,9 @@
 	},
 /area/security/brig)
 "nSd" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -78373,7 +79837,6 @@
 	},
 /obj/effect/decal/cleanable/blood/writing,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -78422,7 +79885,7 @@
 /area/maintenance/fpmaint)
 "nVL" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -78467,6 +79930,11 @@
 	icon_state = "purple"
 	},
 /area/toxins/sm_test_chamber)
+"nXb" = (
+/obj/effect/turf_decal/siding/brown/corner,
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/wood/fancy/light,
+/area/crew_quarters/courtroom)
 "nXf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -78494,7 +79962,7 @@
 	},
 /area/hydroponics)
 "nXs" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel,
 /area/security/securehallway)
@@ -78543,6 +80011,7 @@
 	},
 /area/security/processing)
 "nXU" = (
+/obj/effect/landmark/start/hangover,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -78561,7 +80030,7 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/watermelon,
 /obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/eastleft{
 	name = "Hydroponics Desk";
@@ -78667,11 +80136,11 @@
 "oak" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "oan" = (
@@ -78835,7 +80304,7 @@
 	id_tag = "sw_maint2_sensor";
 	pixel_y = 33
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -78852,9 +80321,11 @@
 	},
 /area/hallway/primary/fore)
 "obE" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -78904,11 +80375,9 @@
 /area/chapel/main)
 "occ" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/eastsouthwest,
+/obj/effect/turf_decal/stripes/end,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	dir = 2;
 	id_tag = "engsm"
@@ -79039,7 +80508,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -79066,7 +80535,7 @@
 "oem" = (
 /obj/machinery/alarm/directional/north,
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -79133,7 +80602,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -79165,6 +80636,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/east)
+"ofy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/secondary/entry/additional)
 "ofC" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -79181,7 +80663,9 @@
 /turf/simulated/floor/plating,
 /area/lawoffice)
 "ofG" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "ofK" = (
@@ -79322,7 +80806,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -79378,7 +80862,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -79434,7 +80920,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "ohL" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -79552,21 +81040,23 @@
 /area/medical/medbay2)
 "ojL" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/permabrig)
 "ojO" = (
 /obj/machinery/seed_extractor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/garden)
 "ojQ" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -79664,7 +81154,7 @@
 /area/maintenance/tourist)
 "okH" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
@@ -79681,8 +81171,10 @@
 /area/maintenance/engineering)
 "okQ" = (
 /obj/machinery/vending/engivend,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -79722,8 +81214,8 @@
 /turf/simulated/floor/plating,
 /area/security/checkpoint/south)
 "olI" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/plasticflaps,
+/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	dir = 1;
@@ -79742,7 +81234,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -79874,7 +81365,9 @@
 /area/security/permahallway)
 "onr" = (
 /obj/machinery/suit_storage_unit/rd,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -79924,7 +81417,7 @@
 /area/hallway/primary/central/sw)
 "oob" = (
 /obj/machinery/mineral/ore_redemption,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_cargo";
 	name = "Cargo Lockdown"
@@ -79944,7 +81437,9 @@
 /area/maintenance/fpmaint)
 "oop" = (
 /obj/machinery/suit_storage_unit/captain,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain/bedroom)
 "ooC" = (
@@ -79961,6 +81456,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
@@ -80185,6 +81681,13 @@
 /obj/machinery/atmospherics/unary/portables_connector,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
+"orc" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "redcorner"
+	},
+/area/security/lobby)
 "orl" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
@@ -80231,7 +81734,9 @@
 	},
 /area/hallway/secondary/entry/commercial)
 "orS" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 4;
@@ -80276,25 +81781,25 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "osi" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
@@ -80402,7 +81907,7 @@
 /area/maintenance/brig)
 "otM" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -80434,7 +81939,7 @@
 /obj/item/seeds/banana,
 /obj/item/seeds/banana,
 /obj/item/seeds/banana,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/radio/intercom/locked/prison/directional/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -80445,12 +81950,16 @@
 	dir = 4
 	},
 /obj/machinery/alarm/directional/north,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/engineering/supermatter)
 "oud" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/binary/volume_pump{
 	desc = "Позволяет опустошить трубы для смеси, отправив весь газ в отходы на фильтрацию";
 	dir = 4;
@@ -80491,7 +82000,9 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "ouL" = (
@@ -80523,10 +82034,11 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/hologram/holopad,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "ovb" = (
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/suit_storage_unit/security,
 /turf/simulated/floor/plasteel{
@@ -80629,7 +82141,9 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "owl" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -80774,7 +82288,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "oyc" = (
@@ -80927,7 +82443,7 @@
 /area/quartermaster/delivery)
 "ozi" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -80988,7 +82504,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -81070,7 +82586,7 @@
 /area/turret_protected/aisat_interior)
 "oAs" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -81121,7 +82637,7 @@
 /area/maintenance/library)
 "oAW" = (
 /obj/machinery/light,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -81166,10 +82682,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/blood_5,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
+"oBF" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/bridge)
 "oBH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -81237,14 +82759,13 @@
 	},
 /obj/effect/spawner/random_spawners/blood_5,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "oCn" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm/directional/south,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "oCo" = (
@@ -81331,11 +82852,9 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -81386,7 +82905,9 @@
 	},
 /area/atmos)
 "oEj" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -81394,7 +82915,7 @@
 /area/medical/research/nhallway)
 "oEk" = (
 /obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "oEr" = (
@@ -81505,7 +83026,9 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/serviceyard)
 "oFJ" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -81520,8 +83043,10 @@
 /area/maintenance/starboard)
 "oFU" = (
 /obj/structure/rack,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/item/stack/sheet/plasteel{
 	amount = 10
 	},
@@ -81534,7 +83059,9 @@
 	},
 /area/engineering/hardsuitstorage)
 "oFX" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "oFZ" = (
@@ -81574,7 +83101,7 @@
 "oGn" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm/directional/east,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "caution"
@@ -81640,6 +83167,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -81672,11 +83200,11 @@
 /area/engineering/engine)
 "oHg" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "oHq" = (
@@ -81747,17 +83275,18 @@
 "oHT" = (
 /obj/machinery/power/energy_accumulator/rad_collector/anchored,
 /obj/structure/cable/yellow{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "oHY" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel,
 /area/security/securehallway)
@@ -81860,7 +83389,7 @@
 	},
 /area/turret_protected/aisat_interior)
 "oJd" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_y = 28
@@ -82008,10 +83537,13 @@
 	locked = 1;
 	name = "Xenobio Kill Room"
 	},
+/obj/structure/plasticflaps/kitchen,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "oKD" = (
-/obj/effect/decal/warning_stripes/eastnorthwest,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/light{
 	dir = 8
@@ -82038,7 +83570,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "oKQ" = (
@@ -82134,7 +83668,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
@@ -82196,7 +83730,9 @@
 	},
 /area/hallway/secondary/entry/lounge)
 "oMz" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
 	dir = 1;
@@ -82344,7 +83880,7 @@
 /area/toxins/misc_lab)
 "oPh" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "oPj" = (
@@ -82390,7 +83926,6 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/window/plasmareinforced{
@@ -82457,7 +83992,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -82465,7 +84000,7 @@
 /area/engineering/break_room)
 "oRe" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -82487,6 +84022,18 @@
 	icon_state = "neutralfull"
 	},
 /area/atmos)
+"oRj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/fore)
 "oRl" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/packageWrap,
@@ -82536,6 +84083,7 @@
 	},
 /area/storage/tech)
 "oSu" = (
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "oSy" = (
@@ -82558,11 +84106,13 @@
 /area/storage/tech)
 "oSO" = (
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "oSQ" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/trinary/mixer,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -82608,7 +84158,7 @@
 	},
 /obj/effect/landmark/lightsout,
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/library)
@@ -82719,7 +84269,6 @@
 /obj/effect/decal/cleanable/dust,
 /obj/item/chair,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -82739,7 +84288,7 @@
 /obj/machinery/bodyscanner{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -82786,7 +84335,7 @@
 /area/maintenance/asmaint)
 "oVl" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -82801,7 +84350,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -82858,7 +84409,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "oVT" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
 /area/gateway)
@@ -83116,7 +84667,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
@@ -83162,7 +84715,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/suit/armor/bulletproof,
@@ -83235,7 +84788,9 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
 "pbv" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /mob/living/carbon/human/lesser/monkey,
 /turf/simulated/floor/plasteel{
@@ -83303,7 +84858,9 @@
 /area/security/customs)
 "pcD" = (
 /obj/item/radio/intercom/directional/east,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "pcG" = (
@@ -83388,9 +84945,11 @@
 	},
 /area/crew_quarters/fitness)
 "pda" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
 	},
@@ -83473,7 +85032,7 @@
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/toy/figure/engineer,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "yellow"
@@ -83484,7 +85043,9 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
 "pem" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/closet/walllocker{
 	pixel_y = 28
 	},
@@ -83550,7 +85111,7 @@
 /area/engineering/engine)
 "pfo" = (
 /obj/structure/table,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/cell_charger,
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/camera{
@@ -83592,7 +85153,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/theatre)
 "pfD" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastright{
 	dir = 2;
 	name = "Chemistry Delivery";
@@ -83667,7 +85228,7 @@
 	},
 /area/medical/research/nhallway)
 "pgt" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -83703,7 +85264,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "pgL" = (
@@ -83820,6 +85383,13 @@
 	icon_state = "dark"
 	},
 /area/medical/morgue)
+"phG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel,
+/area/engineering/engine)
 "phI" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -83855,7 +85425,7 @@
 	},
 /area/library/game_zone)
 "phR" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
@@ -83905,7 +85475,7 @@
 /area/maintenance/brig)
 "pjd" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/brigstaff)
 "pjh" = (
@@ -83931,7 +85501,7 @@
 	},
 /area/medical/medbay2)
 "pjm" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/cargo_technician,
 /turf/simulated/floor/plasteel{
@@ -83982,7 +85552,6 @@
 "pjX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -84080,7 +85649,7 @@
 /area/medical/psych)
 "pln" = (
 /obj/machinery/smartfridge/medbay,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
@@ -84173,6 +85742,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "pmN" = (
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -84210,7 +85780,6 @@
 	dir = 10
 	},
 /obj/structure/cable/yellow{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/window/plasmareinforced{
@@ -84225,8 +85794,6 @@
 /area/teleporter/abandoned)
 "pnx" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
@@ -84253,7 +85820,9 @@
 	},
 /area/library/game_zone)
 "pnJ" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -84287,7 +85856,6 @@
 /area/hallway/primary/central/se)
 "pnU" = (
 /obj/structure/cable/yellow{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/window/plasmareinforced{
@@ -84331,7 +85899,7 @@
 	},
 /obj/item/folder/yellow,
 /obj/item/pen,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/item/poster/random_contraband,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_cargo";
@@ -84400,7 +85968,9 @@
 	},
 /area/atmos)
 "pox" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -84423,7 +85993,9 @@
 	},
 /area/medical/research/shallway)
 "poX" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
@@ -84439,7 +86011,9 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "ppg" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -84503,7 +86077,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -84523,7 +86099,9 @@
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/dropper,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "pqB" = (
@@ -84538,6 +86116,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -84545,6 +86124,7 @@
 /area/crew_quarters/locker)
 "pqJ" = (
 /obj/item/twohanded/required/kirbyplants,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/wood,
 /area/library)
 "pqM" = (
@@ -84581,7 +86161,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -84630,12 +86210,13 @@
 	},
 /area/maintenance/library)
 "prt" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -84655,8 +86236,10 @@
 /area/maintenance/asmaint3)
 "prK" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -84713,7 +86296,9 @@
 	pixel_y = 3
 	},
 /obj/item/circuitboard/mecha_control,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "psg" = (
@@ -84817,7 +86402,7 @@
 	name = "Creature Pen";
 	req_access = list(47)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -84866,8 +86451,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
@@ -84893,7 +86476,9 @@
 	pixel_y = -25;
 	req_access = list(13)
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "pug" = (
@@ -84905,14 +86490,14 @@
 /area/maintenance/perma)
 "pui" = (
 /obj/machinery/vending/hydroseeds,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "green"
 	},
 /area/maintenance/garden)
 "pus" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/field/generator,
 /turf/simulated/floor/plasteel,
@@ -85027,8 +86612,6 @@
 	pixel_x = 32
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -85038,7 +86621,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "pvt" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -85092,7 +86675,9 @@
 	},
 /area/storage/primary)
 "pwH" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/closet/walllocker/emerglocker/directional/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
@@ -85212,6 +86797,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -85224,7 +86810,7 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "pyQ" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -85265,7 +86851,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
@@ -85299,6 +86885,9 @@
 	},
 /area/maintenance/asmaint4)
 "pzO" = (
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 32
+	},
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -85336,8 +86925,10 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "pAh" = (
-/obj/effect/decal/warning_stripes/southwest,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/chem_master,
 /obj/structure/window/plasmareinforced,
 /obj/machinery/light{
@@ -85372,7 +86963,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/pen,
@@ -85406,6 +86997,13 @@
 	icon_state = "whitepurple"
 	},
 /area/medical/research/nhallway)
+"pAA" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/east)
 "pAC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -85456,11 +87054,11 @@
 "pBi" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
@@ -85561,6 +87159,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -85575,7 +87174,9 @@
 /area/toxins/mixing)
 "pCn" = (
 /obj/effect/landmark/start/scientist,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/chair/office/light{
 	dir = 8
 	},
@@ -85593,8 +87194,10 @@
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "pCs" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -85605,7 +87208,7 @@
 /area/storage/eva)
 "pCt" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -85613,7 +87216,7 @@
 	},
 /area/security/customs)
 "pCB" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -85633,7 +87236,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -85737,6 +87340,10 @@
 	icon_state = "neutral"
 	},
 /area/crew_quarters/fitness)
+"pDD" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/wood/fancy/light,
+/area/crew_quarters/courtroom)
 "pDF" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
@@ -85764,7 +87371,7 @@
 /area/security/securehallway)
 "pDU" = (
 /obj/machinery/newscaster/security_unit/directional/north,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/vending/gun_mods,
 /turf/simulated/floor/plasteel,
 /area/security/customs)
@@ -85809,7 +87416,7 @@
 /area/engineering/engine)
 "pEC" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -85938,7 +87545,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/hydroponics/prespawned,
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/plasteel{
@@ -85948,7 +87555,9 @@
 "pGk" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -86029,8 +87638,6 @@
 /area/maintenance/turbine)
 "pGB" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
@@ -86080,7 +87687,9 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "pHr" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -86229,7 +87838,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/item/tank/internals/plasma,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
 	},
@@ -86287,9 +87896,9 @@
 /area/maintenance/kitchen)
 "pJo" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/alarm/directional/west,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -86297,7 +87906,7 @@
 "pJs" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -86365,14 +87974,16 @@
 	pixel_y = -22
 	},
 /obj/item/flag/rnd,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/crew_quarters/hor)
 "pKg" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -86392,7 +88003,7 @@
 /area/maintenance/asmaint4)
 "pKk" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/toxins/explab)
 "pKm" = (
@@ -86404,7 +88015,9 @@
 	},
 /area/security/hos)
 "pKy" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -86435,7 +88048,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/piano,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -86541,10 +88153,9 @@
 /area/medical/surgery/south)
 "pLR" = (
 /obj/structure/cable/yellow{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/toxins/sm_test_chamber)
 "pMj" = (
@@ -86597,7 +88208,7 @@
 /obj/effect/turf_decal/caution{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/turf_decal/delivery/partial,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -86637,6 +88248,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
+"pNo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/assembly/robotics)
 "pNr" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/maintenance/double,
@@ -86669,7 +88295,7 @@
 /area/turret_protected/aisat_interior)
 "pNE" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/bot/right,
+/obj/effect/turf_decal/delivery/hollow/right,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -86750,6 +88376,12 @@
 	icon_state = "grimy"
 	},
 /area/library)
+"pOf" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/bridge)
 "pOg" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -86899,7 +88531,9 @@
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint4)
 "pQK" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/simulated/floor/plasteel{
@@ -87032,6 +88666,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitered"
@@ -87076,7 +88711,7 @@
 /turf/simulated/floor/plating,
 /area/chapel/office)
 "pSF" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate,
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
@@ -87142,8 +88777,10 @@
 /turf/simulated/floor/plating,
 /area/medical/medbay2)
 "pTy" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -87258,8 +88895,10 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "pUM" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "pUP" = (
@@ -87321,7 +88960,7 @@
 /area/bridge/vip)
 "pVL" = (
 /obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/structure/sign/deathsposal{
 	pixel_y = 32
 	},
@@ -87337,7 +88976,7 @@
 	},
 /area/security/processing)
 "pVP" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -87355,7 +88994,7 @@
 	},
 /area/medical/virology/lab)
 "pWf" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/disposal,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/disposalpipe/trunk,
@@ -87403,8 +89042,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -87422,7 +89061,9 @@
 	},
 /area/medical/medbay)
 "pWz" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
@@ -87448,7 +89089,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -87460,6 +89101,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
@@ -87494,7 +89136,7 @@
 	},
 /area/tcommsat/chamber)
 "pXg" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/camera{
 	c_tag = "Atmos Hatch";
 	dir = 8;
@@ -87521,7 +89163,9 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -87578,7 +89222,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "pYm" = (
@@ -87594,7 +89238,9 @@
 /area/chapel/office)
 "pYH" = (
 /obj/machinery/firealarm/directional/east,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "pYJ" = (
@@ -87634,7 +89280,7 @@
 	},
 /area/crew_quarters/serviceyard)
 "pZl" = (
-/obj/effect/decal/warning_stripes/red/partial{
+/obj/effect/turf_decal/delivery/red/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -87646,7 +89292,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "pZu" = (
@@ -87669,7 +89315,7 @@
 /area/maintenance/starboard)
 "pZM" = (
 /obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -87699,13 +89345,13 @@
 	},
 /area/quartermaster/office)
 "pZY" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
@@ -87714,6 +89360,15 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"qag" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/main)
 "qai" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -87819,7 +89474,7 @@
 	},
 /area/maintenance/kitchen)
 "qbl" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	dir = 4;
@@ -87859,7 +89514,7 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "qbx" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/computer/cryopod/robot{
 	pixel_y = 28
 	},
@@ -87883,7 +89538,9 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 5
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/item/reagent_containers/spray/cleaner/medical{
 	pixel_x = -2;
 	pixel_y = 12
@@ -87923,7 +89580,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -87933,7 +89590,9 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "qbY" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -87954,7 +89613,7 @@
 /area/turret_protected/aisat)
 "qce" = (
 /obj/machinery/space_heater,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
@@ -87997,7 +89656,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "qcF" = (
@@ -88031,7 +89692,9 @@
 	},
 /area/bridge)
 "qcW" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -88050,12 +89713,14 @@
 /area/bridge)
 "qdg" = (
 /obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "qdu" = (
 /obj/item/radio/intercom/directional/east,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "qdv" = (
@@ -88133,7 +89798,7 @@
 	},
 /area/hallway/primary/starboard/east)
 "qfg" = (
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /obj/structure/closet/crate/secure/blood,
 /obj/item/tank/internals/emergency_oxygen/plasma,
 /obj/item/reagent_containers/iv_bag/blood/AMinus,
@@ -88251,7 +89916,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -88428,6 +90093,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/security/customs)
 "qiL" = (
@@ -88463,8 +90129,8 @@
 	},
 /area/turret_protected/aisat_interior)
 "qjh" = (
-/obj/effect/decal/warning_stripes/yellow/partial,
-/obj/effect/decal/warning_stripes/arrow,
+/obj/effect/turf_decal/delivery/partial,
+/obj/effect/turf_decal/arrows/black,
 /obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
@@ -88483,12 +90149,12 @@
 /area/bridge/vip)
 "qjp" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/closet/walllocker/emerglocker/directional/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "qjr" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1379;
 	id_tag = "atmos_tank_pump"
@@ -88582,7 +90248,7 @@
 /area/crew_quarters/fitness)
 "qko" = (
 /obj/machinery/firealarm/directional/west,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -88604,14 +90270,14 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "qkz" = (
 /turf/simulated/floor/plating,
 /area/crew_quarters/theatre)
 "qkE" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	name = "Труба на фильтрацию"
@@ -88747,8 +90413,8 @@
 	},
 /area/library)
 "qmu" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -88782,7 +90448,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "green"
@@ -88871,7 +90539,7 @@
 	},
 /area/maintenance/asmaint4)
 "qok" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
@@ -88917,7 +90585,7 @@
 	},
 /area/hallway/primary/port/west)
 "qox" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/kitchenspike,
 /obj/machinery/camera{
 	c_tag = "Kitchen Backroom"
@@ -88977,7 +90645,7 @@
 	name = "Secure Tech Storage";
 	req_access = list(19,23)
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
@@ -88986,7 +90654,7 @@
 	dir = 8
 	},
 /obj/machinery/alarm/directional/west,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 8;
@@ -89028,7 +90696,7 @@
 /area/maintenance/fpmaint)
 "qpk" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "KPPS"
 	},
@@ -89050,7 +90718,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
 /obj/structure/chair/sofa/bench/right{
@@ -89107,7 +90775,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -89118,7 +90786,9 @@
 	pixel_y = 2
 	},
 /obj/item/stock_parts/cell/high,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/alarm/directional/south,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
@@ -89165,14 +90835,13 @@
 	},
 /area/security/permabrig)
 "qqG" = (
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west{
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "siding2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "qqM" = (
@@ -89180,7 +90849,6 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -89317,7 +90985,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
@@ -89329,7 +90997,7 @@
 /turf/simulated/wall,
 /area/medical/surgery/north)
 "qsi" = (
-/obj/structure/plasticflaps,
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "cargodelivery"
@@ -89450,7 +91118,6 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -89573,7 +91240,7 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -89611,7 +91278,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -89639,7 +91306,7 @@
 /area/security/permahallway)
 "qui" = (
 /obj/structure/dispenser/oxygen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -89687,7 +91354,9 @@
 	},
 /area/bridge/meeting_room)
 "quy" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "quC" = (
@@ -89772,6 +91441,7 @@
 /obj/item/storage/secure/safe{
 	pixel_x = 32
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/carpet/royalblue,
 /area/crew_quarters/captain/bedroom)
 "qvA" = (
@@ -89782,11 +91452,9 @@
 "qvF" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -89877,11 +91545,11 @@
 /area/medical/surgery/south)
 "qwK" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/eastnorthwest,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	dir = 2;
 	id_tag = "engsm"
@@ -89908,9 +91576,18 @@
 /area/maintenance/consarea_virology)
 "qwQ" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"qwV" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/hallway/primary/central/north)
 "qwW" = (
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -89933,7 +91610,9 @@
 	},
 /area/medical/surgery/north)
 "qxe" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -89993,7 +91672,7 @@
 /area/security/prison/cell_block/A)
 "qxY" = (
 /obj/effect/landmark/spawner/late/cyborg,
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/turf_decal/delivery/partial,
 /obj/machinery/light_switch/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -90002,7 +91681,9 @@
 /area/assembly/chargebay)
 "qyg" = (
 /obj/structure/closet/secure_closet/captains,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain/bedroom)
 "qyB" = (
@@ -90013,7 +91694,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -90071,6 +91754,13 @@
 	icon_state = "darkblue"
 	},
 /area/tcommsat/chamber)
+"qzo" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/crew_quarters/fitness)
 "qzC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -90095,7 +91785,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
@@ -90132,7 +91821,7 @@
 	},
 /area/medical/virology)
 "qAw" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/jukebox/bar,
 /turf/simulated/floor/carpet/red,
 /area/crew_quarters/bar/atrium)
 "qAH" = (
@@ -90150,8 +91839,6 @@
 /area/security/prison/cell_block/A)
 "qAK" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
@@ -90177,7 +91864,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -90200,14 +91887,18 @@
 "qBb" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm/directional/east,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "qBc" = (
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -90215,7 +91906,7 @@
 /area/crew_quarters/chief)
 "qBn" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -90403,7 +92094,7 @@
 /area/bridge/vip)
 "qDz" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -90476,8 +92167,12 @@
 /area/teleporter)
 "qEj" = (
 /obj/structure/grille,
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "qEo" = (
@@ -90521,7 +92216,7 @@
 	},
 /area/hallway/primary/central/east)
 "qEK" = (
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -90590,7 +92285,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "qFn" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -90771,6 +92466,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -90793,7 +92489,9 @@
 /turf/simulated/floor/plasteel,
 /area/security/customs)
 "qHl" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -90856,7 +92554,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -90916,7 +92614,9 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/east,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "qJh" = (
@@ -90940,6 +92640,10 @@
 	icon_state = "neutralfull"
 	},
 /area/storage/tech)
+"qJr" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/engine,
+/area/toxins/explab)
 "qJB" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -90989,12 +92693,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
 "qKI" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -91313,7 +93016,9 @@
 "qNX" = (
 /obj/item/reagent_containers/food/snacks/meat/humanoid/human,
 /obj/item/reagent_containers/food/snacks/meat/humanoid/human,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/effect/spawner/random_spawners/blood_5,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -91321,7 +93026,7 @@
 /area/maintenance/kitchen)
 "qNZ" = (
 /obj/item/robot_parts/robot_suit,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -91618,7 +93323,9 @@
 /area/ntrep)
 "qRa" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "QMLoad"
@@ -91656,7 +93363,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -91666,8 +93373,10 @@
 	},
 /area/security/permabrig)
 "qRN" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -91713,7 +93422,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -91731,12 +93442,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/range)
+"qTc" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/storage/primary)
+"qTh" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/security/hos)
 "qTl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/light{
 	dir = 1
@@ -91786,7 +93512,9 @@
 	req_access = list(10,13)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "qTP" = (
@@ -91818,7 +93546,9 @@
 /obj/structure/sign/electricshock{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -91836,7 +93566,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/gravitygenerator)
 "qUi" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -91850,7 +93580,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -91883,7 +93613,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -91927,7 +93659,6 @@
 	pixel_y = -10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -91974,7 +93705,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "qVN" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -92029,7 +93762,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -92056,6 +93791,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/crew_quarters/theatre)
+"qWL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel,
+/area/security/brig)
 "qXe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -92100,7 +93844,9 @@
 /area/maintenance/asmaint4)
 "qXH" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/aisat/maintenance)
 "qXI" = (
@@ -92119,18 +93865,20 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "qYb" = (
 /obj/structure/closet/secure_closet/personal/mining,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -92214,11 +93962,15 @@
 	},
 /area/crew_quarters/hor)
 "qZy" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
 /area/engineering/break_room)
+"qZC" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/carpet/green,
+/area/crew_quarters/bar/atrium)
 "qZG" = (
 /obj/structure/table/glass,
 /obj/machinery/camera{
@@ -92264,10 +94016,11 @@
 /area/maintenance/garden)
 "rac" = (
 /obj/structure/cable/yellow{
-	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -92306,7 +94059,7 @@
 /area/crew_quarters/cabin3)
 "rax" = (
 /obj/structure/plasticflaps,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "cargodisposals"
@@ -92332,7 +94085,7 @@
 	},
 /area/engineering/aienter)
 "raR" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "raW" = (
@@ -92395,7 +94148,9 @@
 	},
 /area/security/range)
 "rbs" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkblue"
@@ -92419,7 +94174,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -92511,6 +94266,12 @@
 /obj/effect/landmark/spawner/blob,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
+"rco" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/security/brig)
 "rcp" = (
 /obj/structure/table/reinforced,
 /obj/item/paicard,
@@ -92572,7 +94333,9 @@
 /area/crew_quarters/theatre)
 "rcI" = (
 /obj/item/radio/intercom/directional/south,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "rcM" = (
@@ -92591,7 +94354,9 @@
 /area/engineering/break_room)
 "rcO" = (
 /obj/machinery/r_n_d/protolathe,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -92616,7 +94381,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -92639,7 +94406,9 @@
 	},
 /area/hallway/secondary/exit)
 "rdo" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/box/lights/mixed,
@@ -92698,7 +94467,7 @@
 /obj/structure/table/reinforced,
 /obj/item/analyzer,
 /obj/item/assembly/signaler,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "reD" = (
@@ -92710,7 +94479,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -92760,7 +94528,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -92778,7 +94545,6 @@
 	icon_state = "c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -92795,7 +94561,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -92823,7 +94588,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "rfs" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12;
@@ -92868,7 +94633,7 @@
 /area/maintenance/asmaint3)
 "rfQ" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "rfV" = (
@@ -92885,7 +94650,9 @@
 	},
 /area/maintenance/kitchen)
 "rfZ" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "rgj" = (
@@ -93011,7 +94778,9 @@
 	},
 /area/turret_protected/aisat_interior)
 "ric" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -93050,8 +94819,10 @@
 	},
 /area/security/warden)
 "riR" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -93167,7 +94938,9 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "rkA" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/suit_storage_unit/atmos,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -93179,11 +94952,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitepurple"
@@ -93251,7 +95026,7 @@
 /area/crew_quarters/courtroom)
 "rlE" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -93299,7 +95074,9 @@
 	},
 /area/engineering/engine/monitor)
 "rmK" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "rmQ" = (
@@ -93353,7 +95130,9 @@
 /area/hallway/primary/central/west)
 "rnH" = (
 /obj/structure/table/glass,
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /obj/item/paper_bin,
 /obj/item/pen/red,
 /obj/structure/window/reinforced/polarized{
@@ -93372,8 +95151,12 @@
 	},
 /area/medical/virology/lab)
 "rnJ" = (
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -93550,6 +95333,7 @@
 /area/maintenance/starboard)
 "rpd" = (
 /obj/item/radio/intercom/directional/west,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -93593,7 +95377,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "rpF" = (
@@ -93625,7 +95409,9 @@
 	},
 /area/bridge)
 "rpS" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -93668,11 +95454,11 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "rqI" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light/small,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -93680,6 +95466,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/toxins/sm_test_chamber)
+"rqJ" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
+/area/security/customs)
 "rqO" = (
 /obj/machinery/light{
 	dir = 8
@@ -93709,7 +95501,7 @@
 /obj/machinery/vending/wallmed{
 	pixel_x = 25
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/sign/poster/official/enlist{
 	pixel_y = 32
 	},
@@ -93851,8 +95643,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/southeastcorner,
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -93860,7 +95654,7 @@
 /area/toxins/storage)
 "rtb" = (
 /obj/structure/closet/coffin,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -93956,7 +95750,7 @@
 	},
 /area/bridge)
 "rup" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -94053,14 +95847,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "rvn" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "rvt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkblue"
@@ -94242,6 +96040,12 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
+"rxR" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitebluefull"
+	},
+/area/medical/sleeper)
 "rxS" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -94268,7 +96072,9 @@
 "rym" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm/directional/east,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "ryn" = (
@@ -94312,7 +96118,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1379;
@@ -94322,6 +96128,7 @@
 	pixel_x = 24;
 	pixel_y = 28
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "ryp" = (
@@ -94409,7 +96216,9 @@
 	},
 /area/maintenance/kitchen)
 "rzf" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -94522,7 +96331,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/structure/closet/secure_closet/brig,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -94543,12 +96354,9 @@
 "rBh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -94706,7 +96514,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -94743,7 +96553,9 @@
 	},
 /area/engineering/engine)
 "rDp" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "rDA" = (
@@ -94772,8 +96584,12 @@
 	},
 /area/toxins/xenobiology)
 "rDF" = (
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
@@ -94861,7 +96677,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "rED" = (
@@ -94890,7 +96708,7 @@
 /area/quartermaster/qm)
 "rEM" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -94898,11 +96716,11 @@
 	},
 /area/hallway/secondary/entry/commercial)
 "rEO" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/structure/rack,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "rES" = (
@@ -94953,7 +96771,9 @@
 	},
 /area/maintenance/kitchen)
 "rFw" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box/full,
 /obj/item/storage/fancy/candle_box/full{
@@ -94994,9 +96814,11 @@
 	},
 /area/security/prison/cell_block/A)
 "rFD" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -95008,13 +96830,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
 /area/toxins/xenobiology)
 "rFS" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -95110,7 +96936,7 @@
 	frequency = 1379;
 	id_tag = "solar_xeno_pump"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "solar_xeno_airlock";
 	layer = 3.3;
@@ -95188,7 +97014,7 @@
 /obj/structure/closet/crate{
 	name = "solar pack crate"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/paper/solar,
 /obj/item/circuitboard/solar_control,
 /obj/item/solar_assembly,
@@ -95300,7 +97126,9 @@
 	},
 /area/chapel/main)
 "rIZ" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -95332,7 +97160,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "rJJ" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/radiation,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -95351,8 +97179,10 @@
 	},
 /area/medical/research/nhallway)
 "rKc" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -95362,7 +97192,7 @@
 /area/atmos)
 "rKg" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/door_control{
 	id = "Briefing";
 	name = "Briefing room Shutters Control";
@@ -95393,6 +97223,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
+"rKG" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/wood,
+/area/library)
 "rKK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -95400,7 +97237,7 @@
 /obj/item/assembly/timer,
 /obj/item/multitool,
 /obj/item/multitool,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "rKL" = (
@@ -95413,7 +97250,7 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -95703,7 +97540,7 @@
 /area/medical/research/shallway)
 "rNT" = (
 /obj/structure/closet/secure_closet/injection,
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/machinery/newscaster/security_unit/directional/west,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/simulated/floor/plasteel{
@@ -95740,6 +97577,13 @@
 	icon_state = "bar"
 	},
 /area/security/permabrig)
+"rOt" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/atmos)
 "rOD" = (
 /turf/simulated/floor/plasteel,
 /area/security/permahallway)
@@ -95751,7 +97595,9 @@
 /area/bridge/vip)
 "rOR" = (
 /obj/machinery/iv_drip,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -95759,7 +97605,7 @@
 /area/medical/virology/lab)
 "rOW" = (
 /obj/machinery/alarm/directional/south,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -95780,7 +97626,6 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -95788,7 +97633,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -95808,7 +97653,9 @@
 /area/security/execution)
 "rPj" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "rPs" = (
@@ -95854,7 +97701,9 @@
 /turf/simulated/floor/plasteel,
 /area/security/customs)
 "rPU" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "rQf" = (
@@ -95902,7 +97751,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/pen,
@@ -95934,7 +97783,9 @@
 	},
 /area/security/securehallway)
 "rQP" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Singularity";
 	name = "Singularity Blast Doors"
@@ -95970,8 +97821,6 @@
 	pixel_y = 33
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -96066,7 +97915,9 @@
 	},
 /area/crew_quarters/locker)
 "rSa" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -96110,7 +97961,9 @@
 /area/medical/research/shallway)
 "rSt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "rSH" = (
@@ -96295,8 +98148,8 @@
 /obj/item/stack/rods{
 	amount = 10
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/stack/sheet/glass{
 	amount = 10
 	},
@@ -96309,7 +98162,9 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "rVe" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -96370,7 +98225,9 @@
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "rVM" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_y = -30
@@ -96384,7 +98241,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
@@ -96426,7 +98283,7 @@
 	c_tag = "Cargo Shuttle Airlock";
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -96500,7 +98357,9 @@
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
 "rXc" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1379;
@@ -96636,7 +98495,7 @@
 /area/medical/virology/lab)
 "rZI" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -96809,7 +98668,7 @@
 /obj/item/analyzer,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "sbF" = (
@@ -96835,7 +98694,7 @@
 	name = "Primary Tool Storage Console";
 	pixel_y = 30
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "sci" = (
@@ -96864,7 +98723,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "scB" = (
@@ -96929,7 +98788,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "scZ" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -97006,7 +98865,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "sei" = (
@@ -97070,7 +98929,7 @@
 	},
 /area/medical/medbay)
 "seF" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -97140,6 +98999,7 @@
 "seU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin2)
 "sfb" = (
@@ -97183,7 +99043,7 @@
 /turf/simulated/floor/carpet/red,
 /area/crew_quarters/bar/atrium)
 "sfU" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -97229,8 +99089,10 @@
 /area/medical/virology/lab)
 "sgx" = (
 /obj/structure/rack,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/item/radio/intercom/directional/south,
 /obj/item/stack/sheet/metal{
 	amount = 50
@@ -97343,8 +99205,12 @@
 	id_tag = "roboticsshutters";
 	name = "Mech Bay Shutters"
 	},
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -97377,7 +99243,7 @@
 /area/security/execution)
 "six" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -97392,7 +99258,9 @@
 /area/bridge/vip)
 "siH" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -97412,7 +99280,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
 "siL" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "siM" = (
@@ -97431,7 +99301,6 @@
 	icon_state = "grass_edge_medium"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -97460,7 +99329,9 @@
 	c_tag = "Teleporter";
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/machinery/light_switch/directional/east,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
@@ -97615,7 +99486,7 @@
 "slb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -97713,11 +99584,17 @@
 /area/security/checkpoint)
 "smf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
 /area/engineering/hardsuitstorage)
+"smk" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/crew_quarters/kitchen)
 "smu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -97792,7 +99669,7 @@
 /area/medical/cmo)
 "snl" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -97823,7 +99700,9 @@
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plating/airless,
 /area/medical/virology/lab)
 "snH" = (
@@ -98059,7 +99938,9 @@
 /area/toxins/sm_test_chamber)
 "spH" = (
 /obj/structure/closet/secure_closet/RD,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -98086,7 +99967,7 @@
 /area/engineering/mechanic_workshop/expedition)
 "spL" = (
 /obj/machinery/alarm/directional/south,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/cargotech,
 /obj/item/stamp/granted,
 /obj/item/stamp/denied,
@@ -98210,7 +100091,7 @@
 /area/bridge)
 "sqZ" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -98242,7 +100123,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "srp" = (
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/turf_decal/delivery/partial,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
@@ -98253,7 +100134,7 @@
 /area/bridge/vip)
 "srA" = (
 /obj/structure/closet/l3closet/scientist,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/sign/securearea{
 	pixel_y = -32
 	},
@@ -98380,7 +100261,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
@@ -98414,7 +100295,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/turf_decal/delivery/partial,
 /obj/structure/chair/sofa/bench/right,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -98494,7 +100375,9 @@
 	},
 /area/crew_quarters/locker)
 "suf" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -98559,6 +100442,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -98570,7 +100454,7 @@
 /obj/structure/table/reinforced,
 /obj/item/aicard,
 /obj/item/circuitboard/aicore,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "svo" = (
@@ -98593,7 +100477,7 @@
 	},
 /area/toxins/misc_lab)
 "svJ" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -98625,7 +100509,7 @@
 	},
 /area/hallway/secondary/exit)
 "svN" = (
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
@@ -98678,7 +100562,9 @@
 	locked = 1;
 	name = "West Maintenance External Access"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -98724,7 +100610,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/serviceyard)
 "swV" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -98779,11 +100665,9 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "sxp" = (
@@ -98994,7 +100878,7 @@
 	},
 /area/security/processing)
 "szc" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "szd" = (
@@ -99071,7 +100955,7 @@
 /area/maintenance/tourist)
 "sAv" = (
 /obj/machinery/light/small,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -99131,7 +101015,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "sAQ" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -99153,7 +101039,7 @@
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/securearmory)
 "sBj" = (
@@ -99169,7 +101055,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "sBk" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/camera{
 	c_tag = "Brig Storage";
@@ -99192,7 +101080,7 @@
 	},
 /area/bridge/vip)
 "sBx" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -99252,7 +101140,9 @@
 	pixel_x = -32
 	},
 /obj/machinery/computer/station_alert,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -99264,7 +101154,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door_control{
 	id = "xeno4";
 	name = "Containment Control";
@@ -99310,7 +101200,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "sCB" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
@@ -99341,6 +101231,7 @@
 	pixel_x = 9;
 	pixel_y = 2
 	},
+/obj/structure/closet/walllocker/emerglocker/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkblue"
@@ -99348,7 +101239,7 @@
 /area/aisat)
 "sCN" = (
 /obj/item/trash/cheesie,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -99369,7 +101260,7 @@
 	},
 /area/security/execution)
 "sDl" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -99468,7 +101359,7 @@
 /area/bridge/vip)
 "sEa" = (
 /obj/machinery/vending/snack,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -99506,7 +101397,9 @@
 	},
 /area/toxins/xenobiology)
 "sEO" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
 "sEW" = (
@@ -99568,7 +101461,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -99593,7 +101486,9 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -99683,12 +101578,25 @@
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "sHY" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
 	},
 /area/toxins/explab)
+"sHZ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
+	dir = 4;
+	name = "Труба фильтрации"
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/atmos)
 "sIo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -99707,10 +101615,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -99725,16 +101633,14 @@
 	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "sIJ" = (
 /obj/machinery/suit_storage_unit/security,
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -99841,9 +101747,9 @@
 /area/maintenance/kitchen)
 "sKF" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -99855,7 +101761,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
@@ -99903,11 +101811,11 @@
 /area/engineering/mechanic_workshop)
 "sLV" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -99927,7 +101835,7 @@
 /area/security/securearmory)
 "sMh" = (
 /obj/structure/table,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs{
 	pixel_x = -3;
@@ -99939,7 +101847,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -100030,7 +101938,7 @@
 	},
 /area/hallway/primary/port/west)
 "sNa" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -100071,7 +101979,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -100128,10 +102035,10 @@
 /area/construction/hallway)
 "sOE" = (
 /obj/machinery/light,
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -100159,7 +102066,7 @@
 /area/turret_protected/aisat)
 "sOS" = (
 /obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -100503,12 +102410,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
 "sSa" = (
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/structure/closet/l3closet/security,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -100640,7 +102546,7 @@
 "sUb" = (
 /obj/structure/target_stake,
 /obj/machinery/magnetic_module,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "sUd" = (
@@ -100696,7 +102602,9 @@
 	},
 /area/bridge/vip)
 "sUZ" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -100709,6 +102617,7 @@
 	},
 /area/quartermaster/storage)
 "sVh" = (
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -100754,6 +102663,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/controlroom)
+"sVQ" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/crew_quarters/bar)
 "sVU" = (
 /turf/simulated/wall,
 /area/security/range)
@@ -100781,7 +102696,7 @@
 "sWh" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/window/reinforced,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -100868,7 +102783,7 @@
 /area/engineering/break_room)
 "sXH" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
@@ -100941,7 +102856,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -101043,7 +102958,7 @@
 /obj/structure/closet/secure_closet/medical1{
 	req_access = list(5,62)
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/simulated/floor/plasteel,
 /area/gateway)
@@ -101071,7 +102986,7 @@
 	},
 /area/crew_quarters/bar)
 "sZn" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
 "sZC" = (
@@ -101112,7 +103027,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -101176,7 +103091,9 @@
 	},
 /area/hallway/primary/fore)
 "taw" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -101205,6 +103122,17 @@
 	icon_state = "chapel"
 	},
 /area/maintenance/asmaint4)
+"taL" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/permabrig)
 "taM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -101236,12 +103164,14 @@
 /area/hallway/primary/central/south)
 "tbq" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	dir = 2;
 	id_tag = "engsm"
@@ -101256,6 +103186,24 @@
 /obj/machinery/computer/slot_machine,
 /turf/simulated/floor/carpet/red,
 /area/crew_quarters/bar/atrium)
+"tbA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitebluefull"
+	},
+/area/medical/sleeper)
 "tbM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -101273,7 +103221,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/directional/north,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/chair/stool{
 	dir = 8
 	},
@@ -101338,7 +103288,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "tct" = (
@@ -101348,7 +103300,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
 "tcv" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/computer/supplyquest/workers{
 	pixel_y = 28
 	},
@@ -101366,7 +103318,7 @@
 /obj/machinery/atmospherics/unary/thermomachine/freezer{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -101383,7 +103335,9 @@
 	id = "portsolar";
 	name = "South-West Solar Control"
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "tcH" = (
@@ -101515,7 +103469,9 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "tdv" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -101542,7 +103498,9 @@
 	},
 /area/storage/tech)
 "tdT" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
 	},
@@ -101558,7 +103516,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
@@ -101630,12 +103588,14 @@
 /area/aisat)
 "teJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "teS" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/closet/secure_closet/brig,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -101667,7 +103627,6 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -101690,7 +103649,7 @@
 /area/maintenance/electrical)
 "tfI" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -101703,7 +103662,7 @@
 /obj/machinery/sleeper{
 	pixel_x = 3
 	},
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -101731,7 +103690,9 @@
 	},
 /area/crew_quarters/fitness)
 "tgf" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/camera/emp_proof{
 	c_tag = "Singularity South-East";
 	dir = 8;
@@ -101804,15 +103765,15 @@
 /area/toxins/sm_test_chamber)
 "tgT" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "tgY" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "thk" = (
@@ -101845,15 +103806,21 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "thA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -101874,7 +103841,9 @@
 /area/security/customs)
 "thP" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "tid" = (
@@ -101882,7 +103851,9 @@
 /obj/item/clothing/suit/storage/hazardvest,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/gloves/color/black,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -101896,7 +103867,7 @@
 /turf/simulated/wall/r_wall,
 /area/security/detectives_office)
 "tig" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/shield/riot{
 	pixel_x = -6;
 	pixel_y = -6
@@ -101956,7 +103927,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -101971,7 +103942,7 @@
 /area/security/reception)
 "tin" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -101999,11 +103970,15 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "tiz" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "tiG" = (
@@ -102053,7 +104028,9 @@
 	},
 /area/maintenance/library)
 "tja" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "tjc" = (
@@ -102069,7 +104046,9 @@
 "tje" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/south,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "tjh" = (
@@ -102086,7 +104065,9 @@
 /area/hallway/primary/fore)
 "tjq" = (
 /obj/machinery/vending/snack,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -102100,7 +104081,9 @@
 	},
 /area/toxins/sm_test_chamber)
 "tjA" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /mob/living/carbon/human/lesser/monkey,
 /turf/simulated/floor/plasteel{
@@ -102191,7 +104174,7 @@
 /area/security/permahallway)
 "tkW" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -102205,7 +104188,7 @@
 /area/bridge/checkpoint/south)
 "tlc" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -102280,7 +104263,9 @@
 	dir = 8
 	},
 /obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -102301,7 +104286,7 @@
 	},
 /area/security/interrogation)
 "tmB" = (
-/obj/effect/decal/warning_stripes/blue,
+/obj/effect/turf_decal/delivery/blue,
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
@@ -102341,12 +104326,9 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -102397,7 +104379,7 @@
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "tni" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "tnm" = (
@@ -102438,7 +104420,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "tnE" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/doppler_array{
 	dir = 8
 	},
@@ -102514,7 +104498,9 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "toL" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -102644,6 +104630,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/blueshield)
+"tqq" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/lab)
 "tqu" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -102725,8 +104717,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "tsB" = (
@@ -102758,7 +104754,9 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
 "tsW" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -102834,7 +104832,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/power/smes/full,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -102891,7 +104889,9 @@
 "tuK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "tuP" = (
@@ -103065,7 +105065,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "twm" = (
@@ -103187,7 +105189,9 @@
 	},
 /area/security/permabrig)
 "txD" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/consarea_virology)
@@ -103283,7 +105287,9 @@
 /area/engineering/break_room)
 "tzg" = (
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/camera{
 	c_tag = "Engineering Entrance";
 	dir = 4;
@@ -103297,7 +105303,9 @@
 /area/security/warden)
 "tzi" = (
 /obj/structure/grille,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "tzk" = (
@@ -103344,7 +105352,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/snack,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -103469,7 +105477,9 @@
 /turf/simulated/floor/plating,
 /area/teleporter)
 "tAB" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "tAC" = (
@@ -103552,7 +105562,7 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/crate/plastic{
 	desc = "В ящике хранится оборудование для осуществления уборки станции гражданским персоналом в случае нужды или безработицы";
 	name = "Ящик оборудования для уборки"
@@ -103611,7 +105621,7 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/freezer,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/seeds/wheat,
 /obj/item/seeds/wheat,
 /obj/item/seeds/wheat,
@@ -103731,7 +105741,7 @@
 	dir = 1;
 	network = list("Engineering","SS13")
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -103740,7 +105750,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "tDv" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/external{
 	id_tag = "admin_home";
 	locked = 1
@@ -103811,7 +105821,7 @@
 	dir = 4;
 	pixel_x = -3
 	},
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -103903,7 +105913,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm/directional/south,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "tEP" = (
@@ -103919,12 +105929,15 @@
 	},
 /area/toxins/xenobiology)
 "tFa" = (
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/crew_quarters/theatre)
 "tFd" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -103981,8 +105994,10 @@
 	},
 /area/security/processing)
 "tFO" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/table/reinforced,
 /obj/item/crowbar/red,
 /turf/simulated/floor/plasteel{
@@ -103997,7 +106012,7 @@
 /obj/machinery/alarm/directional/east,
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -104016,7 +106031,9 @@
 /area/toxins/test_area)
 "tGb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	hackProof = 1;
 	id_tag = "emergency_home";
@@ -104031,7 +106048,9 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -104161,7 +106180,7 @@
 	},
 /area/medical/virology/lab)
 "tHC" = (
-/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/turf_decal/delivery/partial,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "tHH" = (
@@ -104196,15 +106215,13 @@
 	},
 /area/medical/genetics)
 "tIx" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
@@ -104248,7 +106265,7 @@
 	},
 /area/medical/reception)
 "tIS" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
@@ -104285,7 +106302,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
@@ -104301,7 +106318,7 @@
 /obj/item/assembly/igniter,
 /obj/item/assembly/igniter,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -104353,7 +106370,7 @@
 /area/security/evidence)
 "tKa" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -104437,7 +106454,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -104464,7 +106483,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/toxins/test_chamber)
@@ -104525,7 +106544,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/item/flag/atmos{
 	name = "Atmosia Flag"
 	},
@@ -104620,7 +106641,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "tNh" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -104639,7 +106660,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/blue,
+/obj/effect/turf_decal/delivery/blue,
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
 /obj/item/pen,
@@ -104703,7 +106724,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -104737,7 +106757,9 @@
 /turf/simulated/floor/plating,
 /area/medical/chemistry)
 "tOg" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
@@ -104785,7 +106807,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -104858,7 +106879,9 @@
 	},
 /area/hallway/primary/central/ne)
 "tPh" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "tPj" = (
@@ -104872,7 +106895,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "tPv" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "tPD" = (
@@ -104952,10 +106977,16 @@
 	icon_state = "1-2"
 	},
 /obj/structure/reflector/box/anchored,
-/obj/effect/decal/warning_stripes/southeastcorner,
-/obj/effect/decal/warning_stripes/northwestcorner,
-/obj/effect/decal/warning_stripes/northeastcorner,
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "tQA" = (
@@ -105063,8 +107094,8 @@
 	},
 /area/crew_quarters/fitness)
 "tRm" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -105073,7 +107104,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -105203,7 +107234,7 @@
 /area/maintenance/electrical)
 "tSU" = (
 /obj/machinery/teleport/station,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/light{
 	dir = 1
@@ -105340,7 +107371,7 @@
 /area/maintenance/starboard)
 "tUd" = (
 /obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "tUh" = (
@@ -105381,7 +107412,7 @@
 /area/maintenance/kitchen)
 "tUB" = (
 /obj/machinery/vending/snack,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/brigstaff)
 "tUI" = (
@@ -105590,7 +107621,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "tXf" = (
@@ -105656,10 +107687,10 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
 "tXJ" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
 /obj/effect/landmark/start/shaft_miner,
@@ -105725,7 +107756,7 @@
 /obj/effect/turf_decal/caution{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
@@ -105809,7 +107840,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -105877,7 +107908,7 @@
 	dir = 8;
 	network = list("Engineering","SS13")
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "tZN" = (
@@ -105894,7 +107925,7 @@
 /area/maintenance/detectives_office)
 "tZR" = (
 /obj/machinery/pipedispenser,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "tZU" = (
@@ -105903,7 +107934,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "uaf" = (
@@ -105922,7 +107953,7 @@
 /area/security/visiting_room)
 "uaF" = (
 /obj/machinery/hydroponics/soil,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/item/seeds/ambrosia/cruciatus,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -106041,7 +108072,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "uca" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -106112,7 +108143,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -106144,7 +108175,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/crew_quarters/trading)
@@ -106236,7 +108266,6 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -106274,11 +108303,11 @@
 "ufl" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "ufn" = (
@@ -106403,7 +108432,7 @@
 	name = "Creature Pen";
 	req_access = list(47)
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -106499,6 +108528,12 @@
 	icon_state = "yellowfull"
 	},
 /area/maintenance/electrical)
+"uhC" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/engine{
+	name = "Holodeck Projector Floor"
+	},
+/area/holodeck/alphadeck)
 "uhI" = (
 /obj/machinery/mass_driver{
 	id_tag = "chapelgun"
@@ -106576,7 +108611,9 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/bar/atrium)
 "uim" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -106614,6 +108651,13 @@
 	icon_state = "greencorner"
 	},
 /area/medical/virology/lab)
+"uiT" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkblue"
+	},
+/area/bridge)
 "uiX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -106672,7 +108716,7 @@
 /area/crew_quarters/fitness)
 "ujF" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/westleft{
 	dir = 1;
 	name = "Cargo Bay Desk";
@@ -106806,7 +108850,7 @@
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
 "ukJ" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -106955,7 +108999,7 @@
 	name = "E.V.A.";
 	req_access = list(18)
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -106988,10 +109032,16 @@
 /obj/structure/table,
 /turf/simulated/floor/plating,
 /area/maintenance/consarea_virology)
+"unw" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/engineering/engine)
 "unx" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/hydroponics/constructable,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -107074,17 +109124,19 @@
 /area/maintenance/asmaint)
 "unX" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "unZ" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/northeastsouth,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
 /obj/machinery/newscaster/directional/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
@@ -107115,7 +109167,7 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "uou" = (
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/machinery/suit_storage_unit/security,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -107179,13 +109231,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
 "upr" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -107371,7 +109423,7 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/maintenance/asmaint3)
 "usp" = (
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/smartfridge/secure/medbay_blood,
 /turf/simulated/floor/plasteel{
@@ -107379,7 +109431,7 @@
 	},
 /area/medical/sleeper)
 "ust" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -107464,6 +109516,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -107676,7 +109729,7 @@
 "uvo" = (
 /obj/structure/closet/emcloset,
 /obj/item/radio/intercom/directional/south,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "uvp" = (
@@ -107747,7 +109800,9 @@
 	},
 /area/library)
 "uvW" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/light,
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
@@ -107813,7 +109868,9 @@
 /obj/machinery/atmospherics/trinary/mixer{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/window/plasmareinforced{
 	dir = 1
 	},
@@ -107839,7 +109896,7 @@
 /area/crew_quarters/bar/atrium)
 "uxL" = (
 /obj/machinery/recharge_station,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/brigstaff)
 "uxS" = (
@@ -107865,7 +109922,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -107906,7 +109963,9 @@
 /turf/simulated/floor/plating,
 /area/security/execution)
 "uyr" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -107989,7 +110048,9 @@
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "uyI" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "uyQ" = (
@@ -108027,7 +110088,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -108173,7 +110234,7 @@
 "uAo" = (
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
@@ -108182,7 +110243,9 @@
 /turf/simulated/wall,
 /area/medical/cmo)
 "uAL" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 1
 	},
@@ -108219,7 +110282,7 @@
 	},
 /area/security/securehallway)
 "uBu" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	name = "Труба на фильтрацию"
@@ -108236,8 +110299,6 @@
 /area/atmos)
 "uBx" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -108316,7 +110377,9 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "uBX" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -108338,7 +110401,7 @@
 /turf/simulated/wall,
 /area/maintenance/asmaint)
 "uCv" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/machinery/suit_storage_unit/security,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -108356,7 +110419,7 @@
 /area/hallway/secondary/entry/commercial)
 "uCO" = (
 /obj/structure/bookcase/random,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "caution"
@@ -108373,12 +110436,14 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/bar/atrium)
 "uDa" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "uDf" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -108423,7 +110488,7 @@
 "uDF" = (
 /obj/machinery/alarm/directional/west,
 /obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -108442,8 +110507,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -108477,6 +110546,7 @@
 	},
 /area/maintenance/bar)
 "uEz" = (
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreencorner"
 	},
@@ -108497,7 +110567,7 @@
 /area/medical/virology/lab)
 "uEX" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -108526,7 +110596,9 @@
 /area/medical/medbay2)
 "uFl" = (
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
@@ -108552,6 +110624,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
+"uFs" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/quartermaster/storage)
 "uFx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -108748,7 +110826,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -108831,7 +110909,7 @@
 /obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/computer/atmoscontrol,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -108843,7 +110921,7 @@
 	dir = 1;
 	network = list("Research","SS13")
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/light,
 /obj/machinery/computer/roboquest,
 /turf/simulated/floor/plasteel{
@@ -108862,7 +110940,9 @@
 /area/medical/research/nhallway)
 "uJa" = (
 /obj/item/radio/intercom/directional/south,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/structure/rack,
 /obj/item/lock_buster,
 /turf/simulated/floor/plasteel{
@@ -108887,11 +110967,9 @@
 /area/crew_quarters/theatre)
 "uJi" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "uJo" = (
@@ -108943,7 +111021,7 @@
 	pixel_x = -1;
 	pixel_y = 2
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -108955,7 +111033,7 @@
 	layer = 3.1;
 	pixel_y = 3
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -108991,7 +111069,7 @@
 	pixel_y = 4
 	},
 /obj/item/radio,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "uKB" = (
@@ -109017,7 +111095,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/window/plasmareinforced{
 	dir = 1
 	},
@@ -109041,7 +111121,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -109054,8 +111134,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/banya)
 "uLk" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -109088,7 +111170,7 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/test_chamber)
 "uLG" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/chair/sofa/bench/left,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -109118,8 +111200,10 @@
 /turf/simulated/floor/plating,
 /area/medical/research)
 "uLW" = (
-/obj/effect/decal/warning_stripes/blue,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/delivery/blue,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/shower{
 	dir = 8
 	},
@@ -109141,7 +111225,9 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/closet/radiation,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "uMn" = (
@@ -109204,7 +111290,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -109244,7 +111332,9 @@
 /area/security/brigstaff)
 "uNJ" = (
 /obj/machinery/alarm/directional/east,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "uNK" = (
@@ -109258,6 +111348,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plating,
 /area/security/visiting_room)
 "uNV" = (
@@ -109267,7 +111358,9 @@
 /area/maintenance/tourist)
 "uNZ" = (
 /obj/machinery/computer/pandemic,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
 	id = "vir_work_zone2"
@@ -109293,7 +111386,9 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -109354,7 +111449,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -109427,7 +111522,7 @@
 	},
 /area/security/permabrig)
 "uPg" = (
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/structure/closet/bombclosetsecurity,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -109443,7 +111538,7 @@
 	},
 /area/crew_quarters/hor)
 "uPl" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -109475,7 +111570,9 @@
 /obj/machinery/vending/wallmed{
 	pixel_x = 26
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -109488,7 +111585,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "uPO" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -109564,7 +111663,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/flashlight,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "uQA" = (
@@ -109586,8 +111685,10 @@
 	name = "Robotics Requests Console";
 	pixel_x = -30
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -109668,14 +111769,13 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/item/beacon,
 /obj/effect/landmark/spawner/blob,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "uRn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -109732,6 +111832,7 @@
 	},
 /area/medical/genetics)
 "uRT" = (
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluecorner"
 	},
@@ -109767,7 +111868,9 @@
 /area/aisat/aihallway)
 "uTj" = (
 /obj/structure/table/glass,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/reagentgrinder{
 	pixel_x = -1;
 	pixel_y = 9
@@ -109825,7 +111928,8 @@
 /area/security/securearmory)
 "uTU" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -109890,7 +111994,7 @@
 	name = "Research Division Access";
 	req_access = list(47)
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "uVh" = (
@@ -109912,7 +112016,9 @@
 "uVl" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -109925,7 +112031,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -109933,9 +112039,16 @@
 /area/medical/medbay2)
 "uVC" = (
 /obj/machinery/vending/coffee,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/gateway)
+"uVI" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "blue"
+	},
+/area/hallway/secondary/entry/lounge)
 "uVY" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -110077,7 +112190,6 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -110127,10 +112239,11 @@
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/secondary/exit)
 "uYL" = (
-/obj/structure/punching_bag,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
 	},
+/obj/effect/landmark/start/hangover,
+/obj/structure/punching_bag,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -110280,13 +112393,13 @@
 	locked = 1;
 	name = "Arrivals External Access"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
 "vaH" = (
 /obj/structure/closet/secure_closet/research_reagents,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = -28
@@ -110444,10 +112557,12 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/serviceyard)
 "vct" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/light,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -110459,7 +112574,7 @@
 /area/crew_quarters/captain)
 "vcx" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -110516,7 +112631,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "vdv" = (
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 8
 	},
 /obj/structure/chair/sofa/bench{
@@ -110660,7 +112775,9 @@
 	id = "QMLoad";
 	name = "Upload"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "vfE" = (
@@ -110699,7 +112816,9 @@
 	name = "Bomb Mix Monitor";
 	sensors = list("burn_sensor"="Burn Mix")
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -110861,7 +112980,7 @@
 /area/crew_quarters/fitness)
 "vhD" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -110902,7 +113021,7 @@
 	},
 /area/security/hos)
 "vhQ" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -110910,12 +113029,14 @@
 	},
 /area/crew_quarters/locker)
 "vhV" = (
-/obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_y = -30
 	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "vib" = (
@@ -111002,6 +113123,10 @@
 	icon_state = "grimy"
 	},
 /area/maintenance/tourist)
+"viU" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/engine,
+/area/toxins/test_chamber)
 "viX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase,
@@ -111102,6 +113227,16 @@
 	icon_state = "bar"
 	},
 /area/maintenance/tourist)
+"vko" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/chapel/office)
 "vkp" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = -30
@@ -111138,7 +113273,7 @@
 /obj/structure/chair/e_chair{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/engine,
@@ -111147,7 +113282,9 @@
 /obj/structure/chair/comfy/purp{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
@@ -111183,11 +113320,11 @@
 /area/crew_quarters/mrchangs)
 "vly" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -111203,7 +113340,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "vlH" = (
@@ -111289,7 +113428,9 @@
 /obj/item/clothing/head/welding,
 /obj/item/assembly/voice,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
@@ -111335,7 +113476,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/vending_refill/youtool,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -111391,7 +113531,7 @@
 /obj/item/extinguisher,
 /obj/item/clothing/mask/gas,
 /obj/item/grenade/chem_grenade/firefighting,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light/small,
 /obj/machinery/light_switch/directional/west,
 /turf/simulated/floor/plasteel{
@@ -111427,7 +113567,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "vnI" = (
@@ -111450,16 +113590,16 @@
 	},
 /area/medical/genetics)
 "vor" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
 /area/toxins/sm_test_chamber)
 "vos" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -111481,7 +113621,6 @@
 /obj/item/stack/sheet/cardboard,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -111562,7 +113701,7 @@
 /area/security/brig)
 "vpz" = (
 /obj/structure/closet/radiation,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -111707,7 +113846,7 @@
 /obj/structure/chair/sofa/bench{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -111761,7 +113900,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -111776,6 +113917,7 @@
 	},
 /area/security/prisonershuttle)
 "vrP" = (
+/obj/effect/landmark/start/hangover,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -111859,7 +114001,9 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -111870,7 +114014,9 @@
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/serviceyard)
 "vsE" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen/toxin_chamber{
 	pixel_y = 2
@@ -111905,7 +114051,9 @@
 /area/quartermaster/sorting)
 "vsM" = (
 /obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -112037,7 +114185,7 @@
 	},
 /area/hallway/secondary/exit)
 "vuD" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -112068,7 +114216,7 @@
 /area/chapel/office)
 "vvE" = (
 /obj/machinery/alarm/directional/south,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -112292,7 +114440,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -112316,7 +114464,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -112510,7 +114658,7 @@
 "vyK" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm/directional/west,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "caution"
@@ -112533,7 +114681,7 @@
 /area/turret_protected/aisat)
 "vyO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/east,
 /turf/simulated/floor/plasteel,
@@ -112626,7 +114774,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -112732,7 +114880,9 @@
 /obj/item/clipboard,
 /obj/item/gps/engineering,
 /obj/item/lighter/zippo/ce,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -112751,7 +114901,9 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "vBm" = (
@@ -112842,7 +114994,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -112896,7 +115048,9 @@
 /area/chapel/office)
 "vCC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	hackProof = 1;
 	id_tag = "emergency_home";
@@ -113001,7 +115155,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -113068,7 +115221,7 @@
 /obj/structure/railing{
 	dir = 10
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -113085,7 +115238,9 @@
 	},
 /area/maintenance/kitchen)
 "vEy" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
@@ -113115,7 +115270,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/vending/assist,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "vFi" = (
@@ -113178,7 +115333,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -113210,7 +115367,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitehall"
@@ -113226,7 +115383,7 @@
 	layer = 2.9
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/item/restraints/handcuffs/toy,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -113257,7 +115414,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "vHi" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -113283,7 +115440,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -113339,7 +115496,7 @@
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/hop)
 "vIE" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -113490,7 +115647,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "vKa" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -113556,10 +115713,11 @@
 "vLd" = (
 /obj/machinery/power/energy_accumulator/rad_collector/anchored,
 /obj/structure/cable/yellow{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "vLh" = (
@@ -113635,7 +115793,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "vMS" = (
@@ -113729,7 +115887,9 @@
 	},
 /area/turret_protected/ai_upload)
 "vNE" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "vNF" = (
@@ -113743,7 +115903,9 @@
 "vNL" = (
 /obj/machinery/alarm/directional/east,
 /obj/machinery/suit_storage_unit/ce,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/chief)
@@ -113767,7 +115929,7 @@
 /turf/simulated/floor/plating,
 /area/security/securearmory)
 "vNZ" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purple"
@@ -113794,7 +115956,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "vOE" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
@@ -113859,7 +116021,9 @@
 	dir = 4
 	},
 /obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -113909,7 +116073,7 @@
 /area/hallway/primary/central/ne)
 "vPZ" = (
 /obj/machinery/alarm/directional/south,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -113944,6 +116108,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -114091,7 +116256,6 @@
 /area/security/nuke_storage)
 "vRl" = (
 /obj/structure/table/reinforced,
-/obj/machinery/defibrillator_mount/loaded,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -114109,16 +116273,25 @@
 	},
 /turf/space,
 /area/space)
+"vRw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/wood/fancy/cherry,
+/area/crew_quarters/bar/atrium)
 "vRz" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "vSm" = (
@@ -114126,7 +116299,6 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/window/plasmareinforced{
@@ -114163,7 +116335,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
@@ -114236,7 +116408,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -114244,7 +116418,9 @@
 "vTj" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/snacks/sliceable/braincake,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -114320,7 +116496,7 @@
 /turf/simulated/floor/plating,
 /area/security/reception)
 "vTG" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/table/reinforced,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -114469,7 +116645,7 @@
 	},
 /area/crew_quarters/fitness)
 "vUJ" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -114482,7 +116658,7 @@
 	frequency = 1379;
 	id_tag = "vir_pump"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "vir_airlock";
 	layer = 3.1;
@@ -114542,6 +116718,10 @@
 	icon_state = "red"
 	},
 /area/security/checkpoint)
+"vVh" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/carpet/arcade,
+/area/crew_quarters/fitness)
 "vVo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -114555,7 +116735,9 @@
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "vVv" = (
@@ -114577,18 +116759,21 @@
 /area/hallway/primary/starboard/east)
 "vVL" = (
 /obj/structure/cable/yellow{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/toxins/sm_test_chamber)
 "vVR" = (
-/obj/effect/decal/warning_stripes/northeast,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/chem_heater,
 /obj/structure/window/plasmareinforced{
 	dir = 4
@@ -114666,7 +116851,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/spawner/xeno,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "vWI" = (
@@ -114699,6 +116884,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/warden)
+"vWZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/central/south)
 "vXh" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -114743,7 +116946,9 @@
 	},
 /area/security/securearmory)
 "vXL" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -114769,6 +116974,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/tourist)
+"vYb" = (
+/obj/structure/closet/walllocker/emerglocker/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/hallway/secondary/entry)
 "vYj" = (
 /obj/machinery/door_control{
 	id = "magistrate";
@@ -114834,7 +117046,7 @@
 "vZi" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/sunflower,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/maintenance/garden)
 "vZk" = (
@@ -114876,7 +117088,9 @@
 	c_tag = "West-South Solars"
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "vZG" = (
@@ -114922,11 +117136,11 @@
 /area/maintenance/bar)
 "waI" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "waL" = (
@@ -114961,7 +117175,6 @@
 /obj/item/trash/candy,
 /obj/effect/spawner/random_spawners/grille_13,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -115146,7 +117359,7 @@
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/firealarm/directional/east,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/reagent_containers/spray/plantbgone{
 	pixel_x = -5;
 	pixel_y = 6
@@ -115173,7 +117386,7 @@
 /area/assembly/chargebay)
 "wcS" = (
 /obj/machinery/atmospherics/unary/tank/air,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint3)
 "wcV" = (
@@ -115311,6 +117524,10 @@
 	icon_state = "dark"
 	},
 /area/engineering/aienter)
+"weN" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit)
 "wff" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
@@ -115329,7 +117546,7 @@
 /obj/structure/chair/sofa/bench{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -115376,6 +117593,13 @@
 	icon_state = "brown"
 	},
 /area/crew_quarters/chief)
+"wfW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/entry/westarrival)
 "wgm" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -115385,11 +117609,9 @@
 	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "wgt" = (
@@ -115442,6 +117664,7 @@
 	layer = 5;
 	pixel_y = -5
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -115454,7 +117677,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm/directional/north,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
 "wgX" = (
@@ -115499,7 +117722,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -115520,7 +117745,7 @@
 /area/hallway/secondary/exit)
 "wio" = (
 /obj/item/flag/species,
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -115658,7 +117883,6 @@
 	},
 /obj/random/tool,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -115675,6 +117899,13 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engineering/engine/monitor)
+"wjY" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/red,
+/area/crew_quarters/bar/atrium)
 "wkc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -115766,6 +117997,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/wood/fancy/light,
 /area/medical/psych)
 "wlm" = (
@@ -115821,7 +118053,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "wmm" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -115831,7 +118063,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -115898,7 +118132,8 @@
 	frequency = 1379;
 	id_tag = "engineering_east_pump"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/walllocker/emerglocker/directional/south,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "wnc" = (
@@ -115910,7 +118145,7 @@
 	},
 /area/hallway/primary/central/south)
 "wnh" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/computer/operating{
 	name = "Robotics Operating Computer"
 	},
@@ -116094,6 +118329,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/hos)
+"wpm" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/ne)
 "wpn" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -116177,7 +118419,6 @@
 	id = "comdel"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -116190,7 +118431,9 @@
 	},
 /area/medical/medbay)
 "wqb" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
@@ -116242,7 +118485,7 @@
 	pixel_x = -24;
 	req_access = list(62)
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "wqx" = (
@@ -116270,7 +118513,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -116425,6 +118668,13 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/sw)
+"wsm" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/hallway/secondary/entry/lounge)
 "wsr" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -116441,12 +118691,14 @@
 "wsA" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/flashlight,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "wsC" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/muffin{
 	pixel_y = 9
@@ -116455,6 +118707,13 @@
 	icon_state = "darkblue"
 	},
 /area/chapel/main)
+"wsE" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/fore)
 "wsG" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/virologist,
@@ -116600,7 +118859,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/folder,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -116701,7 +118960,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -116726,11 +118984,11 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
@@ -116741,6 +118999,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -116797,11 +119056,11 @@
 /obj/effect/decal/cleanable/blood/writing,
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
 "wwb" = (
+/obj/effect/landmark/start/hangover,
 /obj/structure/railing,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
@@ -116860,7 +119119,7 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "wwp" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "wws" = (
@@ -116934,7 +119193,9 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/northeastsouth,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "escape"
 	},
@@ -116963,7 +119224,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
 "wxC" = (
@@ -117152,7 +119413,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "wAL" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/research_reagents,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -117181,11 +119442,9 @@
 /area/crew_quarters/fitness)
 "wAW" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -117340,7 +119599,9 @@
 /turf/simulated/floor/plasteel,
 /area/security/prison/cell_block/A)
 "wDx" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -117368,7 +119629,6 @@
 /area/toxins/xenobiology)
 "wDS" = (
 /obj/structure/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/window/reinforced/polarized{
@@ -117489,8 +119749,10 @@
 	},
 /area/medical/research/nhallway)
 "wEK" = (
-/obj/effect/decal/warning_stripes/northwest,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/chem_dispenser,
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
@@ -117500,7 +119762,7 @@
 	},
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/double,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -117518,6 +119780,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/security/checkpoint/south)
+"wEQ" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research/restroom)
 "wES" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -117659,7 +119927,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
@@ -117719,7 +119986,9 @@
 	},
 /area/quartermaster/miningdock)
 "wGU" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -117729,7 +119998,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/cryopod,
-/obj/effect/decal/warning_stripes/green,
+/obj/effect/turf_decal/delivery/green,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -117754,7 +120023,7 @@
 "wHz" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "wHC" = (
@@ -117790,10 +120059,11 @@
 "wHY" = (
 /obj/structure/bed,
 /obj/structure/curtain/black,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -117896,6 +120166,12 @@
 	icon_state = "neutralfull"
 	},
 /area/security/checkpoint/south)
+"wKj" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	icon_state = "whiteblue"
+	},
+/area/medical/medbay2)
 "wKp" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -118032,7 +120308,9 @@
 /area/maintenance/consarea_virology)
 "wLQ" = (
 /obj/item/radio/intercom/directional/east,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/door/window/brigdoor/northleft{
 	armor = list("melee"=85,"bullet"=20,"laser"=0,"energy"=0,"bomb"=60,"bio"=100,"fire"=99,"acid"=100);
 	damage_deflection = 21
@@ -118114,7 +120392,9 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Area";
 	network = list("SS13","Engineering")
@@ -118176,11 +120456,11 @@
 /area/library/game_zone)
 "wNB" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Singularity";
 	name = "Singularity Blast Doors"
@@ -118216,14 +120496,14 @@
 /area/security/permabrig)
 "wNR" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard/east)
 "wNW" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/chem_master/condimaster,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -118368,7 +120648,7 @@
 /obj/item/assembly/timer,
 /obj/item/assembly/voice,
 /obj/item/assembly/voice,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "wPy" = (
@@ -118405,7 +120685,7 @@
 	},
 /area/medical/reception)
 "wPC" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/newscaster/directional/south,
 /obj/structure/chair/office/light{
 	dir = 8
@@ -118455,12 +120735,19 @@
 	icon_state = "neutral"
 	},
 /area/crew_quarters/fitness)
+"wQg" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/weightmachine/horizontalbar,
+/turf/simulated/floor/plasteel{
+	icon_state = "vault"
+	},
+/area/crew_quarters/fitness)
 "wQj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
@@ -118504,7 +120791,9 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/toxins/test_chamber)
 "wQL" = (
@@ -118523,7 +120812,9 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
 "wQO" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stock_parts/manipulator,
@@ -118537,7 +120828,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/the_singularitygen,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -118559,7 +120850,7 @@
 /area/security/reception)
 "wRg" = (
 /obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/red,
+/obj/effect/turf_decal/delivery/red,
 /obj/machinery/alarm/directional/west,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
@@ -118575,7 +120866,10 @@
 /obj/structure/sign/pods{
 	pixel_x = -32
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "wRq" = (
@@ -118759,9 +121053,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
+"wTp" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/wood/fancy/cherry,
+/area/crew_quarters/bar/atrium)
 "wTs" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "wTz" = (
@@ -118778,7 +121076,7 @@
 	},
 /area/security/permabrig)
 "wTS" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -118821,8 +121119,6 @@
 /area/maintenance/tourist)
 "wUB" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/engineer,
@@ -118831,7 +121127,7 @@
 	},
 /area/engineering/engine)
 "wUC" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/suit_storage_unit/engine,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -118844,7 +121140,7 @@
 	},
 /area/security/permabrig)
 "wUU" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/mouse,
 /turf/simulated/floor/plasteel,
@@ -119015,7 +121311,9 @@
 "wWP" = (
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/papershredder,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -119090,7 +121388,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -119168,11 +121466,11 @@
 /area/ntrep)
 "wZb" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -119191,7 +121489,7 @@
 	},
 /area/bridge)
 "wZB" = (
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	dir = 4;
@@ -119284,7 +121582,7 @@
 	},
 /area/security/prisonershuttle)
 "xaP" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -119338,6 +121636,7 @@
 /area/toxins/mixing)
 "xbv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -119363,7 +121662,8 @@
 /area/security/prison/cell_block/A)
 "xbE" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -119381,7 +121681,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/cryopod,
-/obj/effect/decal/warning_stripes/green,
+/obj/effect/turf_decal/delivery/green,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -119464,7 +121764,9 @@
 	pixel_x = -1;
 	pixel_y = 2
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "xcu" = (
@@ -119473,7 +121775,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -119496,7 +121798,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "xcN" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -119507,7 +121809,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/closet/secure_closet/brig,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -119526,8 +121830,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "xdb" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -119578,12 +121882,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "xdB" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -119616,7 +121924,9 @@
 /area/maintenance/asmaint4)
 "xdP" = (
 /obj/machinery/computer/pandemic,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
 	id = "vir_work_zone1"
@@ -119646,7 +121956,9 @@
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "xdY" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/binary/valve/digital{
 	dir = 4
 	},
@@ -119704,7 +122016,7 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "xeN" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -119718,7 +122030,7 @@
 /area/maintenance/tourist)
 "xeQ" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "xeT" = (
@@ -119743,11 +122055,13 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "xfm" = (
-/obj/effect/turf_decal/bot/right,
+/obj/effect/turf_decal/delivery/hollow/right,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -119838,7 +122152,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "xfX" = (
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -119867,6 +122183,7 @@
 	},
 /area/security/customs)
 "xgh" = (
+/obj/effect/landmark/start/hangover,
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway West 3";
 	dir = 8
@@ -119877,11 +122194,14 @@
 	},
 /area/hallway/primary/central/west)
 "xgj" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/item/twohanded/required/kirbyplants,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/crowbar,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "xgm" = (
@@ -119912,7 +122232,9 @@
 /area/security/detectives_office)
 "xgv" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/computer/security/telescreen/singularity{
 	dir = 8;
 	pixel_x = -32
@@ -120030,7 +122352,9 @@
 	},
 /area/hallway/primary/central/se)
 "xhK" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	name = "Труба обработки"
@@ -120185,6 +122509,7 @@
 /area/aisat/aihallway)
 "xkg" = (
 /obj/structure/table/wood,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/serviceyard)
 "xkm" = (
@@ -120337,13 +122662,14 @@
 /area/security/detectives_office)
 "xmw" = (
 /obj/machinery/computer/mech_bay_power_console,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/securearmory)
 "xmz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "xmJ" = (
@@ -120357,7 +122683,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
 "xmM" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -120384,8 +122710,10 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
@@ -120681,7 +123009,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -120739,7 +123067,9 @@
 /area/security/range)
 "xqA" = (
 /obj/machinery/power/port_gen/pacman,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/item/radio/intercom/directional/north,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -120864,8 +123194,6 @@
 /area/medical/virology/lab)
 "xsj" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -120891,7 +123219,7 @@
 /area/maintenance/bar)
 "xsv" = (
 /obj/machinery/computer/rdconsole/robotics,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -120930,8 +123258,8 @@
 /area/chapel/main)
 "xsK" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/green/hollow,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -120967,7 +123295,7 @@
 	},
 /area/medical/sleeper)
 "xts" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/unary/tank/air,
 /turf/simulated/floor/plating,
 /area/aisat/maintenance)
@@ -120975,7 +123303,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/bombcloset,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
@@ -121004,7 +123332,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "xtL" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -121027,6 +123355,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/maintenance/asmaint4)
+"xtR" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/hallway/primary/central/nw)
 "xua" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/red,
@@ -121097,10 +123432,6 @@
 /turf/simulated/wall/r_wall,
 /area/security/detectives_office)
 "xuA" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/curtain/open/shower,
 /obj/machinery/door_control{
 	id = "showers";
 	name = "Door Bolt Control";
@@ -121108,6 +123439,11 @@
 	pixel_x = 24;
 	specialfunctions = 4
 	},
+/obj/effect/landmark/start/hangover,
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open/shower,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -121176,7 +123512,9 @@
 	},
 /area/turret_protected/aisat)
 "xvt" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/structure/sign/double/no_idiots/right{
 	pixel_y = 32
 	},
@@ -121261,7 +123599,9 @@
 	},
 /area/security/warden)
 "xwd" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/light_switch/directional/east,
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -121270,7 +123610,7 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "xwf" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/bombcloset,
 /obj/machinery/light/small{
 	dir = 1
@@ -121283,7 +123623,7 @@
 "xwj" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/tower,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/maintenance/garden)
 "xwq" = (
@@ -121337,7 +123677,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "xwL" = (
@@ -121407,7 +123749,7 @@
 /area/solar/starboard)
 "xxk" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/item/transfer_valve{
 	pixel_x = 8;
 	pixel_y = -6
@@ -121502,8 +123844,10 @@
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "xxH" = (
-/obj/effect/decal/warning_stripes/blue,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/delivery/blue,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/sink{
 	pixel_y = 22
 	},
@@ -121517,7 +123861,9 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "xxJ" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/closet/l3closet/scientist,
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel,
@@ -121568,7 +123914,9 @@
 /area/crew_quarters/locker)
 "xyJ" = (
 /obj/machinery/teleport/hub,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -121589,7 +123937,9 @@
 /area/maintenance/fpmaint)
 "xyS" = (
 /obj/machinery/computer/teleporter,
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -121668,13 +124018,14 @@
 /area/maintenance/asmaint2)
 "xzt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/qm)
 "xzw" = (
-/obj/effect/decal/warning_stripes/yellow,
-/obj/structure/plasticflaps,
+/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
@@ -121692,8 +124043,8 @@
 	},
 /area/hallway/secondary/entry/commercial)
 "xzK" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "xAb" = (
@@ -121762,7 +124113,7 @@
 /area/security/brig)
 "xBc" = (
 /obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -121823,7 +124174,9 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "xBS" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -121873,12 +124226,12 @@
 	},
 /area/medical/medbay)
 "xCD" = (
-/obj/effect/decal/warning_stripes/arrow,
+/obj/effect/turf_decal/arrows/black,
 /obj/structure/disposaloutlet,
 /obj/structure/window/plasmareinforced{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -121994,7 +124347,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "xDU" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/wardrobe/robotics_black,
 /obj/item/clothing/head/welding{
 	pixel_x = -3;
@@ -122058,7 +124411,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
 /obj/structure/chair/sofa/bench/left{
@@ -122074,7 +124427,9 @@
 	},
 /area/turret_protected/aisat)
 "xEu" = (
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/power/apc/directional/west,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -122171,7 +124526,9 @@
 /area/turret_protected/ai)
 "xFp" = (
 /obj/structure/morgue,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/effect/landmark/spawner/revenant,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -122211,7 +124568,9 @@
 	network = list("SS13","Engineering")
 	},
 /obj/machinery/power/apc/directional/north,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -122268,8 +124627,6 @@
 /area/medical/virology/lab)
 "xGf" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/table/reinforced,
@@ -122316,7 +124673,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/commercial)
 "xGL" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -122338,7 +124697,9 @@
 /turf/space,
 /area/space)
 "xHa" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -122400,7 +124761,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "xHM" = (
@@ -122440,9 +124803,11 @@
 	},
 /area/security/securehallway)
 "xHY" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/structure/rack,
 /obj/item/stack/cable_coil{
 	pixel_x = -2;
@@ -122576,7 +124941,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -122619,8 +124984,10 @@
 /area/medical/research/nhallway)
 "xJC" = (
 /obj/structure/rack,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/item/stack/sheet/glass{
 	amount = 50
 	},
@@ -122701,12 +125068,12 @@
 /area/security/processing)
 "xKq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/field/generator,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "xKu" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
@@ -122747,6 +125114,13 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/sleeper)
+"xKD" = (
+/obj/effect/landmark/start/hangover,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/hallway/secondary/entry)
 "xKE" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -122841,7 +125215,7 @@
 "xLL" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/coffin,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -122850,7 +125224,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "xLY" = (
@@ -122865,7 +125241,9 @@
 "xMc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "xMd" = (
@@ -122873,7 +125251,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -122936,7 +125316,7 @@
 /area/engineering/engine/monitor)
 "xMs" = (
 /obj/machinery/disposal,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -122979,7 +125359,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
 "xMX" = (
@@ -122991,7 +125371,9 @@
 	name = "Engineering Junction";
 	sortType = 4
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -123014,7 +125396,7 @@
 	},
 /area/maintenance/starboard)
 "xNt" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -123022,7 +125404,9 @@
 	},
 /area/engineering/engine)
 "xNu" = (
-/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
@@ -123148,7 +125532,7 @@
 	},
 /area/medical/chemistry)
 "xOM" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "xOQ" = (
@@ -123239,7 +125623,9 @@
 	},
 /area/hallway/primary/starboard/east)
 "xPj" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -123250,7 +125636,7 @@
 	},
 /area/medical/virology/lab)
 "xPl" = (
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
 /obj/structure/chair/sofa/bench{
@@ -123274,7 +125660,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -123312,7 +125700,7 @@
 	},
 /area/hallway/primary/fore)
 "xPQ" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/camera{
 	c_tag = "Escape Shuttle Command Point";
 	dir = 6
@@ -123409,8 +125797,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -123423,7 +125811,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -123527,7 +125917,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -123567,7 +125957,9 @@
 	},
 /area/maintenance/electrical)
 "xRY" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -123684,7 +126076,9 @@
 /turf/simulated/floor/plating,
 /area/security/reception)
 "xTL" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/light{
 	dir = 8
@@ -123714,7 +126108,9 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
 "xTU" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigpack_robust{
 	pixel_x = 6;
@@ -123793,8 +126189,10 @@
 /obj/item/stack/sheet/plasteel{
 	amount = 10
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -123922,7 +126320,7 @@
 "xWm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "KPPN"
 	},
@@ -123934,7 +126332,9 @@
 /area/bridge/checkpoint/south)
 "xWo" = (
 /obj/machinery/firealarm/directional/east,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "xWr" = (
@@ -123943,13 +126343,14 @@
 	c_tag = "Mech Bay External";
 	dir = 4
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
 "xWx" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -123992,8 +126393,6 @@
 	network = list("SS13","Engineering")
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -124010,10 +126409,10 @@
 	},
 /area/teleporter/abandoned)
 "xXi" = (
-/obj/effect/decal/warning_stripes/arrow{
+/obj/effect/turf_decal/arrows/black{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/yellow/partial{
+/obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -124025,7 +126424,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/spawner/revenant,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
@@ -124239,7 +126638,7 @@
 "xYO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -124266,7 +126665,7 @@
 /area/maintenance/library)
 "xZk" = (
 /obj/structure/morgue,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/spawner/revenant,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -124348,7 +126747,7 @@
 /area/security/main)
 "xZT" = (
 /obj/machinery/vending/snack,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -124446,10 +126845,16 @@
 /obj/structure/reflector/box/anchored{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
-/obj/effect/decal/warning_stripes/northwestcorner,
-/obj/effect/decal/warning_stripes/northeastcorner,
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "yaz" = (
@@ -124463,7 +126868,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "yaI" = (
@@ -124535,7 +126940,6 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -124572,8 +126976,12 @@
 /area/maintenance/engineering)
 "ybU" = (
 /obj/structure/grille,
-/obj/effect/decal/warning_stripes/west,
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "ybW" = (
@@ -124682,7 +127090,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -124697,7 +127104,7 @@
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "ycP" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
 "ycV" = (
@@ -124767,7 +127174,7 @@
 	},
 /area/hallway/primary/central/se)
 "ydv" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -124902,7 +127309,7 @@
 /area/aisat/maintenance)
 "yeI" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -124914,15 +127321,17 @@
 	name = "Chapel Launcher Door";
 	protected = 0
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "yeL" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -124954,7 +127363,7 @@
 /area/maintenance/asmaint4)
 "yff" = (
 /obj/machinery/bodyscanner,
-/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/effect/turf_decal/delivery/blue/hollow,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -125000,7 +127409,7 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "yfG" = (
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -125016,8 +127425,10 @@
 /area/maintenance/starboard)
 "yfQ" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
@@ -125165,12 +127576,13 @@
 /mob/living/simple_animal/frog,
 /obj/item/reagent_containers/syringe/steroids,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
 "yhO" = (
-/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -125226,10 +127638,13 @@
 /turf/space,
 /area/solar/starboard)
 "yii" = (
-/obj/effect/decal/warning_stripes/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "yio" = (
@@ -125397,7 +127812,9 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
 "yjG" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
@@ -125439,7 +127856,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/turf_decal/stripes/line,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 6
@@ -125465,7 +127882,7 @@
 /turf/simulated/wall/r_wall,
 /area/assembly/robotics)
 "yky" = (
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -125497,7 +127914,7 @@
 	pixel_x = 12;
 	pixel_y = -25
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -135297,7 +137714,7 @@ qrT
 oKs
 wgX
 uTb
-uwP
+cYt
 ybH
 bXR
 dZq
@@ -146831,7 +149248,7 @@ fLz
 fYB
 gGx
 hrb
-ihm
+aCd
 iNS
 jub
 xpJ
@@ -147115,7 +149532,7 @@ cwu
 cwu
 cwu
 exf
-hrS
+unX
 hWL
 unX
 oKO
@@ -147586,7 +150003,7 @@ nrc
 oQk
 gIq
 cxd
-iNS
+sHZ
 bIP
 bMS
 cfm
@@ -147883,7 +150300,7 @@ mrH
 tdv
 tPh
 dDP
-mXx
+tPh
 tXp
 eAh
 nnT
@@ -147891,7 +150308,7 @@ aIo
 sog
 cqQ
 tXp
-hIt
+tPh
 dDP
 tPh
 rDF
@@ -148406,7 +150823,7 @@ uPO
 dwt
 bXU
 fFR
-tzM
+unw
 tzM
 guS
 uyI
@@ -148625,7 +151042,7 @@ gFR
 jti
 ihm
 dYY
-bwY
+rOt
 cow
 mKO
 nSt
@@ -148654,7 +151071,7 @@ dUI
 dCy
 tzM
 mJD
-jJc
+kgU
 bXU
 bXU
 nCi
@@ -148674,7 +151091,7 @@ pgt
 qac
 lpm
 vEh
-dah
+viU
 dah
 dah
 dah
@@ -149177,7 +151594,7 @@ dSF
 tPh
 tPh
 tPh
-tPh
+phG
 tPh
 tPh
 cPX
@@ -149964,7 +152381,7 @@ dah
 qTt
 dah
 dah
-dah
+viU
 sUj
 lpm
 prC
@@ -150161,7 +152578,7 @@ ihm
 ihm
 ihm
 ihm
-ihm
+aCd
 ihm
 ihm
 ihm
@@ -151144,7 +153561,7 @@ aaq
 etQ
 kaO
 bjg
-aXM
+hWK
 bsC
 aXM
 aXM
@@ -151664,7 +154081,7 @@ aUr
 aUr
 qcW
 bNS
-aPg
+hgj
 bjs
 etQ
 coE
@@ -152558,7 +154975,7 @@ jrc
 pzS
 lbz
 jPf
-jIA
+mvB
 jIA
 vlG
 nSW
@@ -154295,7 +156712,7 @@ tdH
 uaK
 tdH
 tdH
-tdH
+aKR
 mxf
 bxh
 cLX
@@ -155333,7 +157750,7 @@ bYj
 cfu
 xBo
 cAq
-cAq
+gkp
 cAq
 cAq
 mhK
@@ -155605,7 +158022,7 @@ nJx
 gUa
 frN
 rgA
-frN
+rKG
 dBH
 gMw
 nQm
@@ -155835,7 +158252,7 @@ dis
 sOV
 tCu
 tCu
-tCu
+qTc
 tCu
 wou
 wTs
@@ -155891,7 +158308,7 @@ uHt
 dju
 jTZ
 oDB
-oDB
+kFq
 vsA
 hBX
 iKy
@@ -156128,7 +158545,7 @@ qUe
 ddi
 uNo
 tHr
-tHr
+qJr
 tHr
 fXQ
 cNl
@@ -156184,7 +158601,7 @@ xLL
 dHi
 pzG
 cjs
-iJw
+qag
 iJw
 rFw
 llI
@@ -156286,7 +158703,7 @@ aIC
 aIC
 aIC
 aIC
-aIC
+ofy
 aIC
 bDS
 bPr
@@ -156888,7 +159305,7 @@ lIo
 rcr
 gMw
 xks
-fYZ
+dwx
 rgA
 fYZ
 agj
@@ -156940,7 +159357,7 @@ dIv
 dBh
 iNC
 spW
-rxL
+vko
 xvO
 rxL
 lhr
@@ -157420,7 +159837,7 @@ cOY
 cPd
 vkS
 jcR
-fJp
+kma
 bDP
 fEg
 uJo
@@ -157603,7 +160020,7 @@ tDT
 cFO
 nlF
 hpR
-oPj
+lkw
 gtF
 oPj
 roI
@@ -157887,7 +160304,7 @@ nAu
 vTx
 qtU
 uWQ
-qMp
+xtR
 qMp
 cKv
 cMP
@@ -157896,7 +160313,7 @@ qMp
 qMp
 rqO
 six
-bOw
+dht
 vse
 dPt
 dPt
@@ -158089,7 +160506,7 @@ yhg
 acC
 acC
 acC
-bhN
+xKD
 aRQ
 cAz
 aXJ
@@ -158187,7 +160604,7 @@ ybR
 yhX
 vam
 hgH
-tKj
+wEQ
 cQS
 nPX
 tKj
@@ -158394,7 +160811,7 @@ bKU
 jYe
 wVn
 boi
-oBf
+hUV
 bMH
 mMd
 mMd
@@ -158405,7 +160822,7 @@ lKE
 mMd
 tDc
 jcc
-mMd
+lkG
 mMd
 mMd
 eYe
@@ -158426,7 +160843,7 @@ eJR
 eRU
 dWK
 gfQ
-iHE
+bbx
 dWK
 gfQ
 gfQ
@@ -158682,7 +161099,7 @@ bSE
 bSE
 jPB
 jPB
-uTU
+bWe
 uzy
 uEX
 csK
@@ -158901,7 +161318,7 @@ dCK
 pDM
 eaZ
 fVY
-xBC
+smk
 bKU
 bdz
 bKU
@@ -159404,7 +161821,7 @@ aHB
 hpR
 oPj
 gtF
-oPj
+lkw
 wSb
 gWF
 gWF
@@ -159480,7 +161897,7 @@ xKu
 sjW
 pAy
 hCs
-qGf
+lvi
 nmp
 xJf
 nbx
@@ -160174,7 +162591,7 @@ xeI
 uGn
 sfF
 sfF
-sfF
+eHt
 sfF
 ydD
 lAL
@@ -160383,13 +162800,13 @@ ahe
 dZo
 ayB
 amj
-asi
+hbn
 aqB
 asi
 aul
 aBc
 aBc
-aBc
+cMO
 aLX
 aBc
 ahQ
@@ -160438,7 +162855,7 @@ iRF
 vQV
 wNe
 vQM
-wNe
+wTp
 wNe
 gEk
 czq
@@ -160516,13 +162933,13 @@ avZ
 sjm
 vnI
 rmK
-kaX
+aTV
 utT
 xUz
 hJX
 qNZ
 xdb
-nzN
+pNo
 xeT
 cbI
 fqN
@@ -160653,7 +163070,7 @@ aNS
 aXL
 aah
 aah
-aah
+wfW
 buP
 pcD
 aah
@@ -160691,7 +163108,7 @@ isU
 cvQ
 bQO
 dFR
-bLj
+wjY
 enm
 mLL
 agM
@@ -160738,7 +163155,7 @@ wFJ
 cIi
 sZn
 mfs
-ciD
+euR
 lRu
 mup
 csK
@@ -160762,7 +163179,7 @@ cRb
 dAW
 fVX
 oIq
-oIq
+tqq
 oIq
 oXK
 rcO
@@ -160960,7 +163377,7 @@ pyq
 uik
 pyq
 pyq
-pyq
+vRw
 kho
 bcc
 cQK
@@ -160972,7 +163389,7 @@ coE
 pBK
 rpj
 snq
-byU
+pOf
 odI
 bwf
 kyL
@@ -161173,7 +163590,7 @@ aaq
 aaq
 aaq
 bPA
-bhN
+vYb
 bjK
 dPy
 lZy
@@ -161462,7 +163879,7 @@ beW
 cUx
 cvQ
 tJn
-bLj
+wjY
 eoM
 tbv
 jwa
@@ -161498,7 +163915,7 @@ aaq
 aaq
 aaq
 bHj
-tdn
+gtk
 ddy
 vmr
 aaM
@@ -161695,7 +164112,7 @@ bvL
 byh
 bvL
 bvL
-bvL
+uVI
 bvL
 wee
 aQx
@@ -161717,7 +164134,7 @@ aFA
 vEa
 jSy
 aXA
-cvQ
+sVQ
 dPF
 bLj
 eoM
@@ -161726,7 +164143,7 @@ lRO
 bOH
 qfs
 exZ
-lAQ
+qZC
 lAQ
 uxH
 lAQ
@@ -161758,7 +164175,7 @@ bHj
 tgc
 nvt
 gQD
-kiG
+eYM
 snH
 uyB
 hMR
@@ -161992,7 +164409,7 @@ jHQ
 qiF
 xDu
 aEp
-oBf
+hUV
 luQ
 aaq
 pBK
@@ -162025,7 +164442,7 @@ nrh
 ssw
 lMI
 geG
-fYm
+gQl
 fYm
 rcA
 fYm
@@ -162476,7 +164893,7 @@ bNz
 xPP
 xPP
 xPP
-xPP
+hAp
 xPP
 xPP
 cOn
@@ -162500,7 +164917,7 @@ aGz
 xPP
 xPP
 xPP
-xPP
+hAp
 xPP
 pUp
 bcn
@@ -162739,7 +165156,7 @@ xxC
 cOs
 dqq
 dqq
-kLZ
+oRj
 djM
 pux
 dqq
@@ -162820,7 +165237,7 @@ ogb
 doy
 pRB
 pRB
-pRB
+aCt
 pRB
 pRB
 pRB
@@ -162857,7 +165274,7 @@ qBn
 dTD
 pBJ
 pBJ
-xQY
+weN
 pBJ
 dWm
 gds
@@ -162988,7 +165405,7 @@ bBG
 bEN
 qDz
 gwB
-cwd
+wsE
 tav
 ktz
 cwd
@@ -163003,12 +165420,12 @@ cwd
 cwd
 cwd
 cwd
-cwd
+wsE
 uwH
 cwd
 cwd
 fsz
-cwd
+wsE
 cwd
 mhO
 cwd
@@ -163070,7 +165487,7 @@ xUV
 xUV
 xUV
 ycB
-pgL
+gSr
 pgL
 upS
 dvk
@@ -163282,7 +165699,7 @@ hHa
 coE
 bwf
 jOq
-byU
+pOf
 odi
 bUt
 mUS
@@ -163750,7 +166167,7 @@ buO
 bKc
 aMT
 bKc
-bKc
+wsm
 bKc
 bKc
 bKc
@@ -163837,7 +166254,7 @@ xcb
 liV
 ixo
 hmB
-cPy
+gos
 rYG
 dFQ
 cPy
@@ -164046,7 +166463,7 @@ bju
 dLX
 dZg
 fjY
-bnc
+qwV
 jya
 kow
 luQ
@@ -164257,7 +166674,7 @@ aaq
 aaq
 aaq
 bPA
-bhN
+vYb
 dwy
 dPy
 sme
@@ -164325,7 +166742,7 @@ bwf
 aaq
 aaq
 bHj
-kiG
+eYM
 vKk
 bST
 bST
@@ -164338,7 +166755,7 @@ dAE
 bST
 tIK
 wDT
-vjx
+ddN
 csV
 rFS
 goP
@@ -165097,7 +167514,7 @@ irG
 gLq
 cKS
 dAU
-cKS
+uiT
 bST
 wMB
 owP
@@ -166103,7 +168520,7 @@ mCF
 cqB
 cqB
 duW
-jya
+msm
 kow
 luQ
 aaq
@@ -166146,7 +168563,7 @@ lWj
 ely
 gHM
 cCT
-xMi
+vWZ
 liV
 qMm
 gTx
@@ -166157,7 +168574,7 @@ cXj
 cZE
 cRj
 sZT
-vtu
+rxR
 rcy
 yff
 sZT
@@ -166370,7 +168787,7 @@ bwf
 mMQ
 srd
 mMQ
-mMQ
+oBF
 pty
 vcb
 pUb
@@ -166597,7 +169014,7 @@ eZs
 djV
 djV
 eZs
-eZs
+uFs
 djV
 djV
 wTS
@@ -166932,7 +169349,7 @@ vtu
 xik
 wjo
 xte
-vpP
+tbA
 rcy
 gsN
 dfy
@@ -167143,14 +169560,14 @@ sss
 rBg
 tPe
 rRB
-pXO
+fjy
 pXO
 pXO
 aDw
 dfk
 wML
 ofr
-wML
+pAA
 qEF
 wML
 puJ
@@ -167359,7 +169776,7 @@ avk
 uQA
 bUf
 bYJ
-eZs
+uFs
 bkV
 aCf
 cOR
@@ -167424,7 +169841,7 @@ sRr
 mgb
 rai
 ydj
-wPQ
+ebC
 wPQ
 lTQ
 wPQ
@@ -167650,7 +170067,7 @@ ivV
 bNc
 bOX
 uXz
-uXz
+wpm
 qwW
 uXz
 mKL
@@ -167659,7 +170076,7 @@ odl
 uXz
 anP
 uXz
-uXz
+wpm
 uXz
 bNc
 tmc
@@ -167669,7 +170086,7 @@ xHe
 xHe
 qOs
 xHe
-xHe
+kiD
 xHe
 oGV
 xHe
@@ -168412,7 +170829,7 @@ kMn
 bYB
 mfh
 jMn
-uIe
+mrx
 qYb
 cqB
 coE
@@ -168732,11 +171149,11 @@ jHI
 pEi
 pfs
 wVd
-uLv
+wKj
 pRj
 rDQ
 ehw
-wQu
+dmr
 xEF
 mGt
 tnr
@@ -169164,7 +171581,7 @@ cLd
 mHQ
 mHQ
 dHr
-dHr
+abl
 dHr
 vfD
 qRa
@@ -169173,7 +171590,7 @@ dNr
 qbl
 uDx
 bgT
-vft
+bim
 vjO
 vft
 gfk
@@ -169206,7 +171623,7 @@ xnx
 xnx
 vrl
 vVv
-pOC
+laJ
 cyK
 iVC
 kUh
@@ -169256,7 +171673,7 @@ mGt
 tnr
 qPG
 pLM
-tRG
+hNt
 vpc
 vSn
 woE
@@ -169438,7 +171855,7 @@ dDb
 aZp
 iRP
 mfh
-mfh
+ewn
 djR
 uIe
 nKf
@@ -169473,7 +171890,7 @@ krh
 hYl
 krh
 aMq
-fLk
+pDD
 fFL
 nDq
 sxM
@@ -169724,7 +172141,7 @@ pOC
 ydS
 arm
 fLk
-fNq
+nXb
 mqV
 izf
 pIL
@@ -170248,7 +172665,7 @@ iWw
 eNC
 ewF
 ydS
-fre
+nMO
 mfE
 fvU
 cxn
@@ -170276,7 +172693,7 @@ gHp
 wVd
 kSH
 rZI
-sHA
+leu
 sHA
 vMk
 sHA
@@ -170489,7 +172906,7 @@ lsw
 jun
 wwT
 xnx
-xPg
+krZ
 dLN
 pOC
 ydS
@@ -170539,7 +172956,7 @@ vxs
 dxT
 ebI
 dGa
-dxT
+cMK
 dxT
 uTP
 dGa
@@ -171262,7 +173679,7 @@ xmo
 xmo
 scB
 qze
-wPK
+cej
 glJ
 bEa
 bgN
@@ -171274,7 +173691,7 @@ jLn
 bYM
 uIo
 vSD
-fcN
+hwb
 sJc
 uHf
 tUh
@@ -171537,7 +173954,7 @@ hgR
 bUH
 vSD
 vSD
-vSD
+dkm
 vSD
 vSD
 vwy
@@ -172329,7 +174746,7 @@ kUz
 cKY
 ikS
 wFR
-ufP
+gkB
 wrn
 dqR
 dqR
@@ -172819,7 +175236,7 @@ cYQ
 ccs
 cnP
 vzr
-cAk
+mFX
 fcN
 fHj
 tzL
@@ -173059,7 +175476,7 @@ qtN
 qtN
 oLp
 iXu
-ncC
+orc
 vTk
 ezf
 gDB
@@ -173149,7 +175566,7 @@ axo
 fTk
 wfx
 qXI
-uux
+mkz
 aAw
 jks
 aaq
@@ -174607,7 +177024,7 @@ ecU
 thO
 mlQ
 glR
-tpt
+rqJ
 glR
 eTe
 xJj
@@ -175629,7 +178046,7 @@ ocu
 vsb
 vsb
 vsb
-vsb
+qWL
 wQr
 ecU
 thO
@@ -176425,7 +178842,7 @@ fsK
 fsK
 fsK
 cVX
-tbb
+jdb
 pVy
 cFw
 xhV
@@ -177719,7 +180136,7 @@ gYX
 qjY
 xoK
 cQj
-cQj
+vVh
 nZa
 lyM
 wkE
@@ -177944,7 +180361,7 @@ qNH
 lhS
 oyc
 tLv
-tMU
+rco
 faY
 aEY
 bPv
@@ -178210,7 +180627,7 @@ stL
 sVU
 pEe
 gGh
-hdG
+fRG
 bBt
 hdG
 sMh
@@ -178227,7 +180644,7 @@ gXG
 jot
 bxK
 jot
-kTj
+wQg
 wuk
 gYX
 jUU
@@ -179520,7 +181937,7 @@ dZa
 dZa
 dZa
 dZa
-hqP
+qzo
 wkE
 qEC
 yhg
@@ -180541,7 +182958,7 @@ lER
 lER
 lER
 lER
-lER
+uhC
 lER
 lER
 rIU
@@ -181004,7 +183421,7 @@ ffK
 ibF
 chy
 fjL
-chy
+taL
 bMB
 chy
 syC
@@ -181266,7 +183683,7 @@ ugN
 eHP
 mnQ
 xmf
-xan
+beM
 hGa
 aru
 oIn
@@ -181306,7 +183723,7 @@ csj
 wkE
 hjz
 lER
-lER
+uhC
 lER
 lER
 lER
@@ -181804,7 +184221,7 @@ rDA
 lsH
 wuv
 nXz
-vTL
+qTh
 hfM
 uom
 pLz

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -32,9 +32,7 @@
 	},
 /area/crew_quarters/serviceyard)
 "aah" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "aam" = (
@@ -169,7 +167,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /mob/living/simple_animal/parrot/Poly,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -191,9 +189,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "aax" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/iv_drip,
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
@@ -256,7 +252,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /mob/living/simple_animal/pet/dog/corgi/borgi,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -364,9 +360,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "acr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkblue"
@@ -375,9 +369,7 @@
 "act" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/storage/box/masks,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
 "acC" = (
@@ -398,7 +390,7 @@
 /area/crew_quarters/heads/hop)
 "acU" = (
 /obj/machinery/portable_atmospherics/scrubber/huge/stationary,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -407,9 +399,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -417,9 +407,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "adc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
@@ -476,6 +464,7 @@
 	amount = 20
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -489,9 +478,7 @@
 "aex" = (
 /obj/machinery/recharge_station,
 /obj/machinery/alarm/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/aisat/maintenance)
 "aeE" = (
@@ -532,6 +519,7 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/window/plasmareinforced{
@@ -548,9 +536,7 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "afE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "afL" = (
@@ -563,7 +549,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -643,9 +629,7 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry/westarrival)
 "agr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
 /area/toxins/launch)
 "agA" = (
@@ -748,9 +732,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/additional)
 "ahs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aht" = (
@@ -820,7 +802,7 @@
 	network = list("Engineering","SS13");
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -900,9 +882,7 @@
 	},
 /area/quartermaster/miningdock)
 "ajn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "ajy" = (
@@ -944,10 +924,10 @@
 /turf/simulated/wall,
 /area/hallway/secondary/entry/eastarrival)
 "ajP" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /obj/machinery/atm{
@@ -1032,7 +1012,7 @@
 	},
 /area/engineering/mechanic_workshop)
 "ald" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/sign/vacuum{
 	pixel_y = 32
 	},
@@ -1043,7 +1023,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "alt" = (
@@ -1059,9 +1039,7 @@
 /obj/structure/sign/pods{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "alN" = (
@@ -1084,9 +1062,7 @@
 	},
 /area/security/main)
 "alQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "alT" = (
@@ -1174,7 +1150,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
@@ -1190,7 +1166,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "amw" = (
@@ -1257,7 +1233,7 @@
 /area/bridge)
 "amZ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
@@ -1308,7 +1284,7 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/station_map/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -1334,9 +1310,7 @@
 	},
 /area/quartermaster/sorting)
 "anN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "anP" = (
@@ -1389,7 +1363,7 @@
 /area/teleporter/abandoned)
 "aoc" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -1471,9 +1445,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "aoS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/door/airlock/external{
 	id_tag = "admin_home";
 	locked = 1
@@ -1489,7 +1461,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aph" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "api" = (
@@ -1560,7 +1532,7 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "apE" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 1
 	},
@@ -1579,9 +1551,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "apJ" = (
@@ -1667,9 +1637,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "neutral"
@@ -1696,9 +1664,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "aqq" = (
@@ -1725,7 +1691,7 @@
 /area/toxins/sm_test_chamber)
 "aqB" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -1737,7 +1703,7 @@
 "aqY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -1771,7 +1737,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "arm" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1895,9 +1861,7 @@
 	},
 /area/engineering/mechanic_workshop/expedition)
 "arX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "asb" = (
@@ -1910,9 +1874,7 @@
 /turf/simulated/wall,
 /area/engineering/mechanic_workshop/hangar)
 "ase" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -2022,24 +1984,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "atW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aua" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2052,18 +2008,14 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "auf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -2098,9 +2050,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "neutral"
@@ -2182,7 +2132,7 @@
 	name = "Hangar Gate"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2202,7 +2152,7 @@
 /area/hallway/secondary/entry/lounge)
 "avg" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/sign/botany{
 	pixel_x = -32
 	},
@@ -2246,7 +2196,7 @@
 	},
 /area/engineering/mechanic_workshop)
 "avq" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	pixel_y = 15
 	},
 /turf/simulated/floor/plasteel{
@@ -2277,9 +2227,7 @@
 	},
 /area/engineering/controlroom)
 "avC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
@@ -2296,9 +2244,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "avL" = (
@@ -2306,9 +2252,7 @@
 	dir = 1
 	},
 /obj/item/wrench,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/toxins/test_chamber)
 "avO" = (
@@ -2316,7 +2260,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "avX" = (
@@ -2331,7 +2275,7 @@
 	},
 /area/toxins/sm_test_chamber)
 "avZ" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "awg" = (
@@ -2339,9 +2283,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "awh" = (
@@ -2366,9 +2308,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aws" = (
@@ -2391,7 +2331,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -2405,9 +2345,7 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/supermatter)
 "awJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -2429,9 +2367,7 @@
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/arrival/station)
 "awV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "awY" = (
@@ -2445,9 +2381,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "axa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "axf" = (
@@ -2491,7 +2425,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "axm" = (
@@ -2542,9 +2476,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop)
 "axM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -2589,9 +2521,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aym" = (
@@ -2628,10 +2558,8 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "ays" = (
@@ -2652,9 +2580,7 @@
 /turf/simulated/wall,
 /area/quartermaster/sorting)
 "ayB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "ayD" = (
@@ -2669,10 +2595,8 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "ayH" = (
@@ -2682,12 +2606,8 @@
 	},
 /area/engineering/mechanic_workshop)
 "ayI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop)
@@ -2698,7 +2618,7 @@
 	name = "Hangar Gate"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/hangar)
 "ayU" = (
@@ -2727,6 +2647,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -2777,13 +2698,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "azC" = (
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -2803,15 +2722,13 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/arrival/station)
 "aAb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "aAc" = (
@@ -2827,10 +2744,8 @@
 	},
 /area/hallway/secondary/entry/additional)
 "aAh" = (
-/obj/effect/turf_decal/delivery/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/blue,
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/sink{
 	pixel_y = 22
 	},
@@ -2933,10 +2848,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aAO" = (
@@ -2951,7 +2864,7 @@
 /area/hallway/primary/port)
 "aAT" = (
 /obj/machinery/light/small,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/door_control{
 	desiredstate = 1;
 	id = "toilet2";
@@ -2963,7 +2876,6 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
 "aAW" = (
@@ -2971,10 +2883,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aAY" = (
@@ -3025,9 +2935,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aBn" = (
@@ -3079,9 +2987,7 @@
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "aBy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -3141,7 +3047,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/simulated/floor/plating,
 /area/aisat/maintenance)
@@ -3195,13 +3101,11 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "aCA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aCD" = (
-/obj/effect/turf_decal/delivery/blue,
+/obj/effect/decal/warning_stripes/blue,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
@@ -3222,7 +3126,7 @@
 /obj/item/radio,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light_switch/directional/east,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -3236,15 +3140,15 @@
 	},
 /area/maintenance/asmaint4)
 "aDe" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/binary/volume_pump/on,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "aDh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3285,9 +3189,7 @@
 /obj/structure/sign/vacuum{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aDz" = (
@@ -3310,9 +3212,7 @@
 	c_tag = "Cargo Office North-West";
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/computer/supplycomp{
 	dir = 4
 	},
@@ -3363,9 +3263,7 @@
 /area/shuttle/arrival/station)
 "aEh" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whitepurple"
@@ -3403,6 +3301,8 @@
 /area/maintenance/casino)
 "aEn" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3538,13 +3438,15 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3743,7 +3645,7 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aGL" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "aGO" = (
@@ -3756,7 +3658,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -3766,9 +3667,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3782,6 +3681,8 @@
 /area/crew_quarters/serviceyard)
 "aHc" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -3792,6 +3693,8 @@
 "aHe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3800,7 +3703,7 @@
 /area/engineering/controlroom)
 "aHf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery/blue,
+/obj/effect/decal/warning_stripes/blue,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -3814,7 +3717,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3822,7 +3725,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "aHs" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aHu" = (
@@ -3949,7 +3852,7 @@
 	name = "Turbine Generator Access";
 	req_access = list(24)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "aIC" = (
@@ -4099,20 +4002,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
-"aJN" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/ne)
 "aJO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4120,9 +4014,7 @@
 /area/engineering/controlroom)
 "aJQ" = (
 /obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -4210,6 +4102,7 @@
 	},
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -4236,8 +4129,8 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aKH" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel,
@@ -4341,7 +4234,7 @@
 	name = "Atmospherics Access";
 	req_access = list(24)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4374,15 +4267,6 @@
 	icon_state = "solarpanel"
 	},
 /area/solar/auxstarboard)
-"aLk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel,
-/area/security/brig)
 "aLl" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба служит для подачу горючей смеси в турбину для её работы";
@@ -4406,12 +4290,12 @@
 /area/engineering/mechanic_workshop)
 "aLr" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "aLs" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/camera{
 	c_tag = "Arrivals West Bay 4"
 	},
@@ -4431,7 +4315,7 @@
 	},
 /area/engineering/mechanic_workshop)
 "aLv" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -4452,7 +4336,7 @@
 /area/bridge/checkpoint/south)
 "aLE" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/delivery/blue,
+/obj/effect/decal/warning_stripes/blue,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aLG" = (
@@ -4667,9 +4551,7 @@
 	c_tag = "Arrivals West-North";
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aNj" = (
@@ -4747,9 +4629,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "aNA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aNB" = (
@@ -4806,9 +4686,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "aNY" = (
@@ -4819,9 +4697,7 @@
 	},
 /area/crew_quarters/fitness)
 "aOc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aOd" = (
@@ -4949,11 +4825,13 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aOP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding1"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5083,7 +4961,7 @@
 /area/security/permabrig)
 "aPx" = (
 /obj/structure/bookcase,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -5098,7 +4976,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
 	req_access = list(10)
@@ -5206,9 +5084,7 @@
 /turf/simulated/floor/greengrid,
 /area/engineering/controlroom)
 "aQM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 6;
@@ -5217,9 +5093,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "aQO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -5229,9 +5103,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "aQS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -5388,7 +5260,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
@@ -5433,9 +5304,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "aSH" = (
@@ -5519,9 +5388,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aTm" = (
@@ -5622,7 +5489,7 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "aTU" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	dir = 4;
@@ -5676,9 +5543,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "aUr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -5798,9 +5663,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -5815,9 +5678,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -5827,7 +5688,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -5841,7 +5702,6 @@
 	c_tag = "Fore Hallway South 2";
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -5867,7 +5727,7 @@
 "aVI" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -5891,8 +5751,8 @@
 	dir = 1
 	},
 /obj/machinery/plantgenes,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/delivery/green,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/green,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -5918,7 +5778,7 @@
 	},
 /area/crew_quarters/bar)
 "aWr" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/cargotech,
 /obj/item/stamp/granted,
 /obj/item/stamp/denied,
@@ -6023,19 +5883,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/brig)
 "aXd" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/item/extinguisher/mini,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "aXe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/sign/vacuum{
 	pixel_x = -32
 	},
@@ -6069,13 +5925,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "aXt" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
@@ -6135,15 +5989,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "aXM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -6215,13 +6065,11 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "aYx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/suit_storage_unit/atmos,
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -6239,9 +6087,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "aYH" = (
@@ -6288,7 +6134,6 @@
 	name = "Waste Incinerator";
 	req_access = list(12,24,39)
 	},
-/obj/structure/plasticflaps/kitchen,
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "aYW" = (
@@ -6318,8 +6163,8 @@
 /area/hallway/primary/fore)
 "aZc" = (
 /obj/structure/dispenser,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/end,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/eastsouthwest,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -6361,9 +6206,7 @@
 /obj/machinery/atm{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "aZi" = (
@@ -6375,7 +6218,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -6504,17 +6347,13 @@
 	},
 /area/quartermaster/storage)
 "baj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/suit_storage_unit/atmos,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bal" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/suit_storage_unit/atmos,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel,
@@ -6530,7 +6369,7 @@
 /area/atmos)
 "baD" = (
 /obj/machinery/recharge_station,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/camera{
 	c_tag = "Briefing Room South";
@@ -6543,7 +6382,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/structure/closet/firecloset,
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel,
@@ -6564,6 +6403,7 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -6604,12 +6444,6 @@
 	icon_state = "whitehall"
 	},
 /area/toxins/xenobiology)
-"baW" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull"
-	},
-/area/medical/sleeper)
 "baX" = (
 /obj/structure/sign/vacuum{
 	pixel_y = -32
@@ -6688,7 +6522,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "bbw" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -6725,7 +6559,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/fireaxecabinet{
 	pixel_x = 30
 	},
@@ -6765,7 +6599,7 @@
 	pixel_x = -1;
 	pixel_y = 9
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -6806,7 +6640,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/banya)
 "bck" = (
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -6814,7 +6648,7 @@
 /area/engineering/mechanic_workshop/hangar)
 "bcn" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -6856,7 +6690,7 @@
 	},
 /area/quartermaster/office)
 "bcy" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bcz" = (
@@ -6944,9 +6778,7 @@
 	},
 /area/maintenance/bar)
 "bdu" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/northwestsouth,
 /obj/structure/bed/amb_trolley{
 	dir = 4
 	},
@@ -6965,7 +6797,7 @@
 	},
 /area/crew_quarters/kitchen)
 "bdA" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/cargotech,
 /obj/item/stamp/granted,
 /obj/item/stamp/denied,
@@ -6985,12 +6817,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "bdO" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/walllocker/emerglocker/directional/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
@@ -7038,14 +6870,14 @@
 /area/quartermaster/miningdock)
 "bef" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
 "bei" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "bek" = (
@@ -7071,6 +6903,8 @@
 /area/security/medbay)
 "bep" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/lattice/catwalk,
@@ -7128,9 +6962,7 @@
 	id_tag = "janitorshutters";
 	name = "Janitor Shutters"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -7150,7 +6982,7 @@
 /area/maintenance/consarea_virology)
 "bfw" = (
 /obj/structure/ore_box,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "bfz" = (
@@ -7167,9 +6999,7 @@
 	},
 /area/space)
 "bfF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/door/airlock/external{
 	id_tag = "specops_home";
 	locked = 1
@@ -7189,14 +7019,12 @@
 /turf/simulated/floor/carpet/red,
 /area/maintenance/casino)
 "bfU" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
 "bfW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -7213,9 +7041,7 @@
 /area/library)
 "bge" = (
 /obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/door_control{
 	id = "Chemistry2";
 	name = "Chem Medbay Desk Shutters";
@@ -7252,7 +7078,7 @@
 	id_tag = "eva-shutters";
 	name = "E.V.A. Storage Shutters"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -7457,7 +7283,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -7615,14 +7441,14 @@
 /obj/machinery/vending/wallmed{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/miningdock)
 "bib" = (
 /obj/machinery/space_heater,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7647,9 +7473,7 @@
 /area/quartermaster/miningdock)
 "bif" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "biq" = (
@@ -7682,7 +7506,6 @@
 	drive_range = 58;
 	id_tag = "toxinsdriver"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plating,
 /area/toxins/launch)
 "biC" = (
@@ -7696,7 +7519,7 @@
 	},
 /area/maintenance/bar)
 "biL" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	dir = 9;
@@ -7740,9 +7563,7 @@
 /turf/simulated/floor/plasteel/grimy,
 /area/civilian/vacantoffice)
 "biW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -7750,7 +7571,7 @@
 	},
 /area/toxins/mixing)
 "biX" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -7759,10 +7580,8 @@
 /area/toxins/mixing)
 "biZ" = (
 /obj/machinery/mecha_part_fabricator,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -7778,9 +7597,7 @@
 	},
 /area/crew_quarters/kitchen)
 "bjg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -7788,9 +7605,7 @@
 "bjh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -7806,9 +7621,7 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -7845,7 +7658,7 @@
 /turf/simulated/wall,
 /area/crew_quarters/bar/atrium)
 "bju" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8008,7 +7821,7 @@
 	name = "Distribution Loop";
 	req_access = list(24)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "bkE" = (
@@ -8098,10 +7911,10 @@
 	},
 /area/quartermaster/storage)
 "bkV" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -8195,7 +8008,7 @@
 /area/hallway/secondary/entry/commercial)
 "blw" = (
 /obj/machinery/light/small,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -8218,7 +8031,7 @@
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
 "blB" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/sign/cargo{
 	pixel_x = 32;
 	pixel_y = 32
@@ -8246,7 +8059,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "blL" = (
@@ -8286,7 +8099,7 @@
 /area/hallway/secondary/entry/commercial)
 "blS" = (
 /obj/structure/weightmachine/stacklifter,
-/obj/effect/turf_decal/delivery/white/hollow,
+/obj/effect/decal/warning_stripes/white/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -8488,12 +8301,11 @@
 	},
 /area/hallway/primary/starboard/east)
 "bnT" = (
-/obj/machinery/camera{
-	c_tag = "Escape Private Room";
+/obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/chair/sofa/corp/right{
+/obj/machinery/camera{
+	c_tag = "Escape Private Room";
 	dir = 4
 	},
 /turf/simulated/floor/carpet/purple,
@@ -8544,9 +8356,7 @@
 	},
 /area/quartermaster/storage)
 "bot" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bov" = (
@@ -8561,7 +8371,7 @@
 /area/medical/research)
 "boD" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "boG" = (
@@ -8591,7 +8401,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "boK" = (
@@ -8609,7 +8419,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "boU" = (
@@ -8799,9 +8609,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -8817,10 +8625,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -8829,9 +8637,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -8855,7 +8661,7 @@
 	},
 /area/maintenance/banya)
 "brc" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -8944,9 +8750,7 @@
 /area/quartermaster/office)
 "brB" = (
 /obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 5;
@@ -8965,7 +8769,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop/expedition)
 "brF" = (
-/obj/structure/plasticflaps,
+/obj/structure/plasticflaps/mining,
 /obj/effect/spawner/lootdrop/maintenance/double,
 /obj/machinery/conveyor{
 	dir = 8;
@@ -9000,7 +8804,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -9115,6 +8919,8 @@
 /area/civilian/vacantoffice)
 "bsu" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -9123,6 +8929,8 @@
 /area/engineering/controlroom)
 "bsw" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -9130,9 +8938,11 @@
 	},
 /area/engineering/controlroom)
 "bsx" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -9144,6 +8954,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -9167,6 +8979,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -9190,9 +9003,7 @@
 /obj/machinery/atm{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -9207,9 +9018,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "bsH" = (
@@ -9229,7 +9038,7 @@
 	name = "E.V.A.";
 	req_access = list(18)
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "bsM" = (
@@ -9255,7 +9064,6 @@
 	},
 /obj/structure/bed/wicker,
 /obj/item/radio/intercom/locked/prison/directional/east,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plating,
 /area/security/visiting_room)
 "bta" = (
@@ -9336,8 +9144,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
@@ -9352,9 +9160,7 @@
 	c_tag = "Arrivals Center South";
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "btq" = (
@@ -9383,7 +9189,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9397,7 +9203,7 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -9414,9 +9220,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -9444,7 +9248,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -9491,9 +9295,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "btT" = (
@@ -9534,7 +9336,7 @@
 /area/engineering/controlroom)
 "btY" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -9573,15 +9375,17 @@
 	pixel_y = 32
 	},
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "buf" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "bul" = (
@@ -9589,7 +9393,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
 	req_access = list(10)
@@ -9649,14 +9453,14 @@
 	dir = 1
 	},
 /obj/machinery/disposal,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
 /area/hallway/secondary/entry)
 "buK" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9667,7 +9471,7 @@
 /area/hallway/secondary/entry/lounge)
 "buO" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/lounge)
 "buP" = (
@@ -9681,9 +9485,7 @@
 	c_tag = "Arrivals Center Aft";
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "buR" = (
@@ -9719,9 +9521,7 @@
 	c_tag = "Arrivals Aft Starboard";
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "bvj" = (
@@ -9742,9 +9542,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -9778,7 +9576,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -9858,10 +9656,8 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "escape"
 	},
@@ -9954,9 +9750,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "bwF" = (
@@ -10018,11 +9812,11 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "bwS" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "bwT" = (
-/obj/effect/turf_decal/delivery/blue,
+/obj/effect/decal/warning_stripes/blue,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
@@ -10132,7 +9926,7 @@
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/delivery/white,
+/obj/effect/decal/warning_stripes/white,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -10285,9 +10079,7 @@
 	},
 /area/hallway/primary/port/west)
 "byA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/camera{
 	c_tag = "Supermatter Entrance";
 	network = list("SS13","Engineering")
@@ -10301,7 +10093,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/partial,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /obj/structure/chair/sofa/bench/left,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -10380,7 +10172,7 @@
 /area/bridge)
 "byY" = (
 /obj/machinery/alarm/directional/east,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/computer/general_air_control{
 	frequency = 1443;
 	level = 3;
@@ -10452,9 +10244,7 @@
 	},
 /area/atmos)
 "bzj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/flasher/portable,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -10485,9 +10275,7 @@
 	},
 /area/maintenance/asmaint4)
 "bzr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -10550,9 +10338,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -10569,7 +10355,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/landmark/lightsout,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10591,9 +10377,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/northwestsouth,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "bzL" = (
@@ -10603,11 +10387,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "bzT" = (
@@ -10658,7 +10440,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -10735,7 +10517,7 @@
 /area/bridge/checkpoint/north)
 "bAu" = (
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/reagent_dispensers/oil,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/simulated/floor/plasteel{
@@ -10875,9 +10657,7 @@
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -10906,14 +10686,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "bBj" = (
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "bBn" = (
@@ -10933,9 +10711,7 @@
 	},
 /area/quartermaster/storage)
 "bBt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "bBx" = (
@@ -11020,7 +10796,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/circuitboard/chem_dispenser{
 	pixel_x = -1;
 	pixel_y = 1
@@ -11052,18 +10828,14 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/storage/tech)
 "bBQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/door/poddoor/multi_tile/two_tile_ver{
 	id_tag = "mechanicgate"
 	},
@@ -11133,9 +10905,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "bCl" = (
@@ -11281,7 +11051,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /turf/simulated/floor/plasteel{
@@ -11294,7 +11064,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/pen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -11307,9 +11077,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -11337,7 +11105,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bDw" = (
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
@@ -11378,7 +11146,7 @@
 	},
 /area/bridge)
 "bDS" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -11423,13 +11191,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
-"bEc" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/west)
 "bEe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11442,9 +11203,7 @@
 	},
 /area/bridge/checkpoint/north)
 "bEf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "bEg" = (
@@ -11458,7 +11217,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "bEh" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -11519,8 +11278,8 @@
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
 "bEw" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/plasticflaps/opaque,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/plasticflaps,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
@@ -11529,7 +11288,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
 "bEG" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11613,25 +11372,19 @@
 	},
 /area/engineering/break_room)
 "bEV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "bEX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "bFb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "bFd" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -11648,7 +11401,7 @@
 	pixel_y = 3
 	},
 /obj/item/circuitboard/powermonitor,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -11657,7 +11410,7 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/storage/box/lights/mixed,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -11698,7 +11451,7 @@
 	},
 /area/turret_protected/ai_upload)
 "bFA" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -11873,7 +11626,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -11903,13 +11656,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "bGD" = (
@@ -11941,13 +11692,13 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/storage/tech)
 "bGL" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/rack,
 /obj/item/circuitboard/autolathe{
 	pixel_x = 3;
@@ -11987,7 +11738,7 @@
 "bHd" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/storage/firstaid/regular{
 	pixel_x = 4;
 	pixel_y = 4
@@ -12017,7 +11768,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bHo" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -12191,7 +11942,7 @@
 /obj/machinery/vending/wallmed{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -12268,7 +12019,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "bIP" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	dir = 10;
@@ -12341,7 +12092,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "bJk" = (
@@ -12362,7 +12113,7 @@
 	},
 /area/maintenance/electrical)
 "bJq" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/chair/sofa/bench{
 	dir = 1
 	},
@@ -12385,6 +12136,8 @@
 /area/bridge/checkpoint/north)
 "bJx" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
@@ -12401,7 +12154,7 @@
 	pixel_x = -32
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -12546,9 +12299,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -12583,7 +12334,7 @@
 /area/crew_quarters/kitchen)
 "bKV" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/vending/wallmed{
 	pixel_x = 26
 	},
@@ -12760,10 +12511,8 @@
 /turf/space,
 /area/solar/auxport)
 "bMn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -12827,10 +12576,8 @@
 	},
 /area/bridge/checkpoint/north)
 "bMD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "bME" = (
@@ -12857,7 +12604,7 @@
 /area/ntrep)
 "bMH" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -12883,12 +12630,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"bMU" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "whiteblue"
-	},
-/area/medical/medbay2)
 "bMV" = (
 /obj/machinery/porta_turret{
 	dir = 8
@@ -12915,7 +12656,7 @@
 /area/turret_protected/ai_upload)
 "bNc" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -12954,7 +12695,7 @@
 /area/security/prison/cell_block/A)
 "bNz" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -13039,7 +12780,7 @@
 /area/aisat/aihallway)
 "bNS" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
 "bNT" = (
@@ -13079,9 +12820,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -13111,7 +12850,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -13122,7 +12861,7 @@
 /area/hallway/secondary/entry/commercial)
 "bOq" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -13184,9 +12923,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "bOF" = (
@@ -13211,7 +12948,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -13266,7 +13003,7 @@
 /area/hallway/secondary/entry/lounge)
 "bOU" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bOX" = (
@@ -13290,7 +13027,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/power/smes/full,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -13302,7 +13039,7 @@
 	},
 /area/medical/surgery/north)
 "bPk" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -13323,7 +13060,7 @@
 /area/maintenance/fore)
 "bPr" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -13347,9 +13084,7 @@
 	},
 /area/security/customs)
 "bPw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -13393,7 +13128,7 @@
 /turf/space,
 /area/solar/auxstarboard)
 "bPD" = (
-/obj/effect/turf_decal/delivery/blue,
+/obj/effect/decal/warning_stripes/blue,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -13412,7 +13147,7 @@
 	},
 /area/aisat/maintenance)
 "bPK" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -13456,7 +13191,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/power/emitter/welded{
 	dir = 1
 	},
@@ -13482,9 +13217,7 @@
 /turf/space,
 /area/space)
 "bPV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "bPW" = (
@@ -13503,9 +13236,7 @@
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "bQa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/trinary/tvalve/digital/flipped/bypass,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -13535,9 +13266,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "bQh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/camera{
 	c_tag = "Engineering Access";
 	dir = 4;
@@ -13627,19 +13356,15 @@
 /area/engineering/hardsuitstorage)
 "bQu" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bQw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "bQB" = (
@@ -13673,9 +13398,7 @@
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "bQL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/suit_storage_unit/atmos,
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -13683,9 +13406,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
@@ -13703,7 +13424,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -13729,7 +13450,7 @@
 /area/security/nuke_storage)
 "bQT" = (
 /obj/machinery/floodlight,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light_switch/directional/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -13809,6 +13530,8 @@
 /area/medical/cmo)
 "bRn" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -13958,16 +13681,14 @@
 "bRZ" = (
 /obj/machinery/light/small,
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "bSc" = (
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
@@ -14016,7 +13737,7 @@
 /area/aisat/maintenance)
 "bSt" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -14024,14 +13745,12 @@
 	},
 /area/hallway/primary/port)
 "bSw" = (
-/obj/structure/plasticflaps/opaque,
+/obj/structure/plasticflaps,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "bSy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -14062,7 +13781,7 @@
 /area/crew_quarters/heads/hop)
 "bSH" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -14112,7 +13831,7 @@
 /area/crew_quarters/captain/bedroom)
 "bTo" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -14120,9 +13839,7 @@
 /area/crew_quarters/kitchen)
 "bTs" = (
 /obj/machinery/computer/monitor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Minisat Maintenance Room";
@@ -14137,9 +13854,7 @@
 /area/aisat/maintenance)
 "bTt" = (
 /obj/machinery/cryopod/robot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/computer/cryopod/robot{
 	pixel_y = -28
 	},
@@ -14281,7 +13996,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "bUe" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel,
@@ -14301,13 +14016,13 @@
 /area/quartermaster/storage)
 "bUg" = (
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "bUh" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "bUk" = (
@@ -14439,7 +14154,7 @@
 /area/crew_quarters/locker)
 "bUN" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14535,7 +14250,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -14667,10 +14382,8 @@
 /turf/space,
 /area/solar/auxstarboard)
 "bWd" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/item/extinguisher/mini,
@@ -14703,9 +14416,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -14837,10 +14548,10 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "bWS" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light,
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -14910,10 +14621,8 @@
 	},
 /area/security/detectives_office)
 "bXr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/alarm/directional/north,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -14944,7 +14653,7 @@
 /area/medical/virology/lab)
 "bXD" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -14996,9 +14705,7 @@
 	},
 /area/quartermaster/storage)
 "bXN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/effect/landmark/start/cargo_technician,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -15048,9 +14755,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/medical/psych)
 "bXY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -15079,12 +14784,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Storage";
 	req_access = list(32)
@@ -15118,27 +14819,12 @@
 /turf/simulated/floor/engine/insulated,
 /area/maintenance/asmaint4)
 "bYg" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
-"bYh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/central/sw)
 "bYj" = (
 /turf/simulated/wall,
 /area/library/game_zone)
@@ -15190,9 +14876,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "bYJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bYM" = (
@@ -15225,9 +14909,7 @@
 	name = "Chief Engineer Requests Console";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -15252,42 +14934,55 @@
 "bZl" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "bZn" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "bZt" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "bZv" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -15447,9 +15142,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "cah" = (
@@ -15585,13 +15278,15 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/bar)
 "caL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15599,9 +15294,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "caN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "caP" = (
@@ -15632,9 +15325,7 @@
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "cbc" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cbg" = (
@@ -15646,16 +15337,16 @@
 /area/hallway/secondary/entry/lounge)
 "cbj" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cbk" = (
 /obj/machinery/vending/engivend,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -15732,7 +15423,7 @@
 /area/maintenance/bar)
 "cbx" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cbA" = (
@@ -15751,7 +15442,7 @@
 	name = "Janitoral Delivery";
 	req_access = list(26)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -15815,7 +15506,6 @@
 /turf/simulated/floor/engine/insulated,
 /area/maintenance/asmaint4)
 "cbW" = (
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -15835,9 +15525,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -15849,7 +15537,7 @@
 	},
 /obj/machinery/light_switch/directional/west,
 /obj/structure/closet/wardrobe/atmospherics_yellow,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "caution"
@@ -15874,15 +15562,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "ccg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -15911,9 +15595,7 @@
 	},
 /area/atmos)
 "ccl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -16044,9 +15726,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "ccY" = (
@@ -16173,9 +15853,7 @@
 	},
 /area/bridge)
 "cdQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
 	dir = 8;
@@ -16264,7 +15942,6 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "cet" = (
@@ -16279,7 +15956,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit/maint)
 "cev" = (
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -16357,6 +16034,8 @@
 /area/maintenance/fpmaint)
 "ceT" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16365,7 +16044,7 @@
 	},
 /area/security/permabrig)
 "ceY" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "cfb" = (
@@ -16379,9 +16058,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -16409,10 +16086,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
@@ -16554,7 +16231,7 @@
 /area/medical/medbay)
 "cga" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "cge" = (
@@ -16619,9 +16296,7 @@
 /turf/space,
 /area/space)
 "cgD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
@@ -16879,15 +16554,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "cik" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 4;
@@ -17016,9 +16687,7 @@
 "cjp" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 4;
@@ -17027,9 +16696,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cjs" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -17038,7 +16705,7 @@
 	},
 /area/chapel/main)
 "cjv" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/chair/sofa/bench/right,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -17059,8 +16726,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -17193,7 +16860,7 @@
 /obj/item/storage/pill_bottle/painkillers,
 /obj/item/reagent_containers/food/pill/patch/styptic,
 /obj/item/reagent_containers/food/pill/patch/silver_sulf,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/medical_wall{
 	pixel_x = -32
 	},
@@ -17223,9 +16890,7 @@
 	},
 /area/quartermaster/miningdock)
 "ckK" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -17248,7 +16913,7 @@
 	},
 /area/security/customs)
 "cli" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/power/energy_accumulator/tesla_coil,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -17278,9 +16943,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/clothing/glasses/welding/superior,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/item/flashlight/lamp{
 	layer = 4;
 	pixel_x = 5;
@@ -17306,7 +16969,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "clB" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "clF" = (
@@ -17320,7 +16983,7 @@
 /turf/simulated/floor/grass,
 /area/maintenance/fpmaint)
 "clG" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/gun/energy/ionrifle,
 /obj/structure/rack/gunrack,
 /turf/simulated/floor/plasteel{
@@ -17328,9 +16991,7 @@
 	},
 /area/security/securearmory)
 "clH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17374,7 +17035,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "clQ" = (
-/obj/structure/plasticflaps,
+/obj/structure/plasticflaps/mining,
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "QMLoad2"
@@ -17496,7 +17157,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -17542,7 +17203,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "cna" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/dispenser,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -17568,7 +17229,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -17656,8 +17317,8 @@
 	},
 /area/janitor)
 "cnM" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/commercial)
@@ -17702,15 +17363,11 @@
 	},
 /area/turret_protected/ai)
 "cod" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cof" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "coh" = (
@@ -17784,9 +17441,7 @@
 	},
 /area/atmos)
 "coz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -17896,16 +17551,13 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "neutral"
@@ -17918,14 +17570,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "cpi" = (
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cpl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door_control{
 	id = "engstorage";
 	name = "Engineering Secure Storage Control";
@@ -17950,12 +17602,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "cpr" = (
 /obj/machinery/power/emitter,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -18089,9 +17741,7 @@
 	},
 /area/bridge/vip)
 "cqe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -18151,7 +17801,7 @@
 /turf/simulated/wall,
 /area/quartermaster/miningdock)
 "cqJ" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -18162,6 +17812,8 @@
 /area/toxins/xenobiology)
 "cqQ" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -18169,7 +17821,7 @@
 	dir = 1;
 	network = list("Engineering","SS13")
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "cqT" = (
@@ -18180,7 +17832,7 @@
 /area/janitor)
 "cqU" = (
 /obj/machinery/pipedispenser/disposal,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "cqY" = (
@@ -18222,10 +17874,10 @@
 /obj/machinery/atmospherics/trinary/filter/n2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -18322,7 +17974,7 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/maintenance/banya)
 "crI" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -18330,8 +17982,8 @@
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "crJ" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/plasticflaps,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
@@ -18344,7 +17996,7 @@
 /area/hydroponics)
 "crK" = (
 /obj/machinery/vending/cola,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -18363,7 +18015,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/directional/west,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/crate/engineering{
 	desc = "В ящике хранится оборудование и ресурсы для осуществления ремонта станции гражданским персоналом в случае нужды или безработицы";
 	name = "Ящик оборудования для ремонта"
@@ -18419,9 +18071,7 @@
 /area/library)
 "csf" = (
 /obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "csj" = (
@@ -18437,7 +18087,7 @@
 /area/toxins/sm_test_chamber)
 "cso" = (
 /obj/machinery/power/emitter,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "csp" = (
@@ -18465,9 +18115,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "csG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -18479,18 +18127,14 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "csH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "csJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -18600,9 +18244,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "ctJ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -18614,7 +18256,7 @@
 /area/engineering/controlroom)
 "ctP" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -18681,7 +18323,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -18689,7 +18331,7 @@
 "cun" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -18705,11 +18347,13 @@
 /turf/space,
 /area/space)
 "cup" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding4"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18746,7 +18390,7 @@
 /area/quartermaster/storage)
 "cuB" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
@@ -18758,7 +18402,7 @@
 /area/maintenance/brig)
 "cuE" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/sign/radiation/rad_area{
 	pixel_y = 32
 	},
@@ -18808,9 +18452,7 @@
 	},
 /obj/structure/closet/radiation,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cva" = (
@@ -18842,9 +18484,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/controlroom)
 "cvk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
@@ -18867,7 +18507,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
 /obj/machinery/light_switch/directional/east,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -18971,10 +18610,10 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "cvX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18998,16 +18637,14 @@
 	},
 /area/atmos)
 "cwf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cwk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -19049,16 +18686,14 @@
 /area/quartermaster/miningdock)
 "cwy" = (
 /obj/machinery/vending/tool,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/engineering/hardsuitstorage)
 "cwz" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/rack,
 /obj/item/floor_painter{
 	pixel_x = -6;
@@ -19098,6 +18733,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -19218,17 +18854,17 @@
 /area/hallway/primary/central/se)
 "cxh" = (
 /obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/hydroponics)
 "cxk" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -19305,14 +18941,13 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -19392,7 +19027,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -19426,9 +19061,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "cxZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 8;
@@ -19437,9 +19070,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cya" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/binary/volume_pump{
 	desc = "Отправляет неотфильтрованные газы в отходы на повторную фильтрацию";
 	dir = 4;
@@ -19485,7 +19116,7 @@
 	},
 /area/storage/eva)
 "cyl" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -19530,7 +19161,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port/west)
 "cyw" = (
@@ -19699,9 +19330,7 @@
 /turf/simulated/floor/carpet/red,
 /area/maintenance/casino)
 "czw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/field/generator/anchored,
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -19736,9 +19365,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "czE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/binary/volume_pump{
 	desc = "Позволяет опустошить трубу дыхательной смеси, отправив её в отходы на повторную фильтрацию";
 	dir = 4;
@@ -19747,10 +19374,8 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "czG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "czK" = (
@@ -19766,13 +19391,11 @@
 /area/maintenance/casino)
 "czQ" = (
 /obj/machinery/recharge_station,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "czR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -19960,11 +19583,9 @@
 	},
 /area/hallway/primary/port/west)
 "cAD" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -20037,7 +19658,7 @@
 /area/blueshield)
 "cBk" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
 "cBo" = (
@@ -20106,7 +19727,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -20118,7 +19739,7 @@
 "cBI" = (
 /obj/machinery/light/small,
 /obj/effect/landmark/start/civilian,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/door_control{
 	desiredstate = 1;
 	id = "toilet1";
@@ -20137,9 +19758,7 @@
 	id_tag = "janitorshutters";
 	name = "Janitor Shutters"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
@@ -20173,10 +19792,8 @@
 /turf/space,
 /area/solar/auxport)
 "cCd" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
@@ -20195,7 +19812,7 @@
 	name = "Engineering Maintenance";
 	req_access = list(10)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/maintenance/engineering)
@@ -20217,7 +19834,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -20289,9 +19905,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -20355,9 +19969,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/binary/pump{
 	name = "Gas to Turbine"
 	},
@@ -20367,9 +19979,7 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "cCT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -20386,9 +19996,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -20418,16 +20026,14 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "cDe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/vending/wallmed{
 	pixel_y = -32
 	},
@@ -20481,11 +20087,11 @@
 "cDv" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "cDx" = (
@@ -20534,7 +20140,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "cDF" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -20546,7 +20152,7 @@
 /area/engineering/controlroom)
 "cDG" = (
 /obj/machinery/vending/tool,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "cDH" = (
@@ -20558,9 +20164,7 @@
 	},
 /area/turret_protected/ai)
 "cDI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
@@ -20576,9 +20180,7 @@
 	id = "portsolar";
 	name = "South-West Solar Control"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "cDO" = (
@@ -20588,10 +20190,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
@@ -20690,7 +20292,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -20704,6 +20306,7 @@
 	icon_state = "grass_edge_medium"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -20915,12 +20518,8 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "cFG" = (
@@ -20985,6 +20584,7 @@
 	},
 /obj/item/reagent_containers/spray/waterflower,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -20992,10 +20592,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -21032,7 +20632,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -21065,9 +20665,7 @@
 	dir = 8;
 	name = "Nitrogen to Loop"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "cGx" = (
@@ -21134,7 +20732,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cHb" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -21249,7 +20847,7 @@
 /area/bridge)
 "cHU" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "red"
@@ -21321,9 +20919,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -21380,7 +20976,7 @@
 	name = "Tech Storage";
 	req_access = list(23)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -21407,9 +21003,7 @@
 	},
 /area/engineering/break_room)
 "cIE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -21423,9 +21017,7 @@
 /area/medical/chemistry)
 "cIG" = (
 /obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -21490,7 +21082,7 @@
 /obj/item/crowbar,
 /obj/item/wrench,
 /obj/item/gps,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "cJc" = (
@@ -21612,7 +21204,6 @@
 	},
 /area/maintenance/asmaint4)
 "cJD" = (
-/obj/effect/landmark/start/hangover,
 /obj/machinery/door/window/southleft{
 	name = "Bar Delivery";
 	req_access = list(25)
@@ -21653,15 +21244,11 @@
 	},
 /area/engineering/gravitygenerator)
 "cJI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "cJJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "cJK" = (
@@ -21677,7 +21264,7 @@
 /area/toxins/sm_test_chamber)
 "cJL" = (
 /obj/machinery/power/port_gen/pacman,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "cJN" = (
@@ -21700,9 +21287,7 @@
 "cJY" = (
 /obj/machinery/light/small,
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "cKb" = (
@@ -21720,6 +21305,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -21747,9 +21333,7 @@
 "cKf" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -21774,7 +21358,7 @@
 	},
 /area/storage/primary)
 "cKq" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -21807,7 +21391,7 @@
 /obj/structure/chair/comfy/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -21903,7 +21487,7 @@
 "cKW" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/double,
-/obj/effect/turf_decal/delivery/hollow/right,
+/obj/effect/turf_decal/bot/right,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -21942,9 +21526,7 @@
 	id = "QMLoad2";
 	name = "Download"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "cLj" = (
@@ -21981,9 +21563,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/rack,
 /obj/item/crowbar,
 /obj/item/storage/toolbox/mechanical,
@@ -21997,15 +21577,11 @@
 	},
 /area/maintenance/asmaint4)
 "cLC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "cLF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -22015,9 +21591,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -22034,9 +21608,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -22079,9 +21651,7 @@
 /area/hydroponics)
 "cMc" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cMi" = (
@@ -22108,7 +21678,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "cMp" = (
@@ -22274,7 +21844,6 @@
 	dir = 1
 	},
 /obj/effect/spawner/random_spawners/rodent,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whiteblue"
@@ -22503,7 +22072,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -22579,9 +22148,7 @@
 /obj/structure/chair/comfy/purp{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -22595,7 +22162,7 @@
 	},
 /area/maintenance/electrical)
 "cPg" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cautioncorner"
@@ -22623,18 +22190,11 @@
 	},
 /turf/simulated/floor/engine,
 /area/maintenance/turbine)
-"cPp" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "redcorner"
-	},
-/area/security/lobby)
 "cPq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
@@ -22709,7 +22269,7 @@
 	},
 /area/engineering/controlroom)
 "cPE" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/engine,
 /area/medical/chemistry)
@@ -22728,6 +22288,7 @@
 "cPG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -22754,7 +22315,7 @@
 	},
 /area/maintenance/banya)
 "cPK" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -22805,9 +22366,7 @@
 	},
 /area/medical/medbay2)
 "cPX" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -22919,8 +22478,8 @@
 	},
 /area/toxins/test_chamber)
 "cQB" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/plasticflaps/opaque,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/plasticflaps,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	location = "Mime"
@@ -22992,9 +22551,7 @@
 /obj/structure/chair/comfy/purp{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
@@ -23063,7 +22620,7 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
 /obj/item/lightreplacer,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -23119,7 +22676,7 @@
 	},
 /area/medical/chemistry)
 "cRj" = (
-/obj/effect/turf_decal/delivery/blue,
+/obj/effect/decal/warning_stripes/blue,
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
@@ -23227,14 +22784,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "cRK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -23242,10 +22797,8 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "cRU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/window/plasmareinforced{
 	dir = 1
 	},
@@ -23289,7 +22842,7 @@
 	},
 /area/toxins/test_chamber)
 "cSb" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "browncorner"
 	},
@@ -23306,14 +22859,14 @@
 "cSd" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/chocolate,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
 /area/medical/research/restroom)
 "cSe" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -23326,7 +22879,7 @@
 	},
 /area/quartermaster/storage)
 "cSh" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "cSo" = (
@@ -23351,10 +22904,10 @@
 /area/maintenance/asmaint2)
 "cSx" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -23418,15 +22971,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "cSI" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/biogenerator,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -23591,7 +23142,7 @@
 	},
 /area/maintenance/tourist)
 "cTM" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/drone_fabricator,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -23607,7 +23158,7 @@
 	},
 /area/toxins/xenobiology)
 "cTR" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -23628,9 +23179,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/computer/rdconsole/core,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -23640,7 +23189,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "cTZ" = (
@@ -23813,7 +23362,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/flashlight,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -23842,7 +23391,7 @@
 /area/hallway/primary/fore)
 "cUQ" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "cUS" = (
@@ -23865,7 +23414,7 @@
 "cUW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -23877,9 +23426,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -23891,9 +23438,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/r_n_d/protolathe{
 	pixel_y = 2
 	},
@@ -23944,7 +23489,7 @@
 	},
 /area/atmos)
 "cVs" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -23960,7 +23505,7 @@
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/delivery/blue,
+/obj/effect/decal/warning_stripes/blue,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -24015,7 +23560,7 @@
 	},
 /area/medical/chemistry)
 "cVO" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -24086,7 +23631,7 @@
 /area/crew_quarters/sleep)
 "cVZ" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -24135,7 +23680,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "cWn" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -24159,7 +23704,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -24228,7 +23773,7 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "cWJ" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
@@ -24369,7 +23914,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -24431,17 +23975,15 @@
 	network = list("Engineering","SS13");
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/computer/card/minor/ce,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/crew_quarters/chief)
 "cXT" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/plasticflaps/opaque,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/plasticflaps,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	location = "Clown"
@@ -24704,7 +24246,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -24744,7 +24286,7 @@
 /area/hallway/secondary/entry)
 "cZl" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -24797,14 +24339,14 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/storage/tech)
 "cZr" = (
-/obj/effect/turf_decal/arrows/black,
-/obj/effect/turf_decal/delivery/partial,
+/obj/effect/decal/warning_stripes/arrow,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "purple"
@@ -24812,9 +24354,7 @@
 /area/hallway/primary/aft)
 "cZu" = (
 /obj/machinery/computer/rdconsole/core,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -24836,9 +24376,7 @@
 	name = "Research Division Access";
 	req_access = list(47)
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "cZE" = (
@@ -25304,7 +24842,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "dcB" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/window/reinforced,
 /obj/effect/spawner/random_spawners/security_ballistics,
 /turf/simulated/floor/plasteel{
@@ -25358,7 +24896,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/plasticflaps/kitchen,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -25439,7 +24976,7 @@
 /area/toxins/xenobiology)
 "ddb" = (
 /obj/structure/closet/bombcloset,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -25501,9 +25038,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/computer/security/engineering,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25520,7 +25055,6 @@
 	},
 /area/medical/research/nhallway)
 "ddr" = (
-/obj/effect/landmark/start/hangover,
 /obj/structure/railing{
 	dir = 4
 	},
@@ -25541,9 +25075,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "ddx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
@@ -25605,7 +25137,7 @@
 	},
 /area/medical/paramedic)
 "ddO" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "ddR" = (
@@ -25685,11 +25217,9 @@
 /turf/space,
 /area/space)
 "dex" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/door/airlock/external{
 	hackProof = 1;
 	id_tag = "emergency_home";
@@ -25727,10 +25257,8 @@
 	},
 /area/crew_quarters/theatre)
 "deF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /obj/structure/window/plasmareinforced,
@@ -25848,7 +25376,7 @@
 /turf/simulated/floor/wood,
 /area/maintenance/tourist)
 "dfa" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -25858,9 +25386,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "dff" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -25879,9 +25405,7 @@
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
 "dfj" = (
@@ -25896,7 +25420,7 @@
 /area/toxins/test_chamber)
 "dfk" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -25906,7 +25430,7 @@
 /turf/simulated/wall/r_wall,
 /area/assembly/chargebay)
 "dfn" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -25987,10 +25511,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/door_control{
 	id = "xeno7";
 	name = "Containment Control";
@@ -26004,12 +25526,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "dfQ" = (
@@ -26076,15 +25594,11 @@
 /obj/machinery/portable_atmospherics/canister/air{
 	filled = 0.05
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "dfY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/chair/office/light{
 	dir = 4;
 	pixel_y = 3
@@ -26135,7 +25649,7 @@
 /area/maintenance/asmaint3)
 "dge" = (
 /obj/structure/table,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light,
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
@@ -26148,8 +25662,7 @@
 	frequency = 1379;
 	id_tag = "engineering_west_pump"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/walllocker/emerglocker/directional/north,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "dgk" = (
@@ -26315,6 +25828,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -26437,10 +25951,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/firealarm/directional/east,
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel{
@@ -26464,12 +25976,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -26576,6 +26084,7 @@
 	icon_state = "grass_edge_medium_corner"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -26619,9 +26128,7 @@
 	},
 /area/hallway/primary/aft)
 "dio" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -26641,7 +26148,7 @@
 /area/chapel/main)
 "dis" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atm{
 	pixel_y = 32
 	},
@@ -26705,7 +26212,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -26739,9 +26246,7 @@
 	},
 /area/maintenance/asmaint4)
 "diQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -26779,12 +26284,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "djb" = (
@@ -26843,7 +26344,7 @@
 /area/atmos)
 "djt" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -26851,7 +26352,7 @@
 	},
 /area/toxins/mixing)
 "dju" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/dispenser,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -26859,9 +26360,7 @@
 	},
 /area/toxins/mixing)
 "djw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
 	},
@@ -26870,9 +26369,7 @@
 	},
 /area/toxins/mixing)
 "djx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
@@ -26921,9 +26418,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "djT" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastsouth,
 /obj/vehicle/ridden/ambulance{
 	dir = 4
 	},
@@ -27053,7 +26548,7 @@
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
 "dkt" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -27082,7 +26577,7 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/maintenance/asmaint3)
 "dkw" = (
-/obj/structure/plasticflaps,
+/obj/structure/plasticflaps/mining,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "QMLoad"
@@ -27111,9 +26606,7 @@
 	},
 /area/toxins/xenobiology)
 "dkF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
@@ -27131,7 +26624,7 @@
 	pixel_x = -30;
 	pixel_y = -2
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/papershredder,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
@@ -27140,12 +26633,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/mecha,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "dkP" = (
 /obj/structure/table,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/folder/blue{
 	pixel_x = 5
 	},
@@ -27176,9 +26669,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/serviceyard)
 "dkS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "dkX" = (
@@ -27205,9 +26696,7 @@
 /obj/machinery/photocopier/faxmachine/longrange{
 	department = "Chief Engineer's Office"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -27218,7 +26707,7 @@
 	name = "Kitchen Delivery";
 	req_access = list(28)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
 "dle" = (
@@ -27423,7 +26912,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/computer/robotics,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
@@ -27437,11 +26926,11 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Singularity";
 	name = "Singularity Blast Doors"
@@ -27592,7 +27081,7 @@
 	layer = 3.3;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -27672,9 +27161,7 @@
 	pixel_y = 25;
 	req_access = list(32)
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "dmU" = (
@@ -27728,9 +27215,7 @@
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
 "dnn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
 	},
@@ -27765,9 +27250,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -27782,7 +27265,7 @@
 	name = "Atmospherics Access";
 	req_access = list(24)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -27815,9 +27298,7 @@
 	},
 /area/medical/genetics)
 "dnI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -27892,9 +27373,7 @@
 /area/crew_quarters/heads/hop)
 "dog" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /obj/item/rcd_ammo,
 /obj/item/rcd_ammo,
 /obj/item/rcd_ammo,
@@ -27937,9 +27416,7 @@
 /area/maintenance/detectives_office)
 "dom" = (
 /obj/machinery/computer/sm_monitor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -27976,7 +27453,7 @@
 /area/crew_quarters/chief)
 "doy" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -28135,6 +27612,7 @@
 "dpg" = (
 /obj/structure/statue/tranquillite/mime/unique,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -28286,12 +27764,8 @@
 	},
 /area/quartermaster/office)
 "dpY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "roboticsshutters";
@@ -28374,7 +27848,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/delivery)
 "dqw" = (
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
 /turf/simulated/floor/plasteel{
@@ -28382,7 +27856,7 @@
 	},
 /area/quartermaster/storage)
 "dqx" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	dir = 4;
@@ -28477,9 +27951,7 @@
 /area/crew_quarters/courtroom)
 "dri" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "drl" = (
@@ -28525,15 +27997,13 @@
 	},
 /area/medical/research/nhallway)
 "drv" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "drC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -28589,7 +28059,7 @@
 	req_access = list(29)
 	},
 /obj/machinery/door/window/eastleft,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "RoboDesk";
 	name = "Robotics Privacy Shutter"
@@ -28671,7 +28141,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "dsk" = (
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	dir = 8;
@@ -28717,16 +28187,14 @@
 	},
 /area/aisat/aihallway)
 "dsE" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/assembly/robotics)
 "dsG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -29029,9 +28497,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29039,9 +28505,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "duf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "duh" = (
@@ -29058,7 +28522,7 @@
 	amount = 50
 	},
 /obj/machinery/alarm/directional/west,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/stack/sheet/metal{
 	amount = 10
 	},
@@ -29091,7 +28555,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -29115,13 +28579,6 @@
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/qm)
-"duz" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/locker)
 "duI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -29154,7 +28611,7 @@
 /area/crew_quarters/trading)
 "duN" = (
 /obj/machinery/smartfridge/drying_rack,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -29236,7 +28693,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "dvg" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/machine{
 	pixel_x = 4;
@@ -29327,8 +28784,9 @@
 /area/medical/morgue)
 "dvA" = (
 /obj/machinery/power/terminal,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -29407,6 +28865,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -29443,9 +28902,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -29487,11 +28944,11 @@
 /area/engineering/engine)
 "dwt" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "dwu" = (
@@ -29515,9 +28972,7 @@
 	},
 /area/medical/morgue)
 "dwv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -29676,7 +29131,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/lounge)
 "dwW" = (
@@ -29688,12 +29142,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/telepad_cargo,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -29712,7 +29166,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/plasticflaps/kitchen,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -29749,11 +29202,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -29789,7 +29242,7 @@
 	},
 /area/tcommsat/chamber)
 "dxu" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/westleft{
 	dir = 4;
 	name = "Robotic Delivery";
@@ -29925,7 +29378,7 @@
 	network = list("Research","SS13");
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
@@ -29944,12 +29397,8 @@
 "dyv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "dyy" = (
@@ -29984,9 +29433,7 @@
 /turf/simulated/floor/bluegrid/telecomms/mainframe/gcircuit,
 /area/toxins/server)
 "dyI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "dza" = (
@@ -30002,20 +29449,18 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/maintenance/turbine)
 "dzf" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	location = "Chemistry"
 	},
-/obj/structure/plasticflaps/opaque,
+/obj/structure/plasticflaps,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -30041,7 +29486,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -30138,8 +29583,8 @@
 /area/engineering/controlroom)
 "dzA" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "caution"
@@ -30147,27 +29592,23 @@
 /area/toxins/storage)
 "dzC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "dzD" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "escape"
 	},
 /area/toxins/storage)
 "dzE" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
@@ -30189,7 +29630,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "dzQ" = (
-/obj/effect/turf_decal/delivery/partial,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -30223,9 +29664,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
@@ -30289,10 +29728,8 @@
 /turf/simulated/floor/engine/co2,
 /area/atmos)
 "dAN" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/item/extinguisher/mini,
@@ -30342,7 +29779,7 @@
 	},
 /area/medical/genetics)
 "dAZ" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
@@ -30420,25 +29857,29 @@
 /area/medical/virology/lab)
 "dBt" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/landmark/start/engineer,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "dBu" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/sign/electricshock{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -30454,7 +29895,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "dBB" = (
@@ -30477,9 +29918,7 @@
 	},
 /area/library/game_zone)
 "dBF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -30511,9 +29950,7 @@
 /area/library)
 "dBN" = (
 /obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -30550,7 +29987,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "dCc" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -30824,9 +30261,7 @@
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/hop)
 "dDn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/chem_master,
 /turf/simulated/floor/engine,
 /area/medical/chemistry)
@@ -30842,9 +30277,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
@@ -30857,9 +30290,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "dDv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -30894,9 +30325,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "dDO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -30906,11 +30335,11 @@
 /area/atmos)
 "dDP" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "dDQ" = (
@@ -30987,9 +30416,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "dEm" = (
@@ -31025,7 +30452,7 @@
 /area/maintenance/fpmaint)
 "dEH" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "bluefull"
 	},
@@ -31295,10 +30722,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -31333,7 +30758,7 @@
 /area/maintenance/fpmaint)
 "dGe" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
 "dGi" = (
@@ -31396,9 +30821,7 @@
 	},
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "dGB" = (
@@ -31437,9 +30860,7 @@
 	},
 /area/quartermaster/storage)
 "dGQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "dGR" = (
@@ -31535,7 +30956,7 @@
 	layer = 2.9
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/random/toolbox,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -31543,22 +30964,16 @@
 	},
 /area/maintenance/brig)
 "dHp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "dHq" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "dHr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "dHs" = (
@@ -31731,7 +31146,7 @@
 	},
 /area/solar/starboard)
 "dHZ" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -31765,6 +31180,7 @@
 	},
 /obj/item/soap/homemade_banana,
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
@@ -31948,9 +31364,7 @@
 /area/maintenance/turbine)
 "dJi" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "dJk" = (
@@ -31965,10 +31379,10 @@
 	},
 /area/atmos)
 "dJl" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
 /obj/effect/landmark/start/shaft_miner,
@@ -32048,7 +31462,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
 "dJW" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -32083,10 +31497,8 @@
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/secondary/exit)
 "dKm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/item/extinguisher/mini,
@@ -32145,7 +31557,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -32406,8 +31818,9 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "dLM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding2"
 	},
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -32426,7 +31839,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -32487,7 +31900,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitegreencorner"
@@ -32548,7 +31961,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit/maint)
 "dMn" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -32646,7 +32059,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "dMK" = (
@@ -32730,7 +32143,7 @@
 	dir = 8
 	},
 /obj/item/wirecutters,
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -32739,9 +32152,7 @@
 	},
 /area/security/permabrig)
 "dNr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "dNt" = (
@@ -32763,6 +32174,7 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -32897,7 +32309,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/hop)
 "dNP" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -32923,9 +32335,7 @@
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper/precision,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -32933,9 +32343,7 @@
 /area/medical/virology/lab)
 "dNX" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /obj/item/paper_bin,
 /obj/item/pen/red,
 /obj/structure/window/reinforced/polarized{
@@ -33110,12 +32518,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "dOZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "dPa" = (
@@ -33238,7 +32647,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "dPO" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/flasher{
 	id = "hopflash";
 	pixel_x = 58
@@ -33266,7 +32675,7 @@
 /area/hallway/secondary/entry/lounge)
 "dPX" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -33378,9 +32787,7 @@
 	},
 /area/turret_protected/ai)
 "dQq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -33402,9 +32809,7 @@
 	},
 /area/hallway/secondary/entry)
 "dQy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "dQz" = (
@@ -33429,11 +32834,6 @@
 	icon_state = "neutral"
 	},
 /area/crew_quarters/fitness)
-"dQD" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/structure/closet/secure_closet/engineering_personal,
-/turf/simulated/floor/plasteel,
-/area/engineering/engine)
 "dQF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33646,7 +33046,7 @@
 	id_tag = "eva-shutters";
 	name = "E.V.A. Storage Shutters"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -33690,7 +33090,7 @@
 /area/security/permabrig)
 "dSc" = (
 /obj/structure/closet/coffin,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -33777,9 +33177,7 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "dSB" = (
@@ -33806,9 +33204,7 @@
 	},
 /area/medical/research/nhallway)
 "dSF" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -33954,7 +33350,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1379;
@@ -34015,7 +33411,7 @@
 /area/turret_protected/ai)
 "dTO" = (
 /obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -34048,7 +33444,7 @@
 	locked = 1;
 	name = "Arrivals External Access"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
 "dUc" = (
@@ -34140,9 +33536,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/power/apc/directional/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
@@ -34193,7 +33587,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "dUI" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "dUJ" = (
@@ -34257,9 +33651,7 @@
 	},
 /area/atmos)
 "dVa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -34285,9 +33677,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "dVi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 4;
@@ -34319,7 +33709,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -34368,7 +33758,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/junction/reversed{
@@ -34469,7 +33859,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil/random,
 /obj/item/reagent_containers/spray/cleaner{
@@ -34491,7 +33881,7 @@
 	},
 /area/hydroponics)
 "dWc" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "dWd" = (
@@ -34507,7 +33897,7 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/xenobiology)
 "dWh" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/requests_console{
 	department = "Hydroponics";
 	departmentType = 2;
@@ -34516,7 +33906,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/smartfridge/disks,
-/obj/effect/turf_decal/delivery/green,
+/obj/effect/decal/warning_stripes/green,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -34539,7 +33929,7 @@
 /area/hallway/primary/aft)
 "dWk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -34596,9 +33986,7 @@
 /area/bridge/vip)
 "dWy" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "dWz" = (
@@ -34630,9 +34018,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "dWE" = (
@@ -34687,7 +34073,7 @@
 	},
 /area/medical/cryo)
 "dWQ" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -34811,7 +34197,7 @@
 /area/solar/auxstarboard)
 "dXr" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light_switch/directional/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -34845,9 +34231,7 @@
 	req_access = list(13)
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "dXx" = (
@@ -34861,7 +34245,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
 "dXy" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
 "dXz" = (
@@ -35025,10 +34409,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -35089,9 +34471,7 @@
 	},
 /area/crew_quarters/theatre)
 "dYt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
@@ -35111,7 +34491,7 @@
 	},
 /area/aisat/aihallway)
 "dYz" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	name = "Труба обработки"
@@ -35134,7 +34514,7 @@
 	},
 /area/turret_protected/ai)
 "dYE" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	dir = 4;
@@ -35143,7 +34523,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dYJ" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 6;
@@ -35205,7 +34585,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "dYY" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 4;
@@ -35220,7 +34600,7 @@
 	},
 /area/crew_quarters/fitness)
 "dZb" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "dZc" = (
@@ -35298,9 +34678,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Airlock"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "dZq" = (
@@ -35328,7 +34706,7 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/clothing/glasses/hud/hydroponic,
 /obj/item/clothing/glasses/hud/hydroponic,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/sign/botany{
 	pixel_y = -32
 	},
@@ -35349,7 +34727,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -35360,7 +34738,7 @@
 /obj/item/paper/pamphlet,
 /obj/item/paper/pamphlet,
 /obj/item/paper/pamphlet,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -35444,9 +34822,7 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "dZM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -35476,9 +34852,7 @@
 	},
 /area/atmos)
 "dZU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -35529,9 +34903,7 @@
 	},
 /area/medical/sleeper)
 "eap" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -35574,7 +34946,7 @@
 	},
 /area/medical/virology/lab)
 "eaC" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/bombcloset,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -35703,10 +35075,10 @@
 	},
 /area/hallway/secondary/exit)
 "ebV" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -35735,7 +35107,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -35752,6 +35124,8 @@
 "eci" = (
 /obj/effect/landmark/start/engineer,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -35791,9 +35165,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitehall"
@@ -35808,9 +35180,7 @@
 	},
 /area/maintenance/consarea_virology)
 "edj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/item/beacon,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -35931,6 +35301,7 @@
 	icon_state = "grass_edge_medium_corner"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -35950,7 +35321,6 @@
 	dir = 10;
 	initialize_directions = 10
 	},
-/obj/structure/plasticflaps/kitchen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -35963,7 +35333,7 @@
 /turf/simulated/floor/engine/air,
 /area/atmos)
 "eeG" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -36012,6 +35382,8 @@
 /area/security/permabrig)
 "efA" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
@@ -36133,9 +35505,7 @@
 "egU" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/storage/box/masks,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
 	dir = 1;
@@ -36254,7 +35624,7 @@
 /area/medical/virology/lab)
 "ehV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -36324,9 +35694,7 @@
 	},
 /area/security/permabrig)
 "eiw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -36356,7 +35724,7 @@
 	},
 /area/maintenance/bar)
 "eiO" = (
-/obj/structure/plasticflaps/opaque,
+/obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "cargodelivery"
@@ -36397,7 +35765,7 @@
 	},
 /area/hallway/primary/fore)
 "ejf" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -36440,9 +35808,13 @@
 /area/security/prison/cell_block/A)
 "ejp" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
@@ -36450,9 +35822,7 @@
 	},
 /area/engineering/engine)
 "ejB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -36517,7 +35887,7 @@
 	dir = 1;
 	req_access = list(10)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "ekj" = (
@@ -36623,12 +35993,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/medical/genetics)
-"ekX" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/crew_quarters/bar)
 "elh" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -36664,9 +36028,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -36677,9 +36039,7 @@
 	},
 /area/medical/morgue)
 "ely" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -36704,7 +36064,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -36846,9 +36205,7 @@
 	},
 /area/maintenance/asmaint4)
 "enO" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	name = "Труба обработки"
@@ -36893,7 +36250,7 @@
 /obj/item/wrench,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light_switch/directional/south,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/paper/gravity_gen,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -36902,8 +36259,8 @@
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "eoB" = (
@@ -36978,7 +36335,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/serviceyard)
 "eoV" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -37008,9 +36365,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -37103,9 +36458,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "eqN" = (
@@ -37126,9 +36479,7 @@
 	},
 /area/quartermaster/office)
 "eqO" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -37250,7 +36601,7 @@
 /obj/item/tank/jetpack/oxygen,
 /obj/item/tank/internals/oxygen,
 /obj/item/clothing/shoes/magboots,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/alarm/directional/south,
 /obj/machinery/camera{
 	c_tag = "Brig Pilot Office";
@@ -37270,9 +36621,7 @@
 	c_tag = "Engine Room North";
 	network = list("Engineering","SS13")
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_y = 28
@@ -37337,9 +36686,7 @@
 /area/maintenance/kitchen)
 "esz" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37366,8 +36713,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -37444,13 +36791,10 @@
 	},
 /area/turret_protected/ai_upload)
 "etE" = (
-/obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
@@ -37489,7 +36833,7 @@
 /obj/item/seeds/carrot,
 /obj/item/seeds/carrot,
 /obj/item/seeds/carrot,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -37558,7 +36902,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin2)
 "ewi" = (
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurplecorner"
@@ -37603,7 +36946,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/securehallway)
 "ewF" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_y = -32
 	},
@@ -37613,9 +36956,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "exh" = (
@@ -37705,9 +37046,7 @@
 /area/chapel/office)
 "eyi" = (
 /obj/structure/morgue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/effect/landmark/spawner/revenant,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -37868,11 +37207,11 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "eAm" = (
@@ -37911,7 +37250,7 @@
 	},
 /area/turret_protected/ai_upload)
 "eAH" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -37938,13 +37277,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/security/visiting_room)
-"eBf" = (
-/obj/structure/closet/walllocker/emerglocker/directional/north,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
-	},
-/area/hallway/secondary/entry)
 "eBo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -37998,13 +37330,12 @@
 /obj/effect/decal/cleanable/dust,
 /obj/structure/grille/broken,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "eBF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/door_control{
 	id = "engsm";
 	name = "Supermatter Blast Doors";
@@ -38127,9 +37458,7 @@
 	},
 /area/security/brig)
 "eDV" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -38153,10 +37482,8 @@
 /area/security/permabrig)
 "eEq" = (
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -38317,9 +37644,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "eGd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/chair/office/light{
 	dir = 8
 	},
@@ -38341,7 +37666,7 @@
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
 	id_tag = "paramedic";
@@ -38356,7 +37681,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/effect/turf_decal/delivery/red/partial{
+/obj/effect/decal/warning_stripes/red/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -38398,7 +37723,7 @@
 "eGT" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -38570,9 +37895,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /obj/item/tank/internals/emergency_oxygen/engi,
@@ -38601,7 +37924,7 @@
 /turf/simulated/wall/r_wall,
 /area/atmos)
 "eJl" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/rack,
 /obj/item/flashlight{
 	pixel_x = -6;
@@ -38636,7 +37959,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "eJs" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/binary/volume_pump/on{
 	desc = "Возвращает газ после обработки в трубу смешивания";
 	name = "Выход газа после обработки"
@@ -38667,11 +37990,11 @@
 "eJG" = (
 /obj/machinery/power/energy_accumulator/tesla_coil,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "eJH" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/clothing/glasses/meson{
 	pixel_x = -6;
 	pixel_y = 4
@@ -38796,10 +38119,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/west)
-"eKF" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/engine,
-/area/toxins/test_chamber)
 "eLf" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -38881,9 +38200,7 @@
 	},
 /area/atmos)
 "eLT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -38964,6 +38281,8 @@
 /area/atmos)
 "eMv" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -38989,7 +38308,7 @@
 	},
 /area/medical/virology/lab)
 "eMA" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
 	id = "garbage";
@@ -39022,7 +38341,7 @@
 	},
 /area/library)
 "eMM" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	dir = 6;
@@ -39086,7 +38405,7 @@
 	},
 /area/crew_quarters/locker)
 "eNs" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit/maint)
@@ -39167,9 +38486,7 @@
 	},
 /area/hallway/primary/central/sw)
 "eNZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -39208,9 +38525,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "eOC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
@@ -39276,7 +38591,7 @@
 	},
 /area/medical/virology/lab)
 "ePl" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	name = "Труба на фильтрацию"
@@ -39321,9 +38636,11 @@
 	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "ePU" = (
@@ -39416,11 +38733,11 @@
 /turf/simulated/floor/plasteel,
 /area/security/permahallway)
 "eRa" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "eRh" = (
@@ -39449,15 +38766,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "eRN" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -39476,16 +38793,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"eRT" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/starboard/east)
 "eRU" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -39533,7 +38843,7 @@
 /area/maintenance/asmaint4)
 "eSQ" = (
 /obj/machinery/power/energy_accumulator/tesla_coil,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "eTb" = (
@@ -39548,7 +38858,7 @@
 /area/crew_quarters/serviceyard)
 "eTe" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -39643,6 +38953,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -39764,8 +39075,7 @@
 	},
 /area/maintenance/asmaint4)
 "eUJ" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/chair/sofa/bench,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -39820,9 +39130,7 @@
 /area/crew_quarters/locker)
 "eVB" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -39921,12 +39229,8 @@
 	},
 /area/crew_quarters/serviceyard)
 "eWC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
@@ -39938,16 +39242,14 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "eWN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -40016,7 +39318,7 @@
 /area/toxins/explab)
 "eXm" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -40029,9 +39331,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "eXx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "eXz" = (
@@ -40079,7 +39379,7 @@
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/flashlight,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -40217,7 +39517,7 @@
 	},
 /area/quartermaster/office)
 "eYR" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel,
@@ -40352,9 +39652,7 @@
 	},
 /area/maintenance/electrical)
 "faG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -40372,7 +39670,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -40399,7 +39697,7 @@
 /area/security/customs)
 "faZ" = (
 /obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -40433,7 +39731,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -40522,7 +39820,7 @@
 	},
 /area/crew_quarters/locker)
 "fcP" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -40639,7 +39937,7 @@
 	desc = "A machine used to process slimes and retrieve their extract.";
 	name = "Slime Processor"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light_switch/directional/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -40678,10 +39976,8 @@
 /area/medical/cmostore)
 "feE" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
@@ -40757,6 +40053,7 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/window/plasmareinforced{
@@ -40788,11 +40085,11 @@
 "ffP" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "ffQ" = (
@@ -40809,7 +40106,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/disposalpipe/junction/reversed,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -40865,7 +40161,7 @@
 /area/security/permabrig)
 "fgz" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -40921,10 +40217,8 @@
 	},
 /area/medical/medbay2)
 "fgG" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -40988,24 +40282,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/security/range)
-"fhN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull"
-	},
-/area/medical/sleeper)
 "fhP" = (
 /obj/structure/table/wood,
 /obj/effect/mapping_helpers/table_flip{
@@ -41021,7 +40297,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -41092,7 +40368,7 @@
 	},
 /obj/structure/table,
 /obj/item/analyzer,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -41102,7 +40378,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
 /obj/machinery/light_switch/directional/east,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/hop)
 "fiS" = (
@@ -41118,7 +40393,7 @@
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "fiU" = (
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -41156,7 +40431,6 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint)
 "fjw" = (
-/obj/effect/landmark/start/hangover,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
@@ -41238,7 +40512,7 @@
 /area/crew_quarters/fitness)
 "fjY" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "fkf" = (
@@ -41250,9 +40524,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "fkh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/closet/walllocker{
 	pixel_y = 28
 	},
@@ -41306,7 +40578,7 @@
 /obj/item/seeds/wheat/rice,
 /obj/item/seeds/wheat/rice,
 /obj/item/seeds/wheat/rice,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -41340,9 +40612,7 @@
 	},
 /area/aisat/aihallway)
 "fkX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -41352,7 +40622,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/east,
 /obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/camera{
 	c_tag = "Toxins Gas Storage";
 	dir = 8;
@@ -41449,9 +40719,7 @@
 	},
 /area/aisat/aihallway)
 "fmF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel{
@@ -41611,9 +40879,7 @@
 	c_tag = "Cargo Supply South";
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "fnY" = (
@@ -41650,9 +40916,7 @@
 /area/atmos)
 "fox" = (
 /obj/structure/cable/yellow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -41678,12 +40942,11 @@
 /area/security/main)
 "foM" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -41738,7 +41001,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit/maint)
 "fpy" = (
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 8
 	},
 /obj/structure/chair/sofa/bench/right{
@@ -41765,24 +41028,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/west)
-"fpY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/central/south)
 "fpZ" = (
 /obj/machinery/newscaster/directional/north,
 /obj/structure/cable{
@@ -41791,9 +41036,7 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "fqf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -41839,10 +41082,9 @@
 	},
 /area/atmos)
 "fqN" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/optable,
 /obj/item/radio/intercom/directional/south,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -41898,6 +41140,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -41934,12 +41177,8 @@
 /area/crew_quarters/kitchen)
 "fsc" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -41950,13 +41189,6 @@
 /obj/structure/holosign/barrier,
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
-"fst" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/entry/westarrival)
 "fsu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -42015,7 +41247,7 @@
 "fsH" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/tea,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "greencorner"
@@ -42113,7 +41345,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "ftW" = (
@@ -42164,16 +41395,10 @@
 /obj/structure/reflector/box/anchored{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "fuE" = (
@@ -42210,9 +41435,7 @@
 	},
 /area/quartermaster/storage)
 "fuT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/table/reinforced,
 /obj/machinery/alarm/directional/north,
 /obj/item/assembly/signaler,
@@ -42239,7 +41462,7 @@
 	name = "Toxins Launcher";
 	req_access = list(7)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plating,
 /area/toxins/launch)
 "fvt" = (
@@ -42290,15 +41513,13 @@
 /area/medical/research/restroom)
 "fvC" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "fvE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -42383,9 +41604,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/sign/radiation/rad_area{
 	pixel_y = 32
 	},
@@ -42478,6 +41697,8 @@
 /area/maintenance/turbine)
 "fxD" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
@@ -42487,7 +41708,7 @@
 /turf/space,
 /area/space)
 "fxR" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/table/reinforced,
 /obj/item/melee/baton,
 /turf/simulated/floor/plasteel{
@@ -42526,12 +41747,6 @@
 	icon_state = "wood-broken3"
 	},
 /area/maintenance/starboard)
-"fxZ" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/east)
 "fye" = (
 /obj/structure/sign/goldenplaque{
 	desc = "ЦК награждает клоуна Шляпку как первого заключённого брига после перестройки. Он был задержан по статьям 100 104 и 309. Так держать.";
@@ -42568,7 +41783,7 @@
 /area/maintenance/bar)
 "fyt" = (
 /obj/structure/closet/coffin,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -42593,12 +41808,6 @@
 	icon_state = "darkredfull"
 	},
 /area/security/evidence)
-"fzd" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/starboard/east)
 "fzv" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -42765,7 +41974,7 @@
 /area/crew_quarters/theatre)
 "fBI" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/sign/fire{
 	pixel_y = 32
 	},
@@ -42819,7 +42028,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/clothing/shoes/combat/riot,
 /obj/item/clothing/shoes/combat/riot,
 /obj/item/clothing/shoes/combat/riot,
@@ -42862,9 +42071,7 @@
 /area/security/warden)
 "fCH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "fCJ" = (
@@ -42891,10 +42098,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/landmark/start/hangover,
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "neutral"
@@ -42902,9 +42106,7 @@
 /area/engineering/mechanic_workshop/expedition)
 "fDy" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "fDU" = (
@@ -42928,7 +42130,7 @@
 /area/maintenance/library)
 "fEb" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/apc_electronics,
 /obj/item/airlock_electronics,
 /obj/item/firelock_electronics,
@@ -43133,7 +42335,7 @@
 /area/turret_protected/ai)
 "fFz" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -43185,7 +42387,7 @@
 	},
 /area/toxins/launch)
 "fFR" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -43221,7 +42423,7 @@
 	},
 /area/bridge/vip)
 "fGp" = (
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /obj/structure/chair/sofa/bench/left{
@@ -43246,7 +42448,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -43286,9 +42488,7 @@
 	},
 /area/crew_quarters/locker)
 "fHp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/door_control{
 	desc = "A remote control-switch for the pod doors.";
 	id = "secpilot";
@@ -43419,6 +42619,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
@@ -43439,12 +42641,6 @@
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
-"fJf" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "cmo"
-	},
-/area/medical/ward)
 "fJh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -43524,7 +42720,7 @@
 /area/tcommsat/chamber)
 "fKI" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "red"
@@ -43539,12 +42735,6 @@
 /obj/effect/spawner/lootdrop/maintenance/double,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"fKO" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/permabrig)
 "fKQ" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/machinery/door/poddoor/preopen{
@@ -43565,7 +42755,6 @@
 "fLb" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
 "fLk" = (
@@ -43652,9 +42841,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -43673,9 +42860,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
 "fMo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkblue"
@@ -43694,7 +42879,7 @@
 /area/chapel/main)
 "fMJ" = (
 /obj/effect/landmark/start/cyborg,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
 	},
@@ -43717,7 +42902,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/prison/cell_block/A)
 "fMY" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -43731,7 +42916,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -43744,7 +42928,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/camera{
 	c_tag = "Departure Lounge East";
 	dir = 8
@@ -43787,7 +42971,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "fNO" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light,
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel,
@@ -43829,32 +43013,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"fOf" = (
-/obj/machinery/optable,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/shower{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/medical/surgery/north)
 "fOr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding4"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43897,10 +43063,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "fPs" = (
@@ -43918,6 +43081,8 @@
 /area/toxins/sm_test_chamber)
 "fPA" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -43926,7 +43091,7 @@
 /area/engineering/engine)
 "fPF" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/light,
 /obj/item/spacepod_equipment/key{
 	id = 100000
@@ -43959,7 +43124,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
 "fQd" = (
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /obj/structure/chair/sofa/bench{
@@ -43975,11 +43140,12 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -44268,7 +43434,6 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -44377,7 +43542,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
@@ -44496,9 +43661,7 @@
 	},
 /area/library)
 "fWg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -44538,7 +43701,6 @@
 /turf/simulated/floor/plating,
 /area/security/hos)
 "fWs" = (
-/obj/effect/landmark/start/hangover,
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
@@ -44558,9 +43720,7 @@
 	},
 /area/security/permabrig)
 "fWD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -44619,7 +43779,7 @@
 	},
 /area/hallway/primary/aft)
 "fWW" = (
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/door_control{
@@ -44687,25 +43847,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "fXK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "fXL" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/power/emitter/welded{
 	dir = 8
 	},
@@ -44791,7 +43947,7 @@
 /area/atmos)
 "fYC" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -44829,10 +43985,8 @@
 	},
 /area/quartermaster/storage)
 "fZf" = (
-/obj/effect/turf_decal/delivery/partial,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -44986,7 +44140,7 @@
 /area/maintenance/asmaint4)
 "gbc" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -45023,6 +44177,7 @@
 	network = list("SS13","Medical");
 	pixel_x = 30
 	},
+/obj/machinery/defibrillator_mount/loaded,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -45065,14 +44220,12 @@
 	},
 /area/quartermaster/office)
 "gca" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "gcg" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -45106,10 +44259,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/hos)
-"gcI" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/mech_bay_recharge_floor,
-/area/assembly/chargebay)
 "gcK" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -45125,9 +44274,7 @@
 	},
 /area/maintenance/kitchen)
 "gcY" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -45141,7 +44288,7 @@
 	},
 /area/medical/cloning)
 "gds" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -45177,7 +44324,7 @@
 /area/crew_quarters/sleep)
 "gdQ" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -45210,7 +44357,7 @@
 /area/bridge/vip)
 "geP" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -45256,6 +44403,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -45345,7 +44493,7 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "ghI" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -45419,13 +44567,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/maintenance/starboard)
-"giy" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/wood,
-/area/library)
 "giN" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -45443,7 +44584,7 @@
 /obj/item/cartridge/signal/toxins{
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/lighter/zippo/rd,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
@@ -45469,9 +44610,7 @@
 	},
 /area/medical/research/restroom)
 "gjM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "gjR" = (
@@ -45494,16 +44633,6 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
-"gkb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/office)
 "gkh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -45514,7 +44643,7 @@
 	},
 /area/medical/paramedic)
 "gko" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -45546,7 +44675,7 @@
 	pixel_x = 32
 	},
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint3)
 "gkQ" = (
@@ -45599,9 +44728,7 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "glv" = (
@@ -45639,7 +44766,7 @@
 	},
 /area/hallway/primary/central/north)
 "glA" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/rack,
 /obj/item/airlock_painter{
 	pixel_x = -6;
@@ -45710,15 +44837,15 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/medical/cloning)
 "gmf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -45754,7 +44881,7 @@
 /area/library)
 "gml" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/vending_refill/custom{
 	pixel_x = 3;
 	pixel_y = 5
@@ -45822,7 +44949,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
 "gnI" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -45945,9 +45072,7 @@
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "goP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -46195,6 +45320,7 @@
 "grb" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -46213,7 +45339,7 @@
 /area/bridge)
 "grl" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "grq" = (
@@ -46278,9 +45404,7 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
@@ -46345,7 +45469,7 @@
 	dir = 4;
 	pixel_x = -3
 	},
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -46425,9 +45549,7 @@
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/serviceyard)
 "gtQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
@@ -46469,7 +45591,7 @@
 /obj/item/target/syndicate,
 /obj/item/target/syndicate,
 /obj/item/target/syndicate,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
 /area/security/range)
@@ -46491,7 +45613,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -46597,7 +45719,7 @@
 "gvo" = (
 /obj/machinery/newscaster/directional/west,
 /obj/structure/closet/bombcloset,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -46780,7 +45902,7 @@
 	pixel_x = 26;
 	req_access = list(18)
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -46807,7 +45929,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/clothing/gloves/combat/riot,
 /obj/item/clothing/gloves/combat/riot,
 /obj/item/clothing/gloves/combat/riot,
@@ -46871,7 +45993,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/perma)
 "gyP" = (
-/obj/effect/turf_decal/delivery/partial,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /obj/structure/chair/sofa/bench,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -46892,7 +46014,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -46902,7 +46023,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/computer/card/minor/rd,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "gyZ" = (
@@ -46936,9 +46057,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "gzs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -46952,6 +46071,7 @@
 	level = 1
 	},
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/window/plasmareinforced{
@@ -46989,9 +46109,7 @@
 	},
 /area/chapel/office)
 "gzM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -47018,8 +46136,8 @@
 /area/crew_quarters/theatre)
 "gzR" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "gAw" = (
@@ -47144,13 +46262,6 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/lab)
-"gCd" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/bridge/vip)
 "gCe" = (
 /obj/effect/spawner/random_spawners/oil_20,
 /turf/simulated/floor/plating,
@@ -47291,7 +46402,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot,
@@ -47414,9 +46525,7 @@
 	},
 /area/security/prison/cell_block/A)
 "gES" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkred"
@@ -47436,6 +46545,8 @@
 /area/chapel/main)
 "gFc" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -47485,7 +46596,7 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/sorting)
 "gFm" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -47521,12 +46632,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -47553,9 +46660,7 @@
 	},
 /area/bridge)
 "gGh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "gGp" = (
@@ -47576,9 +46681,7 @@
 	},
 /area/hallway/primary/aft)
 "gGx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/binary/pump{
 	desc = "Позволяет пропустить смесь не загружая её в хранилище";
 	name = "Смесь в обход хранилища";
@@ -47643,11 +46746,11 @@
 "gHc" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "gHn" = (
@@ -47674,14 +46777,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet,
 /area/library)
-"gHv" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/bridge)
 "gHz" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/table/reinforced,
@@ -47711,7 +46810,7 @@
 	id_tag = "stationawaygate";
 	name = "Gateway Access Shutters"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Exp_lockdown";
@@ -47779,7 +46878,7 @@
 	id_tag = "stationawaygate";
 	name = "Gateway Access Shutters"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Exp_lockdown";
@@ -47809,9 +46908,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/bridge/meeting_room)
 "gIq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -47820,7 +46917,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "gIs" = (
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -47843,11 +46940,12 @@
 "gIy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
 "gIA" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 1;
@@ -47892,7 +46990,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "gJA" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	name = "Труба на фильтрацию"
@@ -47985,9 +47083,7 @@
 	},
 /area/security/permabrig)
 "gKs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48101,7 +47197,7 @@
 	},
 /area/medical/cryo)
 "gLG" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/consarea_virology)
@@ -48143,7 +47239,7 @@
 /area/space)
 "gMa" = (
 /obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/garden)
 "gMf" = (
@@ -48203,7 +47299,7 @@
 /area/chapel/office)
 "gNb" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "gNg" = (
@@ -48253,9 +47349,7 @@
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "gNy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "gNz" = (
@@ -48321,7 +47415,7 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
 	},
@@ -48349,9 +47443,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/plasteel,
@@ -48398,9 +47490,7 @@
 	},
 /area/security/permabrig)
 "gOv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "gOx" = (
@@ -48432,7 +47522,7 @@
 /obj/effect/turf_decal/caution/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/red/partial{
+/obj/effect/decal/warning_stripes/red/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -48471,7 +47561,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/lootdrop/maintenance/double,
 /turf/simulated/floor/plasteel{
@@ -48521,9 +47611,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -48557,9 +47645,7 @@
 	},
 /area/security/permabrig)
 "gQj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/alarm/directional/south,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -48661,7 +47747,7 @@
 "gRa" = (
 /obj/machinery/light,
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "gRb" = (
@@ -48686,7 +47772,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/clothing/suit/armor/riot,
 /obj/item/clothing/suit/armor/riot,
 /obj/item/clothing/suit/armor/riot,
@@ -48752,10 +47838,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"gSV" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/wood/fancy/light,
-/area/crew_quarters/courtroom)
 "gSY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -48826,9 +47908,7 @@
 	},
 /area/maintenance/asmaint4)
 "gTl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -48836,12 +47916,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"gTo" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/crew_quarters/kitchen)
 "gTr" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -48854,9 +47928,7 @@
 /area/atmos)
 "gTx" = (
 /obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -48878,7 +47950,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -48980,7 +48052,7 @@
 	},
 /area/toxins/launch)
 "gVd" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/eastright{
 	name = "Hydroponics Delivery";
 	req_access = list(35)
@@ -48994,7 +48066,7 @@
 /area/hydroponics)
 "gVo" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
@@ -49062,8 +48134,8 @@
 	},
 /area/hallway/secondary/exit)
 "gVN" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/plasticflaps/opaque,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/plasticflaps,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
 	dir = 1;
@@ -49112,6 +48184,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -49132,7 +48205,7 @@
 /area/crew_quarters/serviceyard)
 "gWH" = (
 /obj/machinery/chem_master,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -49151,7 +48224,7 @@
 /obj/item/ai_module/reset,
 /obj/item/flash,
 /obj/item/flash,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/requests_console{
 	department = "Tech Storage";
 	name = "Tech Storage Requests Console";
@@ -49178,7 +48251,6 @@
 	},
 /area/crew_quarters/kitchen)
 "gXf" = (
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "gXh" = (
@@ -49207,7 +48279,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -49306,16 +48378,20 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/medical/medbay)
 "gYo" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
@@ -49367,7 +48443,7 @@
 /area/crew_quarters/fitness)
 "gZb" = (
 /obj/structure/weightmachine/weightlifter,
-/obj/effect/turf_decal/delivery/white/hollow,
+/obj/effect/decal/warning_stripes/white/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -49411,14 +48487,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "gZC" = (
 /obj/structure/morgue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/effect/landmark/spawner/revenant,
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -49429,6 +48504,7 @@
 /obj/effect/landmark/start/mime,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -49453,9 +48529,7 @@
 	id = "auxsolareast";
 	name = "North-East Solar Control"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "haf" = (
@@ -49667,7 +48741,7 @@
 /area/lawoffice)
 "hdV" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "KPPS"
 	},
@@ -49728,9 +48802,7 @@
 /area/hydroponics)
 "hev" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -49798,9 +48870,7 @@
 	},
 /area/medical/reception)
 "hfl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -49818,6 +48888,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -49826,7 +48897,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -49999,10 +49070,8 @@
 /area/teleporter)
 "hhg" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -50066,7 +49135,7 @@
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
 /obj/item/radio,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -50226,9 +49295,7 @@
 /turf/simulated/floor/plating,
 /area/security/podbay)
 "hkF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -50273,7 +49340,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "hlF" = (
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /obj/structure/closet/crate/secure/blood/xeno,
 /obj/item/reagent_containers/iv_bag/blood/wryn,
 /obj/item/reagent_containers/iv_bag/blood/vulpkanin,
@@ -50292,9 +49359,7 @@
 	},
 /area/medical/sleeper)
 "hlG" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -50310,7 +49375,6 @@
 "hlX" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/hydroponics/soil,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "hmb" = (
@@ -50431,7 +49495,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/confetti,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -50465,16 +49528,14 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "hoo" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/status_display/supply_display{
 	layer = 3.25;
 	pixel_y = 32
@@ -50547,15 +49608,13 @@
 /area/maintenance/starboard)
 "hoJ" = (
 /obj/machinery/chem_heater,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
 /turf/simulated/floor/engine,
 /area/medical/chemistry)
 "hoM" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -50617,7 +49676,6 @@
 	pixel_y = 24;
 	req_access = list(58)
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -50736,9 +49794,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -50758,7 +49814,7 @@
 /area/medical/virology/lab)
 "hqC" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -50819,9 +49875,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "hrk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -50840,7 +49894,7 @@
 /area/bridge)
 "hrt" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/driver_button{
 	id_tag = "trash";
 	name = "Trash Ejector Button";
@@ -50879,6 +49933,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
+"hrS" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plating,
+/area/engineering/engine)
 "hrX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
@@ -50989,7 +50050,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "htt" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/purple,
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel{
@@ -51003,7 +50064,7 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/mirror{
 	pixel_x = -26
 	},
@@ -51018,14 +50079,13 @@
 	pixel_y = -28
 	},
 /obj/item/radio/intercom/locked/prison/directional/south,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
 "htC" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -51151,7 +50211,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -51166,9 +50226,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "hvI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 10;
@@ -51181,18 +50239,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "hvP" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "hvU" = (
@@ -51330,9 +50382,7 @@
 /turf/simulated/wall/r_wall/rust,
 /area/toxins/sm_test_chamber)
 "hxp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/vending/plasmaresearch,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -51423,6 +50473,8 @@
 "hyv" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -51458,9 +50510,7 @@
 	name = "Chapel Launcher Door";
 	protected = 0
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
@@ -51509,9 +50559,7 @@
 /area/maintenance/starboard)
 "hzX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -51519,9 +50567,7 @@
 /area/hallway/primary/central/south)
 "hAw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "hAy" = (
@@ -51551,7 +50597,7 @@
 	},
 /area/quartermaster/miningdock)
 "hAQ" = (
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -51580,7 +50626,6 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -51626,9 +50671,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "hBX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -51642,11 +50685,13 @@
 	},
 /area/crew_quarters/locker)
 "hCl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding1"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -51710,7 +50755,7 @@
 	},
 /area/hallway/primary/central/south)
 "hDg" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/eastright{
 	dir = 8;
 	name = "Clown Delivery";
@@ -51729,6 +50774,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -51769,14 +50815,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/port)
 "hEe" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
 	},
@@ -51893,7 +50939,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -51902,7 +50948,7 @@
 /area/hallway/primary/central/nw)
 "hFn" = (
 /obj/effect/landmark/start/cyborg,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "purple"
@@ -52058,7 +51104,7 @@
 /area/hallway/primary/central/north)
 "hHo" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
@@ -52095,15 +51141,15 @@
 /area/hallway/primary/central/east)
 "hHu" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space)
 "hHy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -52153,10 +51199,14 @@
 	icon_state = "grimy"
 	},
 /area/chapel/main)
-"hIq" = (
-/obj/effect/landmark/start/hangover,
+"hIt" = (
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/engineering/engine)
 "hIA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -52200,7 +51250,7 @@
 /area/crew_quarters/fitness)
 "hJr" = (
 /obj/machinery/power/terminal,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -52228,7 +51278,7 @@
 	name = "Creature Pen";
 	req_access = list(47)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -52238,7 +51288,7 @@
 /area/toxins/xenobiology)
 "hJO" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler{
 	pixel_x = -8;
@@ -52264,9 +51314,7 @@
 	id_tag = "admin_home";
 	locked = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "hJW" = (
@@ -52279,7 +51327,7 @@
 	},
 /area/toxins/sm_test_chamber)
 "hJX" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -52316,7 +51364,6 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "hKh" = (
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -52339,7 +51386,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -52348,10 +51395,8 @@
 	},
 /area/hallway/primary/central/ne)
 "hKt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/chem_dispenser,
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
@@ -52408,6 +51453,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -52502,7 +51548,7 @@
 /area/crew_quarters/theatre)
 "hMh" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "KPPN"
 	},
@@ -52668,7 +51714,7 @@
 /turf/simulated/floor/carpet/black,
 /area/quartermaster/storage)
 "hOs" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -52685,7 +51731,7 @@
 	},
 /area/hallway/primary/port/west)
 "hOy" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -52705,7 +51751,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -52759,7 +51805,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain/bedroom)
 "hPr" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/computer/supplycomp/public{
 	dir = 8
 	},
@@ -52829,7 +51875,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -52855,7 +51901,7 @@
 	},
 /area/security/hos)
 "hQl" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/radiation,
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
@@ -52934,7 +51980,7 @@
 /area/crew_quarters/theatre)
 "hQU" = (
 /obj/structure/cable/yellow,
-/obj/effect/turf_decal/stripes/end,
+/obj/effect/decal/warning_stripes/eastsouthwest,
 /obj/machinery/power/emitter/welded,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
@@ -53078,11 +52124,11 @@
 	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -53108,11 +52154,13 @@
 	},
 /area/medical/medbay)
 "hTb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding1"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53197,6 +52245,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/hatdispenser,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -53266,7 +52315,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -53289,6 +52337,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -53359,6 +52408,8 @@
 	pixel_y = -34
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -53414,14 +52465,16 @@
 /area/hallway/secondary/entry/lounge)
 "hWL" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "hWX" = (
@@ -53479,7 +52532,7 @@
 	},
 /area/toxins/lab)
 "hXt" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/double,
 /turf/simulated/floor/plasteel{
@@ -53518,7 +52571,7 @@
 /obj/item/mop,
 /obj/item/caution,
 /obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/mop,
 /obj/item/mop,
 /turf/simulated/floor/plasteel{
@@ -53535,7 +52588,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -53549,9 +52602,7 @@
 /area/crew_quarters/courtroom)
 "hYw" = (
 /obj/machinery/shieldgen,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "hYL" = (
@@ -53681,7 +52732,7 @@
 /area/toxins/xenobiology)
 "iao" = (
 /obj/machinery/disposal,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -53699,9 +52750,7 @@
 	},
 /area/maintenance/asmaint4)
 "iaH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -53725,7 +52774,7 @@
 /turf/simulated/floor/plating,
 /area/security/processing)
 "ibu" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -53787,16 +52836,16 @@
 	dir = 1
 	},
 /obj/structure/displaycase/labcage,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "ibT" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "ibW" = (
@@ -53846,7 +52895,7 @@
 /area/security/main)
 "ics" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -53856,14 +52905,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "icz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "icF" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
@@ -53910,7 +52957,7 @@
 "idu" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/coffin,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/door/window/eastleft{
 	dir = 8;
 	name = "Coffin Storage";
@@ -53995,7 +53042,7 @@
 /obj/item/seeds/chili,
 /obj/item/seeds/chili,
 /obj/item/seeds/chili,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -54023,7 +53070,7 @@
 /obj/item/toy/figure/rd{
 	pixel_x = -7
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
@@ -54053,7 +53100,7 @@
 /area/medical/research/nhallway)
 "ifD" = (
 /obj/machinery/space_heater,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "ifK" = (
@@ -54077,7 +53124,7 @@
 /obj/machinery/atmospherics/unary/thermomachine/freezer{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/end,
+/obj/effect/decal/warning_stripes/eastsouthwest,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
@@ -54116,7 +53163,7 @@
 	pixel_y = -27
 	},
 /obj/machinery/vending/department_clothesmate/cargo,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -54142,7 +53189,7 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -54351,9 +53398,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -54361,9 +53406,7 @@
 /area/maintenance/asmaint2)
 "ijw" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -54445,21 +53488,18 @@
 /area/toxins/explab)
 "ikr" = (
 /obj/machinery/suit_storage_unit/security/hos,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/hos)
 "iku" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/closet/crate{
-	icon_state = "crate_open";
-	opened = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -54522,9 +53562,7 @@
 	},
 /area/engineering/break_room)
 "ikN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 5;
@@ -54584,8 +53622,8 @@
 /area/medical/cloning)
 "ilx" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
@@ -54621,17 +53659,13 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/northwestsouth,
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
 /area/atmos)
 "iml" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -54704,9 +53738,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "imJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
@@ -54785,9 +53817,7 @@
 	},
 /area/quartermaster/storage)
 "inw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
@@ -54795,7 +53825,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "inx" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/eastleft{
 	dir = 2;
 	name = "Chapel Delivery";
@@ -54809,9 +53839,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
@@ -54893,9 +53921,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "iof" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
@@ -55026,10 +54052,8 @@
 /area/maintenance/asmaint2)
 "iqD" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/northwestsouth,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "iqN" = (
@@ -55072,7 +54096,7 @@
 /area/maintenance/detectives_office)
 "iqZ" = (
 /obj/effect/landmark/start/civilian,
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
 /obj/structure/chair/sofa/bench{
@@ -55107,7 +54131,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -55157,10 +54181,10 @@
 /turf/simulated/floor/glass,
 /area/maintenance/consarea_virology)
 "irZ" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -55179,6 +54203,8 @@
 /area/maintenance/fpmaint)
 "isc" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
@@ -55265,11 +54291,13 @@
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "itk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding1"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -55309,12 +54337,8 @@
 /area/space)
 "iuh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "iui" = (
@@ -55341,7 +54365,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "ium" = (
@@ -55355,7 +54379,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/landmark/lightsout,
 /turf/simulated/floor/plasteel{
@@ -55512,12 +54536,8 @@
 /area/bridge/checkpoint/south)
 "ivy" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -55572,7 +54592,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
@@ -55581,9 +54601,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -55777,14 +54795,13 @@
 /obj/machinery/atm{
 	pixel_y = -32
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry/commercial)
 "iyh" = (
 /obj/structure/closet/coffin,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "vault"
@@ -55839,7 +54856,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -56079,7 +55096,7 @@
 /area/medical/research)
 "iCV" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
 	},
@@ -56136,7 +55153,7 @@
 /obj/item/target,
 /obj/item/target,
 /obj/item/target,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "iDE" = (
@@ -56174,7 +55191,7 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "iEu" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/alarm/directional/north,
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plasteel,
@@ -56200,13 +55217,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/maintenance/trading)
-"iEL" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/hallway/primary/central/north)
 "iET" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -56219,7 +55229,7 @@
 	},
 /area/quartermaster/miningdock)
 "iEY" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/disposal,
 /obj/structure/window/reinforced,
 /obj/structure/disposalpipe/trunk{
@@ -56251,11 +55261,12 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -56319,7 +55330,7 @@
 	},
 /area/crew_quarters/theatre)
 "iFG" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/table,
 /obj/item/plant_analyzer,
 /obj/item/hatchet,
@@ -56337,7 +55348,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -56466,6 +55477,8 @@
 	network = list("SS13","Engineering")
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -56593,9 +55606,11 @@
 /area/crew_quarters/heads/hop)
 "iIm" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "iIq" = (
@@ -56647,9 +55662,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -56660,9 +55673,7 @@
 /turf/simulated/floor/carpet/black,
 /area/maintenance/casino)
 "iJw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -56680,9 +55691,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "iJN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
 /obj/item/clothing/glasses/sunglasses/blindfold/black,
@@ -56693,7 +55702,6 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -56701,9 +55709,7 @@
 /area/medical/morgue)
 "iJV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -56748,9 +55754,7 @@
 	},
 /area/crew_quarters/fitness)
 "iKq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
@@ -56758,9 +55762,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -56798,7 +55800,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/theatre)
 "iKW" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
@@ -56810,7 +55812,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/closet/emcloset,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -56884,7 +55886,7 @@
 /area/maintenance/asmaint3)
 "iLK" = (
 /obj/machinery/portable_atmospherics/scrubber/huge/stationary,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -56901,9 +55903,7 @@
 	},
 /area/hallway/primary/starboard/east)
 "iMh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -56925,7 +55925,7 @@
 	},
 /area/bridge)
 "iMj" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -56943,7 +55943,7 @@
 	},
 /area/atmos)
 "iMP" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/gibber,
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel,
@@ -56971,7 +55971,7 @@
 	pixel_y = -30
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "iNi" = (
@@ -57083,7 +56083,7 @@
 /area/maintenance/starboard)
 "iOk" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
@@ -57097,6 +56097,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -57205,7 +56206,7 @@
 "iPh" = (
 /obj/structure/dispenser/oxygen,
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "iPo" = (
@@ -57230,9 +56231,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastsouth,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "iQf" = (
@@ -57342,7 +56341,7 @@
 /area/toxins/xenobiology)
 "iRA" = (
 /obj/machinery/seed_extractor,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -57366,7 +56365,7 @@
 /obj/machinery/atm{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -57391,6 +56390,7 @@
 	icon_state = "grass_edge_medium_corner"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -57422,16 +56422,12 @@
 /area/storage/eva)
 "iSY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "iTe" = (
-/obj/effect/turf_decal/delivery/blue,
+/obj/effect/decal/warning_stripes/blue,
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
@@ -57479,8 +56475,8 @@
 /obj/machinery/seed_extractor{
 	pixel_y = -1
 	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/delivery/green,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/green,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -57514,7 +56510,7 @@
 /obj/structure/table/reinforced,
 /obj/item/paicard,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "iUX" = (
@@ -57612,6 +56608,7 @@
 /area/crew_quarters/hor)
 "iWm" = (
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
@@ -57632,9 +56629,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
 "iWB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/autolathe,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -57676,7 +56671,7 @@
 	},
 /area/hallway/primary/port/west)
 "iWO" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -57690,7 +56685,7 @@
 /area/maintenance/electrical)
 "iXb" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -57717,10 +56712,10 @@
 	},
 /area/toxins/mixing)
 "iXh" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -57820,7 +56815,7 @@
 /obj/machinery/sleeper{
 	pixel_x = 3
 	},
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /obj/machinery/alarm/directional/north,
 /obj/machinery/camera{
 	c_tag = "Medbay Exam Room North";
@@ -57889,11 +56884,11 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "iYC" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -58038,7 +57033,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -58058,9 +57053,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "jbb" = (
@@ -58082,21 +57075,19 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "jby" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
 "jbE" = (
-/obj/effect/turf_decal/delivery/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/blue,
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/shower{
 	dir = 4;
 	pixel_y = 4
@@ -58238,8 +57229,8 @@
 	},
 /area/maintenance/banya)
 "jde" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -58300,7 +57291,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -58339,7 +57330,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "jeg" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/roboticist,
 /obj/item/radio/headset/headset_sci{
 	pixel_x = -3
@@ -58364,9 +57355,7 @@
 /area/maintenance/engineering)
 "jeu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -58427,7 +57416,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -58472,7 +57461,7 @@
 "jfk" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/monkey_recycler,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -58549,14 +57538,14 @@
 "jfX" = (
 /obj/machinery/vending/tool,
 /obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "jfY" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -58565,9 +57554,7 @@
 /area/quartermaster/storage)
 "jgf" = (
 /obj/machinery/chem_master,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/disposalpipe/segment,
 /obj/structure/reagent_dispensers/fueltank/chem{
 	pixel_x = 32
@@ -58618,9 +57605,7 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/maintenance/turbine)
 "jgL" = (
@@ -58652,9 +57637,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
 "jhm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "jhv" = (
@@ -58697,6 +57680,7 @@
 /obj/machinery/vending/autodrobe,
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -58719,7 +57703,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -58745,7 +57729,7 @@
 /area/medical/psych)
 "jiL" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -58796,11 +57780,6 @@
 	icon_state = "darkred"
 	},
 /area/maintenance/brig)
-"jiU" = (
-/obj/effect/turf_decal/siding/brown/corner,
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/wood/fancy/light,
-/area/crew_quarters/courtroom)
 "jiV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58825,9 +57804,7 @@
 	},
 /area/medical/virology)
 "jjc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -58927,7 +57904,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -59050,12 +58027,8 @@
 	},
 /area/security/processing)
 "jme" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "jmj" = (
@@ -59064,9 +58037,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
@@ -59077,7 +58048,7 @@
 /area/maintenance/asmaint3)
 "jmo" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -59133,7 +58104,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -59189,6 +58160,7 @@
 /obj/structure/closet/cardboard,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -59207,7 +58179,7 @@
 /area/chapel/main)
 "jnA" = (
 /obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/rack,
 /obj/item/gps{
 	pixel_x = -6;
@@ -59291,9 +58263,7 @@
 /area/maintenance/brig)
 "job" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59358,6 +58328,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -59529,7 +58500,7 @@
 /turf/simulated/wall,
 /area/maintenance/casino)
 "jqx" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/camera{
 	c_tag = "Secure Armory East";
 	dir = 8;
@@ -59652,9 +58623,7 @@
 	},
 /area/atmos)
 "jrU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/chair/stool{
 	dir = 8
 	},
@@ -59705,9 +58674,7 @@
 	},
 /area/bridge/checkpoint/south)
 "jso" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -59749,9 +58716,7 @@
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "jsz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "jsC" = (
@@ -59769,17 +58734,15 @@
 /area/hallway/secondary/exit)
 "jsU" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "jtd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/binary/valve/digital/open{
 	desc = "Позволяет отключить подачу дыхательной смеси на станцию, не отключая саму закачку газа. (Например, если требуется подать только смесь из оранжевых труб)";
 	dir = 4;
@@ -59885,11 +58848,11 @@
 /area/security/brigstaff)
 "jtS" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "jub" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 1;
@@ -59912,7 +58875,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/clothing/head/helmet/alt,
 /obj/item/clothing/head/helmet/alt,
 /obj/item/clothing/head/helmet/alt,
@@ -59957,7 +58920,7 @@
 /obj/structure/railing{
 	dir = 5
 	},
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluefull"
 	},
@@ -59986,13 +58949,6 @@
 	icon_state = "red"
 	},
 /area/security/permahallway)
-"jvd" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/bridge)
 "jvf" = (
 /obj/effect/spawner/new_year/garland/west,
 /turf/simulated/floor/carpet/red,
@@ -60006,16 +58962,12 @@
 	},
 /area/quartermaster/delivery)
 "jvi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "jvq" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -60121,9 +59073,7 @@
 	name = "Privacy Shutters";
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/chief)
@@ -60180,12 +59130,8 @@
 /area/engineering/engine)
 "jwR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -60226,7 +59172,7 @@
 	},
 /area/crew_quarters/theatre)
 "jxu" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	name = "Труба дыхательной смеси"
@@ -60271,7 +59217,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "jxO" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/closet/walllocker{
 	pixel_y = -28
 	},
@@ -60387,15 +59333,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"jyE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/chapel/main)
 "jyF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -60477,18 +59414,6 @@
 	icon_state = "whitepurple"
 	},
 /area/medical/research/restroom)
-"jzS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/fore)
 "jzW" = (
 /mob/living/simple_animal/turtle,
 /turf/simulated/floor/plasteel{
@@ -60511,7 +59436,6 @@
 	c_tag = "Mr. Chang's";
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/mrchangs)
 "jAi" = (
@@ -60543,12 +59467,6 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"jAq" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/engineering/engine)
 "jAs" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -60581,9 +59499,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -60597,12 +59513,13 @@
 	},
 /area/bridge/checkpoint/north)
 "jAF" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/eastright{
 	name = "Mime Delivery";
 	req_access = list(46)
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -60624,7 +59541,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
@@ -60665,7 +59582,7 @@
 "jBw" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "bluefull"
 	},
@@ -60869,7 +59786,7 @@
 /area/hallway/primary/fore)
 "jEe" = (
 /obj/machinery/newscaster/directional/north,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -60893,7 +59810,7 @@
 /area/security/prison/cell_block/A)
 "jEw" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -60907,7 +59824,7 @@
 /area/quartermaster/office)
 "jEA" = (
 /obj/machinery/biogenerator,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -60992,7 +59909,7 @@
 	},
 /area/toxins/xenobiology)
 "jFS" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -61025,9 +59942,11 @@
 /area/maintenance/consarea_virology)
 "jGo" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -61056,14 +59975,14 @@
 	},
 /obj/item/flashlight,
 /obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
 	},
 /area/engineering/engine)
 "jGR" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -61124,17 +60043,14 @@
 	network = list("SS13","Engineering")
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/closet/walllocker/emerglocker/directional/east,
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "jHC" = (
 /turf/simulated/wall/r_wall/rust,
 /area/toxins/launch)
 "jHF" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -61209,8 +60125,8 @@
 	},
 /area/hallway/primary/central/sw)
 "jIl" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/plasticflaps/opaque,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/plasticflaps,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	location = "Chapel"
@@ -61245,13 +60161,10 @@
 	},
 /area/bridge)
 "jIA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "jIF" = (
@@ -61323,9 +60236,8 @@
 /turf/simulated/floor/glass/reinforced,
 /area/maintenance/asmaint4)
 "jJc" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/reagent_containers/food/drinks/mug/eng,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "jJj" = (
@@ -61367,9 +60279,7 @@
 	name = "Research Division Access";
 	req_access = list(47)
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -61403,14 +60313,13 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "jJQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
 /turf/simulated/floor/plasteel{
@@ -61451,7 +60360,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -61504,7 +60413,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "jKV" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/driver_button{
 	id_tag = "toxinsdriver";
 	pixel_x = 26
@@ -61553,10 +60462,8 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/locker)
 "jLs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -61668,7 +60575,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/directional/east,
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -61769,9 +60676,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -32
-	},
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -61779,9 +60683,9 @@
 /area/medical/sleeper)
 "jOX" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -61797,9 +60701,7 @@
 	},
 /area/bridge)
 "jPf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/newscaster/directional/north,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
@@ -61992,7 +60894,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -62018,7 +60920,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -62133,6 +61034,8 @@
 "jUa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -62152,7 +61055,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "jUu" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -62271,10 +61174,8 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "jVF" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/camera{
 	c_tag = "EVA West"
 	},
@@ -62299,7 +61200,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "jWe" = (
@@ -62337,22 +61238,16 @@
 /area/maintenance/fore)
 "jWR" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /obj/structure/closet/walllocker/emerglocker/directional/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/hydroponics)
-"jWW" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/holodeck/alphadeck)
 "jXb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -62540,7 +61435,7 @@
 	pixel_x = 30
 	},
 /obj/machinery/reagentgrinder,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "jYS" = (
@@ -62706,7 +61601,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -62743,7 +61637,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -62813,6 +61707,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wardrobe/pjs,
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
@@ -62897,7 +61792,7 @@
 /area/security/securehallway)
 "keJ" = (
 /obj/machinery/recharge_station,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -62907,11 +61802,11 @@
 "keL" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "keU" = (
@@ -62930,7 +61825,7 @@
 	},
 /area/security/execution)
 "keY" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/recharge_station,
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32
@@ -63007,9 +61902,7 @@
 /area/security/permabrig)
 "kfB" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -63152,16 +62045,14 @@
 	},
 /area/turret_protected/ai)
 "khT" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "khY" = (
@@ -63190,7 +62081,7 @@
 	name = "Mining Desk";
 	req_access = list(48)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_cargo";
 	name = "Cargo Lockdown"
@@ -63218,7 +62109,7 @@
 /area/turret_protected/ai)
 "kjk" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -63265,7 +62156,7 @@
 	},
 /obj/item/beacon,
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -63379,7 +62270,7 @@
 /area/maintenance/fpmaint)
 "klb" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "klj" = (
@@ -63400,10 +62291,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -63433,9 +62322,11 @@
 	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "klB" = (
@@ -63531,9 +62422,7 @@
 	},
 /area/quartermaster/office)
 "kmh" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -63546,22 +62435,18 @@
 	},
 /obj/structure/closet/firecloset,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "kmA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/atmos)
 "kmD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	name = "Труба обработки"
@@ -63624,7 +62509,7 @@
 	},
 /area/medical/research)
 "knl" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
@@ -63654,7 +62539,7 @@
 /area/maintenance/asmaint4)
 "knB" = (
 /obj/machinery/telepad_cargo,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -63668,7 +62553,7 @@
 	dir = 4;
 	network = list("Toxins","Research","SS13")
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel/airless/indestructible,
 /area/toxins/test_area)
 "knS" = (
@@ -63684,9 +62569,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "knU" = (
@@ -63785,15 +62668,13 @@
 /area/bridge/vip)
 "kpn" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/hallway/secondary/exit)
 "kpq" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -63832,7 +62713,7 @@
 	},
 /area/medical/medbay)
 "kpL" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -63858,7 +62739,7 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 5
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -63952,7 +62833,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -64107,7 +62988,7 @@
 /obj/item/seeds/orange,
 /obj/item/seeds/orange,
 /obj/item/seeds/orange,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -64328,14 +63209,13 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable/yellow{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "kwN" = (
@@ -64385,9 +63265,7 @@
 /area/security/interrogation)
 "kxn" = (
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/aisat/maintenance)
@@ -64405,7 +63283,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "kxu" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -64528,12 +63406,12 @@
 /area/bridge/checkpoint/south)
 "kyz" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -64698,9 +63576,7 @@
 "kAo" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
@@ -64717,7 +63593,7 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/break_room)
 "kAV" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Singularity North-East";
 	dir = 8;
@@ -64733,9 +63609,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/spawner/xeno,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -64750,9 +63624,7 @@
 	},
 /area/atmos/control)
 "kBk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/item/restraints/handcuffs/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -64833,9 +63705,9 @@
 /area/toxins/xenobiology)
 "kCr" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light_switch/directional/south,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -64866,9 +63738,7 @@
 /turf/space,
 /area/solar/starboard)
 "kCD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -64917,9 +63787,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "kDa" = (
@@ -65000,7 +63868,7 @@
 /area/toxins/xenobiology)
 "kEg" = (
 /obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -65051,8 +63919,8 @@
 /area/maintenance/fpmaint)
 "kEM" = (
 /obj/machinery/floodlight,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -65112,14 +63980,12 @@
 /area/maintenance/fpmaint)
 "kFz" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "kFO" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
@@ -65193,10 +64059,6 @@
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/security/securearmory)
-"kGC" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/carpet/arcade,
-/area/crew_quarters/fitness)
 "kGG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -65261,8 +64123,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -65306,9 +64168,7 @@
 	},
 /area/hydroponics)
 "kIb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -65376,7 +64236,7 @@
 "kJs" = (
 /obj/structure/window/reinforced,
 /obj/machinery/vending/cola,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -65394,12 +64254,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "kJL" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -65423,7 +64283,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/photocopier/faxmachine/longrange{
 	department = "Research Director's Office"
 	},
@@ -65517,7 +64377,7 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/effect/turf_decal/delivery/white,
+/obj/effect/decal/warning_stripes/white,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -65566,9 +64426,7 @@
 /area/space)
 "kLx" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "kLF" = (
@@ -65584,7 +64442,7 @@
 /turf/simulated/wall,
 /area/atmos)
 "kLY" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "kLZ" = (
@@ -65599,8 +64457,8 @@
 	},
 /area/hallway/primary/fore)
 "kMb" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	dir = 1;
@@ -65610,9 +64468,7 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "kMe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/r_n_d/circuit_imprinter{
 	pixel_x = -1;
 	pixel_y = 3
@@ -65881,7 +64737,7 @@
 	},
 /area/maintenance/detectives_office)
 "kPe" = (
-/obj/structure/plasticflaps/opaque,
+/obj/structure/plasticflaps,
 /obj/effect/turf_decal/siding/green/corner{
 	color = "";
 	dir = 4;
@@ -65933,7 +64789,7 @@
 /obj/item/extinguisher,
 /obj/item/clothing/mask/gas,
 /obj/item/grenade/chem_grenade/firefighting,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
@@ -65976,8 +64832,8 @@
 	},
 /area/medical/cmo)
 "kQH" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/plasticflaps/opaque,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/plasticflaps,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	location = "Bar"
@@ -66078,9 +64934,7 @@
 	id_tag = "admin_home";
 	locked = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "kSQ" = (
@@ -66165,13 +65019,6 @@
 	color = "orange"
 	},
 /area/crew_quarters/courtroom)
-"kUp" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/storage/tech)
 "kUr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -66207,11 +65054,10 @@
 /area/hallway/secondary/exit)
 "kUO" = (
 /obj/structure/cable/yellow{
+	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/eastnorthwest,
 /obj/machinery/power/emitter/welded{
 	dir = 1
 	},
@@ -66273,7 +65119,7 @@
 /area/medical/research/nhallway)
 "kVH" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -66362,7 +65208,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/clothing/gloves/color/black/ballistic,
 /obj/item/clothing/gloves/color/black/ballistic,
 /obj/item/clothing/gloves/color/black/ballistic,
@@ -66392,7 +65238,7 @@
 	name = "Research Division Access";
 	req_access = list(47)
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -66485,6 +65331,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -66801,7 +65648,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "ldk" = (
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /obj/structure/chair/sofa/bench/right{
@@ -66828,12 +65675,8 @@
 /area/crew_quarters/fitness)
 "ldN" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "ldR" = (
@@ -66881,16 +65724,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint2)
-"les" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "blue"
-	},
-/area/hallway/secondary/entry/lounge)
 "lev" = (
 /obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whitepurple"
@@ -66907,15 +65743,6 @@
 /obj/machinery/power/apc/directional/south,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
-"leU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/wood/fancy/cherry,
-/area/crew_quarters/bar/atrium)
 "lfc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -67219,13 +66046,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/podbay)
-"lhM" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkblue"
-	},
-/area/bridge)
 "lhQ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -67265,9 +66085,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "lij" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -67527,26 +66345,13 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/supermatter)
 "llx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
-"llA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/aft)
 "llF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -67638,7 +66443,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/directional/east,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "lmx" = (
@@ -67658,24 +66463,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/turret_protected/ai)
-"lnk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/locker)
 "lnn" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "lnt" = (
@@ -67691,7 +66482,7 @@
 "lnx" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "yellow"
@@ -67769,9 +66560,7 @@
 /turf/simulated/wall,
 /area/crew_quarters/cabin4)
 "lox" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "loC" = (
@@ -67800,9 +66589,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "loL" = (
@@ -67810,7 +66597,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -67859,7 +66645,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "lpd" = (
@@ -67921,9 +66707,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "lpO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 8;
@@ -67938,9 +66722,7 @@
 	network = list("Engineering","SS13");
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
@@ -67955,13 +66737,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "lqa" = (
 /obj/machinery/biogenerator,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "green"
@@ -67974,7 +66756,7 @@
 "lqd" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -67996,13 +66778,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "lqn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "lqA" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/binary/valve/digital{
 	desc = "Открывает газу путь к нагревателям, холодильникам и фильтрам";
 	dir = 4;
@@ -68058,7 +66838,7 @@
 	},
 /area/maintenance/starboard)
 "lqQ" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -68072,7 +66852,7 @@
 	},
 /area/maintenance/consarea_virology)
 "lrb" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 1;
@@ -68113,7 +66893,7 @@
 /turf/space,
 /area/maintenance/consarea_virology)
 "lrz" = (
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 4;
@@ -68126,15 +66906,13 @@
 /obj/machinery/r_n_d/destructive_analyzer{
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/toxins/lab)
 "lrN" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 4;
@@ -68144,9 +66922,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "lrR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 1;
@@ -68156,7 +66932,7 @@
 /area/atmos)
 "lsc" = (
 /obj/machinery/recharge_station,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
 	},
@@ -68179,10 +66955,8 @@
 /area/lawoffice)
 "lsz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "lsA" = (
@@ -68238,12 +67012,6 @@
 	icon_state = "dark"
 	},
 /area/chapel/main)
-"lsW" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/north)
 "lsX" = (
 /obj/structure/railing,
 /obj/machinery/camera{
@@ -68292,7 +67060,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/power/emitter/welded{
 	dir = 4
 	},
@@ -68324,9 +67092,7 @@
 	},
 /area/security/main)
 "luo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/sign/poster/official/help_others{
@@ -68381,7 +67147,7 @@
 	},
 /area/medical/ward)
 "luK" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/lootdrop/maintenance/double,
 /turf/simulated/floor/plasteel{
@@ -68401,7 +67167,7 @@
 "luV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/multitool,
 /obj/item/multitool,
 /obj/item/clothing/glasses/welding,
@@ -68474,7 +67240,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen)
 "lwc" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
 	dir = 4
@@ -68510,7 +67276,7 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/clothing/glasses/hud/hydroponic,
 /obj/item/clothing/glasses/hud/hydroponic,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -68644,9 +67410,10 @@
 /area/security/customs)
 "lyX" = (
 /obj/structure/cable/yellow{
+	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -68741,6 +67508,7 @@
 /obj/effect/spawner/random_spawners/rodent,
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -68799,7 +67567,7 @@
 	},
 /area/toxins/test_chamber)
 "lBs" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -68819,7 +67587,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/cabin4)
 "lBB" = (
@@ -68843,9 +67610,7 @@
 "lBI" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "lBJ" = (
@@ -68909,8 +67674,8 @@
 	},
 /area/quartermaster/office)
 "lDj" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -68944,20 +67709,9 @@
 /obj/effect/decal/ants,
 /turf/simulated/floor/plating,
 /area/crew_quarters/theatre)
-"lDz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/quartermaster/qm)
 "lDA" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "lDJ" = (
@@ -68976,7 +67730,7 @@
 	},
 /area/medical/research/nhallway)
 "lEd" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "lEe" = (
@@ -69019,17 +67773,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard/east)
-"lEw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/medbay)
 "lEy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -69051,8 +67794,8 @@
 /area/maintenance/asmaint)
 "lEI" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/portable_atmospherics/pump,
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel,
@@ -69075,7 +67818,7 @@
 	},
 /area/hallway/primary/starboard/east)
 "lFc" = (
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 8
 	},
 /obj/structure/chair/sofa/bench/left{
@@ -69223,10 +67966,10 @@
 	},
 /area/medical/cmo)
 "lHc" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -69441,13 +68184,13 @@
 "lJF" = (
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/personal/mining,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/miningdock)
 "lJK" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/emcloset,
 /obj/machinery/vending/wallmed{
 	pixel_y = 30
@@ -69629,7 +68372,6 @@
 	network = list("SS13","Security")
 	},
 /obj/machinery/light_switch/directional/north,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -69704,7 +68446,7 @@
 /area/hallway/primary/central/nw)
 "lNp" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/window/reinforced{
 	color = "red";
 	dir = 4
@@ -69746,7 +68488,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -69881,9 +68623,7 @@
 	id_tag = "engstorage";
 	name = "Secure Storage Blast Doors"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -70144,20 +68884,20 @@
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "lTF" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "lTH" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/permabrig)
 "lTM" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -70181,9 +68921,7 @@
 "lUd" = (
 /obj/structure/morgue,
 /obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/camera{
 	c_tag = "Morgue";
 	dir = 4;
@@ -70195,13 +68933,6 @@
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
-"lUj" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/fore)
 "lUm" = (
 /obj/machinery/alarm/directional/north,
 /obj/machinery/kitchen_machine/grill,
@@ -70249,9 +68980,7 @@
 	},
 /area/bridge)
 "lUS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/toxins/launch)
 "lUZ" = (
@@ -70351,7 +69080,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -70367,9 +69096,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -70406,7 +69133,7 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -70417,7 +69144,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/consarea_virology)
@@ -70428,10 +69155,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
 "lXa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/window/plasmareinforced{
 	dir = 1
 	},
@@ -70456,10 +69181,8 @@
 /area/medical/surgery/north)
 "lXf" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -70530,7 +69253,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -70540,7 +69263,7 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -70573,7 +69296,7 @@
 	},
 /area/security/warden)
 "lYu" = (
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -70613,12 +69336,6 @@
 	icon_state = "chapel"
 	},
 /area/chapel/main)
-"lZn" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/security/hos)
 "lZp" = (
 /obj/item/folder/red{
 	pixel_x = -2;
@@ -70646,7 +69363,7 @@
 	},
 /area/maintenance/detectives_office)
 "lZw" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -70691,10 +69408,8 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -70708,11 +69423,11 @@
 "mac" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/door/window/brigdoor,
 /turf/simulated/floor/plating,
 /area/toxins/sm_test_chamber)
@@ -70739,9 +69454,7 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "mal" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "man" = (
@@ -70774,9 +69487,7 @@
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "maB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -70851,13 +69562,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
-"mbK" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/hallway/secondary/entry/lounge)
 "mbR" = (
 /obj/effect/spawner/random_spawners/wall_rusted_70,
 /turf/simulated/wall,
@@ -70881,9 +69585,7 @@
 /turf/simulated/wall,
 /area/medical/research)
 "mcf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -70932,9 +69634,9 @@
 /area/maintenance/asmaint2)
 "mdl" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70966,9 +69668,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "mdx" = (
@@ -70977,7 +69677,7 @@
 	layer = 5;
 	pixel_y = -5
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/mirror{
 	pixel_y = -30
 	},
@@ -71056,7 +69756,7 @@
 /turf/simulated/floor/plating,
 /area/toxins/sm_test_chamber)
 "meq" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 1;
@@ -71090,7 +69790,7 @@
 	},
 /area/medical/research/shallway)
 "meY" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/safe{
 	known_by = list("hos")
 	},
@@ -71101,9 +69801,7 @@
 /area/security/securearmory)
 "mfb" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -71199,8 +69897,8 @@
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	dir = 5;
@@ -71209,9 +69907,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "mfL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -71274,9 +69970,7 @@
 	},
 /area/bridge/vip)
 "mgu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -71377,14 +70071,14 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/library/game_zone)
 "mhL" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "mhO" = (
@@ -71400,7 +70094,7 @@
 	},
 /area/hallway/primary/fore)
 "mhS" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -71412,7 +70106,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -71422,7 +70116,7 @@
 /area/hallway/primary/fore)
 "mid" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -71430,10 +70124,7 @@
 	},
 /area/hallway/primary/fore)
 "mie" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -71454,14 +70145,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "miw" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "miO" = (
@@ -71505,9 +70195,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
@@ -71515,9 +70203,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -71627,9 +70313,7 @@
 	amount = 5
 	},
 /obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
 	id = "vir_work_zone1"
@@ -71677,7 +70361,7 @@
 /turf/space,
 /area/solar/starboard)
 "mlh" = (
-/obj/effect/turf_decal/delivery/partial,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /turf/simulated/floor/plating,
 /area/toxins/launch)
 "mln" = (
@@ -71716,7 +70400,7 @@
 "mlQ" = (
 /obj/item/radio/intercom/directional/north,
 /obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -71750,19 +70434,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "mmv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 5
 	},
@@ -71855,9 +70535,7 @@
 	},
 /area/hallway/primary/port/west)
 "mnb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/suit_storage_unit/atmos,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -71877,7 +70555,7 @@
 "mnk" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/lightsout,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=V4";
 	location = "V3"
@@ -71964,9 +70642,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -71977,7 +70653,7 @@
 	},
 /area/engineering/break_room)
 "mop" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/closet/secure_closet/pilot_sniper,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -72035,7 +70711,7 @@
 /turf/simulated/floor/engine/insulated,
 /area/maintenance/asmaint4)
 "moF" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
 	},
@@ -72046,6 +70722,7 @@
 /area/maintenance/fpmaint)
 "moK" = (
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/generator/directional/east,
@@ -72059,7 +70736,6 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -72312,16 +70988,14 @@
 /turf/simulated/floor/plating,
 /area/security/main)
 "mqY" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/engineering/hardsuitstorage)
 "mrf" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -72410,9 +71084,7 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "mrN" = (
@@ -72518,9 +71190,7 @@
 "mtD" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/item/paper/monitorkey,
 /obj/item/paper/rnd_logs_key{
 	pixel_x = 6;
@@ -72577,13 +71247,6 @@
 	},
 /turf/simulated/floor/noslip,
 /area/engineering/controlroom)
-"mtS" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/locker)
 "muf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72651,7 +71314,7 @@
 /area/atmos)
 "muK" = (
 /obj/effect/spawner/window/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
 "muM" = (
@@ -72695,7 +71358,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -72850,13 +71513,13 @@
 /obj/item/wrench,
 /obj/item/crowbar,
 /obj/item/paicard,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "mxh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -72939,10 +71602,8 @@
 	},
 /area/crew_quarters/theatre)
 "mxZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/chem_heater,
 /obj/structure/window/plasmareinforced{
 	dir = 4
@@ -72965,13 +71626,10 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "myK" = (
@@ -72982,18 +71640,14 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/maintenance/banya)
 "myZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/securearmory)
 "mzf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -73047,9 +71701,7 @@
 	},
 /area/toxins/misc_lab)
 "mAl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -73159,9 +71811,7 @@
 	},
 /area/engineering/hardsuitstorage)
 "mBa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/chemist,
 /obj/structure/cable{
@@ -73284,7 +71934,7 @@
 /area/crew_quarters/bar)
 "mCe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -73392,7 +72042,7 @@
 	c_tag = "Primary Tool Storage";
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/janitorialcart,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -73400,7 +72050,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "mDe" = (
@@ -73643,13 +72293,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
-"mEV" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whiteblue"
-	},
-/area/medical/medbay)
 "mFb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -73779,17 +72422,14 @@
 /turf/simulated/floor/engine,
 /area/toxins/test_chamber)
 "mHa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor/closed,
 /turf/simulated/floor/plating,
 /area/maintenance/consarea_virology)
 "mHb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/landmark/start/hangover,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -73823,13 +72463,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin3)
-"mHr" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/carpet/green,
-/area/crew_quarters/serviceyard)
 "mHs" = (
 /obj/structure/chair{
 	dir = 8
@@ -73849,9 +72482,7 @@
 /turf/simulated/floor/noslip,
 /area/engineering/controlroom)
 "mHQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -73863,7 +72494,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/clothing/shoes/jackboots/armored,
 /obj/item/clothing/shoes/jackboots/armored,
 /obj/item/clothing/shoes/jackboots/armored,
@@ -73900,7 +72531,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "mIl" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -73998,10 +72629,10 @@
 	},
 /area/medical/medbay2)
 "mJD" = (
+/obj/effect/landmark/start/trainee_engineer,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -74043,7 +72674,7 @@
 "mJQ" = (
 /obj/structure/dispenser,
 /obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "mJT" = (
@@ -74204,7 +72835,7 @@
 /area/medical/research/nhallway)
 "mLd" = (
 /obj/machinery/vending/protein,
-/obj/effect/turf_decal/delivery/white,
+/obj/effect/decal/warning_stripes/white,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -74321,16 +72952,6 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/bar/atrium)
-"mLM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/library/game_zone)
 "mLS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -74383,10 +73004,8 @@
 	pixel_x = -1;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -74448,7 +73067,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -74465,9 +73084,7 @@
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "mMQ" = (
@@ -74516,7 +73133,7 @@
 /area/security/hos)
 "mNo" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "mNq" = (
@@ -74530,7 +73147,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "mNI" = (
@@ -74583,7 +73200,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -74660,7 +73277,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/sign/electricshock{
 	pixel_y = -32
 	},
@@ -74670,9 +73287,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/effect/landmark/start/trainee_engineer,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -74738,9 +73353,9 @@
 /area/maintenance/garden)
 "mQi" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -74860,11 +73475,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -74880,21 +73493,10 @@
 	icon_state = "blue"
 	},
 /area/bridge/checkpoint/south)
-"mRK" = (
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/permabrig)
 "mRM" = (
 /obj/effect/landmark/start/shaft_miner,
-/obj/effect/turf_decal/delivery/partial,
-/obj/effect/turf_decal/arrows/black,
+/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/decal/warning_stripes/arrow,
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
 	},
@@ -74966,7 +73568,7 @@
 /area/hallway/primary/port/west)
 "mSo" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "mSE" = (
@@ -74990,7 +73592,6 @@
 /area/space)
 "mSK" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
 	},
@@ -75085,7 +73686,7 @@
 "mTR" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "mTS" = (
@@ -75158,7 +73759,7 @@
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
 "mUF" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/firecloset,
 /obj/machinery/camera{
 	c_tag = "Toxin Equipment Storage";
@@ -75222,6 +73823,7 @@
 	icon_state = "grass_edge_medium"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -75237,7 +73839,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -75342,11 +73944,11 @@
 /area/maintenance/fpmaint)
 "mWV" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Singularity";
 	name = "Singularity Blast Doors"
@@ -75379,7 +73981,7 @@
 /area/maintenance/detectives_office)
 "mXf" = (
 /obj/structure/closet/crate/freezer,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -75422,11 +74024,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/locker)
+"mXx" = (
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/reagent_containers/food/drinks/mug/eng,
+/turf/simulated/floor/plasteel,
+/area/engineering/engine)
 "mXP" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/meter,
@@ -75486,14 +74093,12 @@
 	},
 /area/hallway/primary/central/south)
 "mYg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/power/apc/directional/north,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "mYl" = (
@@ -75528,22 +74133,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "mYX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
 "mZb" = (
@@ -75604,9 +74205,7 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -75657,7 +74256,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -75675,7 +74273,7 @@
 	pixel_x = 21;
 	pixel_y = -21
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint4)
@@ -75720,7 +74318,7 @@
 	id_tag = "sw_maint_sensor";
 	pixel_y = 33
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1379;
@@ -75736,7 +74334,7 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "naI" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
@@ -75846,14 +74444,12 @@
 "nbG" = (
 /obj/machinery/alarm/directional/west,
 /obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "nbI" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/westright{
 	dir = 4;
 	name = "Front Desk";
@@ -75870,7 +74466,7 @@
 /obj/structure/urinal{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker/locker_toilet)
 "nbT" = (
@@ -75883,7 +74479,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -75941,27 +74537,9 @@
 	dir = 1
 	},
 /obj/machinery/disposal,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
-"ndi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/central/north)
 "ndm" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -76123,7 +74701,7 @@
 	},
 /area/chapel/main)
 "nfj" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/rack/gunrack,
 /obj/structure/window/reinforced,
 /obj/item/gun/energy/gun{
@@ -76186,14 +74764,13 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/window/northleft,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	id_tag = "researchdesk1";
 	name = "Research Desk Shutters"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/toxins/lab)
 "nfV" = (
@@ -76251,7 +74828,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -76266,7 +74843,7 @@
 	icon_state = "grass_edge_medium"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/item/trash/cheesie,
 /turf/simulated/floor/plating,
@@ -76282,9 +74859,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating/airless,
 /area/medical/virology/lab)
@@ -76297,7 +74872,6 @@
 	pixel_y = 28
 	},
 /obj/item/radio/intercom/locked/prison/directional/north,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "redcorner"
@@ -76443,6 +75017,7 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -76479,7 +75054,7 @@
 	},
 /area/medical/cryo)
 "njv" = (
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "njy" = (
@@ -76506,7 +75081,7 @@
 	id_tag = "paramedic";
 	name = "Paramedic Garage"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
 	name = "Quarantine Lockdown"
@@ -76582,7 +75157,7 @@
 /area/toxins/xenobiology)
 "nkJ" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 6
@@ -76599,8 +75174,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/chem_dispenser/botanical,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/delivery/green,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/green,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -76609,7 +75184,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -76645,7 +75219,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/delivery)
 "nlk" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
@@ -76688,9 +75262,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -76750,7 +75322,7 @@
 "nmp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -76790,9 +75362,7 @@
 /area/security/hos)
 "nnh" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -76801,9 +75371,7 @@
 "nnj" = (
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkblue"
@@ -76820,7 +75388,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -76884,7 +75452,7 @@
 	},
 /area/hallway/primary/central/south)
 "nom" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -76935,17 +75503,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "npi" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/office)
-"npq" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/mixing)
 "npr" = (
 /obj/structure/sign/radiation{
 	pixel_x = -32
@@ -76962,7 +75524,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "npD" = (
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -76986,7 +75547,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -77072,12 +75633,13 @@
 	pixel_y = -10
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
 "nqB" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/eastleft{
 	name = "Hydroponics Desk";
@@ -77130,7 +75692,7 @@
 /area/hallway/primary/central/north)
 "nqI" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -77141,9 +75703,7 @@
 	id_tag = "engstorage";
 	name = "Secure Storage Blast Doors"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "nqM" = (
@@ -77207,7 +75767,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -77253,9 +75813,7 @@
 /obj/item/scalpel{
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
@@ -77390,20 +75948,18 @@
 	pixel_x = -1;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/toxins/lab)
 "nsT" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "nsU" = (
@@ -77421,7 +75977,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "nta" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -77508,7 +76064,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -77559,9 +76115,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -77593,26 +76147,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"nuS" = (
-/obj/machinery/optable,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/shower{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/medical/surgery/south)
 "nuU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light/small{
@@ -77734,6 +76268,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -77785,7 +76320,7 @@
 /area/hallway/primary/central/north)
 "nwv" = (
 /obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light_switch/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -77797,14 +76332,12 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/crowbar,
 /obj/item/wrench,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "nwH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/closet/walllocker{
 	pixel_y = 28
 	},
@@ -77813,12 +76346,6 @@
 	icon_state = "darkblue"
 	},
 /area/medical/morgue)
-"nwW" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
 "nwZ" = (
 /obj/structure/chair/sofa/right{
 	dir = 1
@@ -77921,9 +76448,7 @@
 	},
 /area/library/game_zone)
 "nyX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "nyZ" = (
@@ -77951,9 +76476,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/courtroom)
 "nzh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "nzn" = (
@@ -78080,11 +76603,11 @@
 	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -78186,7 +76709,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "nCi" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Singularity";
 	name = "Singularity Blast Doors"
@@ -78198,7 +76721,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -78244,9 +76767,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
@@ -78309,7 +76830,7 @@
 	c_tag = "Secure Technical Storage";
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
@@ -78324,7 +76845,7 @@
 /area/maintenance/asmaint4)
 "nDF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -78366,9 +76887,7 @@
 /area/engineering/gravitygenerator)
 "nEb" = (
 /obj/machinery/chem_heater,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -78424,7 +76943,7 @@
 /obj/machinery/newscaster/directional/north,
 /obj/item/storage/belt/utility,
 /obj/item/weldingtool,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "nFe" = (
@@ -78438,7 +76957,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -78602,7 +77121,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -78636,7 +77155,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "nGY" = (
@@ -78714,9 +77233,7 @@
 	},
 /area/security/prison/cell_block/A)
 "nHQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -78753,9 +77270,7 @@
 	},
 /area/hallway/primary/central/north)
 "nIo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -78777,8 +77292,8 @@
 /area/maintenance/starboard)
 "nIw" = (
 /obj/machinery/vending/hydroseeds,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -78838,6 +77353,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
@@ -78923,7 +77439,7 @@
 "nJD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "KPPS"
 	},
@@ -78937,10 +77453,8 @@
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/alarm/directional/west,
 /obj/machinery/mecha_part_fabricator,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -78978,7 +77492,7 @@
 /area/security/visiting_room)
 "nKf" = (
 /obj/structure/closet/secure_closet/personal/mining,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/alarm/directional/south,
 /obj/machinery/camera{
 	c_tag = "Mining West";
@@ -79036,13 +77550,13 @@
 	},
 /area/medical/research/nhallway)
 "nKJ" = (
-/obj/effect/turf_decal/delivery/hollow/right,
+/obj/effect/turf_decal/bot/right,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
 "nKR" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/plasteel,
@@ -79065,6 +77579,7 @@
 	},
 /obj/effect/spawner/random_spawners/grille_50,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -79139,9 +77654,7 @@
 	},
 /area/medical/research/nhallway)
 "nMG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -79180,7 +77693,7 @@
 /area/quartermaster/storage)
 "nNj" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/sw)
 "nNn" = (
@@ -79291,7 +77804,7 @@
 /area/maintenance/brig)
 "nOw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -79337,16 +77850,14 @@
 /area/hallway/primary/central/ne)
 "nPN" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "nPX" = (
 /obj/structure/chair/comfy/purp{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -79516,9 +78027,7 @@
 	},
 /area/security/brig)
 "nSd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -79864,6 +78373,7 @@
 	},
 /obj/effect/decal/cleanable/blood/writing,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -79912,7 +78422,7 @@
 /area/maintenance/fpmaint)
 "nVL" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -79984,7 +78494,7 @@
 	},
 /area/hydroponics)
 "nXs" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel,
 /area/security/securehallway)
@@ -80033,7 +78543,6 @@
 	},
 /area/security/processing)
 "nXU" = (
-/obj/effect/landmark/start/hangover,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -80052,7 +78561,7 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/watermelon,
 /obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/eastleft{
 	name = "Hydroponics Desk";
@@ -80158,11 +78667,11 @@
 "oak" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "oan" = (
@@ -80326,7 +78835,7 @@
 	id_tag = "sw_maint2_sensor";
 	pixel_y = 33
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -80343,11 +78852,9 @@
 	},
 /area/hallway/primary/fore)
 "obE" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -80397,9 +78904,11 @@
 /area/chapel/main)
 "occ" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/end,
+/obj/effect/decal/warning_stripes/eastsouthwest,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	dir = 2;
 	id_tag = "engsm"
@@ -80530,7 +79039,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -80557,7 +79066,7 @@
 "oem" = (
 /obj/machinery/alarm/directional/north,
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -80624,9 +79133,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -80674,9 +79181,7 @@
 /turf/simulated/floor/plating,
 /area/lawoffice)
 "ofG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "ofK" = (
@@ -80817,7 +79322,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -80873,9 +79378,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -80931,9 +79434,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "ohL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -81051,23 +79552,21 @@
 /area/medical/medbay2)
 "ojL" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/security/permabrig)
 "ojO" = (
 /obj/machinery/seed_extractor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/maintenance/garden)
 "ojQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -81165,7 +79664,7 @@
 /area/maintenance/tourist)
 "okH" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
@@ -81182,10 +79681,8 @@
 /area/maintenance/engineering)
 "okQ" = (
 /obj/machinery/vending/engivend,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -81225,8 +79722,8 @@
 /turf/simulated/floor/plating,
 /area/security/checkpoint/south)
 "olI" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/plasticflaps/opaque,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/plasticflaps,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	dir = 1;
@@ -81245,6 +79742,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -81376,9 +79874,7 @@
 /area/security/permahallway)
 "onr" = (
 /obj/machinery/suit_storage_unit/rd,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -81428,7 +79924,7 @@
 /area/hallway/primary/central/sw)
 "oob" = (
 /obj/machinery/mineral/ore_redemption,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_cargo";
 	name = "Cargo Lockdown"
@@ -81448,9 +79944,7 @@
 /area/maintenance/fpmaint)
 "oop" = (
 /obj/machinery/suit_storage_unit/captain,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain/bedroom)
 "ooC" = (
@@ -81467,7 +79961,6 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
@@ -81498,11 +79991,6 @@
 	icon_state = "dark"
 	},
 /area/engineering/aienter)
-"opf" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/chair/sofa/left,
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint4)
 "opt" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken7"
@@ -81743,9 +80231,7 @@
 	},
 /area/hallway/secondary/entry/commercial)
 "orS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	desc = "Труба хранит в себе набор газов для смешивания";
 	dir = 4;
@@ -81790,25 +80276,25 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "osi" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
@@ -81916,7 +80402,7 @@
 /area/maintenance/brig)
 "otM" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -81948,7 +80434,7 @@
 /obj/item/seeds/banana,
 /obj/item/seeds/banana,
 /obj/item/seeds/banana,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/radio/intercom/locked/prison/directional/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -81959,16 +80445,12 @@
 	dir = 4
 	},
 /obj/machinery/alarm/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/engineering/supermatter)
 "oud" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/binary/volume_pump{
 	desc = "Позволяет опустошить трубы для смеси, отправив весь газ в отходы на фильтрацию";
 	dir = 4;
@@ -82009,9 +80491,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "ouL" = (
@@ -82043,11 +80523,10 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "ovb" = (
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/suit_storage_unit/security,
 /turf/simulated/floor/plasteel{
@@ -82149,16 +80628,8 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/carpet,
 /area/library)
-"owe" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "redfull"
-	},
-/area/security/customs)
 "owl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -82303,9 +80774,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "oyc" = (
@@ -82458,7 +80927,7 @@
 /area/quartermaster/delivery)
 "ozi" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -82519,7 +80988,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -82601,7 +81070,7 @@
 /area/turret_protected/aisat_interior)
 "oAs" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -82652,7 +81121,7 @@
 /area/maintenance/library)
 "oAW" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -82697,6 +81166,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/blood_5,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -82767,13 +81237,14 @@
 	},
 /obj/effect/spawner/random_spawners/blood_5,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
 "oCn" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "oCo" = (
@@ -82860,9 +81331,11 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -82913,9 +81386,7 @@
 	},
 /area/atmos)
 "oEj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -82923,7 +81394,7 @@
 /area/medical/research/nhallway)
 "oEk" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "oEr" = (
@@ -83034,9 +81505,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/serviceyard)
 "oFJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -83051,10 +81520,8 @@
 /area/maintenance/starboard)
 "oFU" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/north,
 /obj/item/stack/sheet/plasteel{
 	amount = 10
 	},
@@ -83067,9 +81534,7 @@
 	},
 /area/engineering/hardsuitstorage)
 "oFX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "oFZ" = (
@@ -83109,7 +81574,7 @@
 "oGn" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "caution"
@@ -83175,7 +81640,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -83208,11 +81672,11 @@
 /area/engineering/engine)
 "oHg" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "oHq" = (
@@ -83283,18 +81747,17 @@
 "oHT" = (
 /obj/machinery/power/energy_accumulator/rad_collector/anchored,
 /obj/structure/cable/yellow{
+	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "oHY" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel,
 /area/security/securehallway)
@@ -83397,7 +81860,7 @@
 	},
 /area/turret_protected/aisat_interior)
 "oJd" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_y = 28
@@ -83514,12 +81977,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"oKg" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/reception)
 "oKo" = (
 /obj/structure/chair/comfy/brown,
 /obj/machinery/alarm/directional/north,
@@ -83551,13 +82008,10 @@
 	locked = 1;
 	name = "Xenobio Kill Room"
 	},
-/obj/structure/plasticflaps/kitchen,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "oKD" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/eastnorthwest,
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/light{
 	dir = 8
@@ -83584,9 +82038,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "oKQ" = (
@@ -83682,7 +82134,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
@@ -83744,9 +82196,7 @@
 	},
 /area/hallway/secondary/entry/lounge)
 "oMz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
 	dir = 1;
@@ -83786,15 +82236,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plasteel/grimy,
 /area/civilian/vacantoffice)
-"oNa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/toxins/launch)
 "oNc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
@@ -83903,7 +82344,7 @@
 /area/toxins/misc_lab)
 "oPh" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "oPj" = (
@@ -83949,6 +82390,7 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/window/plasmareinforced{
@@ -84015,7 +82457,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -84023,7 +82465,7 @@
 /area/engineering/break_room)
 "oRe" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -84094,7 +82536,6 @@
 	},
 /area/storage/tech)
 "oSu" = (
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "oSy" = (
@@ -84117,13 +82558,11 @@
 /area/storage/tech)
 "oSO" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "oSQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/trinary/mixer,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -84169,7 +82608,7 @@
 	},
 /obj/effect/landmark/lightsout,
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/library)
@@ -84280,6 +82719,7 @@
 /obj/effect/decal/cleanable/dust,
 /obj/item/chair,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -84299,7 +82739,7 @@
 /obj/machinery/bodyscanner{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -84346,7 +82786,7 @@
 /area/maintenance/asmaint)
 "oVl" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -84361,9 +82801,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -84420,7 +82858,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "oVT" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
 /area/gateway)
@@ -84447,13 +82885,6 @@
 /obj/effect/mapping_helpers/turfs/burn,
 /turf/simulated/floor/plating/airless,
 /area/space)
-"oWL" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/bridge/vip)
 "oWT" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Cell Block";
@@ -84614,21 +83045,6 @@
 	icon_state = "white"
 	},
 /area/toxins/lab)
-"oYC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/assembly/robotics)
 "oYL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -84700,9 +83116,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
@@ -84748,7 +83162,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/suit/armor/bulletproof,
@@ -84821,9 +83235,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
 "pbv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /mob/living/carbon/human/lesser/monkey,
 /turf/simulated/floor/plasteel{
@@ -84891,9 +83303,7 @@
 /area/security/customs)
 "pcD" = (
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "pcG" = (
@@ -84978,11 +83388,9 @@
 	},
 /area/crew_quarters/fitness)
 "pda" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
 	},
@@ -85065,7 +83473,7 @@
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/toy/figure/engineer,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "yellow"
@@ -85076,9 +83484,7 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
 "pem" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/closet/walllocker{
 	pixel_y = 28
 	},
@@ -85144,7 +83550,7 @@
 /area/engineering/engine)
 "pfo" = (
 /obj/structure/table,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/cell_charger,
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/camera{
@@ -85186,7 +83592,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/theatre)
 "pfD" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/eastright{
 	dir = 2;
 	name = "Chemistry Delivery";
@@ -85261,7 +83667,7 @@
 	},
 /area/medical/research/nhallway)
 "pgt" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -85297,9 +83703,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "pgL" = (
@@ -85451,7 +83855,7 @@
 	},
 /area/library/game_zone)
 "phR" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
@@ -85501,7 +83905,7 @@
 /area/maintenance/brig)
 "pjd" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/brigstaff)
 "pjh" = (
@@ -85527,7 +83931,7 @@
 	},
 /area/medical/medbay2)
 "pjm" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/cargo_technician,
 /turf/simulated/floor/plasteel{
@@ -85578,6 +83982,7 @@
 "pjX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -85675,7 +84080,7 @@
 /area/medical/psych)
 "pln" = (
 /obj/machinery/smartfridge/medbay,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
@@ -85768,7 +84173,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "pmN" = (
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -85806,6 +84210,7 @@
 	dir = 10
 	},
 /obj/structure/cable/yellow{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/window/plasmareinforced{
@@ -85820,6 +84225,8 @@
 /area/teleporter/abandoned)
 "pnx" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
@@ -85846,9 +84253,7 @@
 	},
 /area/library/game_zone)
 "pnJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -85882,6 +84287,7 @@
 /area/hallway/primary/central/se)
 "pnU" = (
 /obj/structure/cable/yellow{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/window/plasmareinforced{
@@ -85925,7 +84331,7 @@
 	},
 /obj/item/folder/yellow,
 /obj/item/pen,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/item/poster/random_contraband,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_cargo";
@@ -85994,9 +84400,7 @@
 	},
 /area/atmos)
 "pox" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -86019,9 +84423,7 @@
 	},
 /area/medical/research/shallway)
 "poX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
@@ -86037,9 +84439,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
 "ppg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -86103,9 +84503,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -86125,9 +84523,7 @@
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/dropper,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "pqB" = (
@@ -86142,7 +84538,6 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -86150,7 +84545,6 @@
 /area/crew_quarters/locker)
 "pqJ" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/wood,
 /area/library)
 "pqM" = (
@@ -86187,7 +84581,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -86236,13 +84630,12 @@
 	},
 /area/maintenance/library)
 "prt" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -86262,10 +84655,8 @@
 /area/maintenance/asmaint3)
 "prK" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -86322,9 +84713,7 @@
 	pixel_y = 3
 	},
 /obj/item/circuitboard/mecha_control,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "psg" = (
@@ -86428,7 +84817,7 @@
 	name = "Creature Pen";
 	req_access = list(47)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -86477,6 +84866,8 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
@@ -86502,9 +84893,7 @@
 	pixel_y = -25;
 	req_access = list(13)
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "pug" = (
@@ -86516,14 +84905,14 @@
 /area/maintenance/perma)
 "pui" = (
 /obj/machinery/vending/hydroseeds,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "green"
 	},
 /area/maintenance/garden)
 "pus" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/field/generator,
 /turf/simulated/floor/plasteel,
@@ -86611,10 +85000,6 @@
 "puN" = (
 /turf/simulated/wall/rust,
 /area/maintenance/disposal)
-"puR" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/carpet/green,
-/area/crew_quarters/bar/atrium)
 "puT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -86642,6 +85027,8 @@
 	pixel_x = 32
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -86651,7 +85038,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "pvt" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -86705,9 +85092,7 @@
 	},
 /area/storage/primary)
 "pwH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/closet/walllocker/emerglocker/directional/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
@@ -86827,7 +85212,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -86840,7 +85224,7 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "pyQ" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -86881,7 +85265,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
@@ -86915,9 +85299,6 @@
 	},
 /area/maintenance/asmaint4)
 "pzO" = (
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 32
-	},
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -86955,10 +85336,8 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "pAh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/southwest,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/chem_master,
 /obj/structure/window/plasmareinforced,
 /obj/machinery/light{
@@ -86993,7 +85372,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/pen,
@@ -87077,11 +85456,11 @@
 "pBi" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
@@ -87182,7 +85561,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -87197,9 +85575,7 @@
 /area/toxins/mixing)
 "pCn" = (
 /obj/effect/landmark/start/scientist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/chair/office/light{
 	dir = 8
 	},
@@ -87217,10 +85593,8 @@
 /turf/simulated/floor/plating,
 /area/toxins/lab)
 "pCs" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -87231,7 +85605,7 @@
 /area/storage/eva)
 "pCt" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -87239,7 +85613,7 @@
 	},
 /area/security/customs)
 "pCB" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -87259,7 +85633,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -87390,7 +85764,7 @@
 /area/security/securehallway)
 "pDU" = (
 /obj/machinery/newscaster/security_unit/directional/north,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/vending/gun_mods,
 /turf/simulated/floor/plasteel,
 /area/security/customs)
@@ -87426,13 +85800,6 @@
 	icon_state = "neutral"
 	},
 /area/hallway/primary/central/south)
-"pEn" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/nw)
 "pEo" = (
 /obj/machinery/computer/teleporter,
 /turf/simulated/floor/plasteel,
@@ -87442,7 +85809,7 @@
 /area/engineering/engine)
 "pEC" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -87571,7 +85938,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/crate/hydroponics/prespawned,
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/plasteel{
@@ -87581,9 +85948,7 @@
 "pGk" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -87664,6 +86029,8 @@
 /area/maintenance/turbine)
 "pGB" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
@@ -87713,9 +86080,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "pHr" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -87864,7 +86229,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/item/tank/internals/plasma,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
 	},
@@ -87922,9 +86287,9 @@
 /area/maintenance/kitchen)
 "pJo" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/alarm/directional/west,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -87932,7 +86297,7 @@
 "pJs" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -88000,16 +86365,14 @@
 	pixel_y = -22
 	},
 /obj/item/flag/rnd,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/crew_quarters/hor)
 "pKg" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -88029,7 +86392,7 @@
 /area/maintenance/asmaint4)
 "pKk" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/toxins/explab)
 "pKm" = (
@@ -88041,9 +86404,7 @@
 	},
 /area/security/hos)
 "pKy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -88074,6 +86435,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/piano,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -88179,9 +86541,10 @@
 /area/medical/surgery/south)
 "pLR" = (
 /obj/structure/cable/yellow{
+	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/toxins/sm_test_chamber)
 "pMj" = (
@@ -88234,7 +86597,7 @@
 /obj/effect/turf_decal/caution{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/partial,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -88306,7 +86669,7 @@
 /area/turret_protected/aisat_interior)
 "pNE" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery/hollow/right,
+/obj/effect/turf_decal/bot/right,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -88536,9 +86899,7 @@
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint4)
 "pQK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/simulated/floor/plasteel{
@@ -88671,7 +87032,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitered"
@@ -88715,15 +87075,8 @@
 	},
 /turf/simulated/floor/plating,
 /area/chapel/office)
-"pSr" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/ne)
 "pSF" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/crate,
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
@@ -88789,10 +87142,8 @@
 /turf/simulated/floor/plating,
 /area/medical/medbay2)
 "pTy" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -88907,10 +87258,8 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
 "pUM" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "pUP" = (
@@ -88972,7 +87321,7 @@
 /area/bridge/vip)
 "pVL" = (
 /obj/machinery/disposal,
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/structure/sign/deathsposal{
 	pixel_y = 32
 	},
@@ -88988,7 +87337,7 @@
 	},
 /area/security/processing)
 "pVP" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -89006,7 +87355,7 @@
 	},
 /area/medical/virology/lab)
 "pWf" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/disposal,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/disposalpipe/trunk,
@@ -89054,8 +87403,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -89073,9 +87422,7 @@
 	},
 /area/medical/medbay)
 "pWz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
@@ -89101,7 +87448,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -89113,7 +87460,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
@@ -89148,7 +87494,7 @@
 	},
 /area/tcommsat/chamber)
 "pXg" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/camera{
 	c_tag = "Atmos Hatch";
 	dir = 8;
@@ -89175,9 +87521,7 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -89234,7 +87578,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "pYm" = (
@@ -89250,9 +87594,7 @@
 /area/chapel/office)
 "pYH" = (
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "pYJ" = (
@@ -89292,7 +87634,7 @@
 	},
 /area/crew_quarters/serviceyard)
 "pZl" = (
-/obj/effect/turf_decal/delivery/red/partial{
+/obj/effect/decal/warning_stripes/red/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -89304,7 +87646,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "pZu" = (
@@ -89327,7 +87669,7 @@
 /area/maintenance/starboard)
 "pZM" = (
 /obj/machinery/light/small,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -89357,13 +87699,13 @@
 	},
 /area/quartermaster/office)
 "pZY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
@@ -89477,7 +87819,7 @@
 	},
 /area/maintenance/kitchen)
 "qbl" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	dir = 4;
@@ -89517,7 +87859,7 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "qbx" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/computer/cryopod/robot{
 	pixel_y = 28
 	},
@@ -89541,9 +87883,7 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/item/reagent_containers/spray/cleaner/medical{
 	pixel_x = -2;
 	pixel_y = 12
@@ -89583,7 +87923,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -89593,9 +87933,7 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "qbY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 4;
@@ -89616,7 +87954,7 @@
 /area/turret_protected/aisat)
 "qce" = (
 /obj/machinery/space_heater,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
@@ -89659,9 +87997,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "qcF" = (
@@ -89695,9 +88031,7 @@
 	},
 /area/bridge)
 "qcW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -89716,14 +88050,12 @@
 /area/bridge)
 "qdg" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "qdu" = (
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "qdv" = (
@@ -89801,7 +88133,7 @@
 	},
 /area/hallway/primary/starboard/east)
 "qfg" = (
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /obj/structure/closet/crate/secure/blood,
 /obj/item/tank/internals/emergency_oxygen/plasma,
 /obj/item/reagent_containers/iv_bag/blood/AMinus,
@@ -89919,7 +88251,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -90096,7 +88428,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/security/customs)
 "qiL" = (
@@ -90132,8 +88463,8 @@
 	},
 /area/turret_protected/aisat_interior)
 "qjh" = (
-/obj/effect/turf_decal/delivery/partial,
-/obj/effect/turf_decal/arrows/black,
+/obj/effect/decal/warning_stripes/yellow/partial,
+/obj/effect/decal/warning_stripes/arrow,
 /obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
@@ -90152,12 +88483,12 @@
 /area/bridge/vip)
 "qjp" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/walllocker/emerglocker/directional/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "qjr" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1379;
 	id_tag = "atmos_tank_pump"
@@ -90251,7 +88582,7 @@
 /area/crew_quarters/fitness)
 "qko" = (
 /obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -90273,14 +88604,14 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "qkz" = (
 /turf/simulated/floor/plating,
 /area/crew_quarters/theatre)
 "qkE" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	name = "Труба на фильтрацию"
@@ -90337,13 +88668,6 @@
 	icon_state = "vault"
 	},
 /area/engineering/mechanic_workshop/hangar)
-"qlj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/entry/westarrival)
 "qlu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -90423,8 +88747,8 @@
 	},
 /area/library)
 "qmu" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -90458,9 +88782,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "green"
@@ -90549,7 +88871,7 @@
 	},
 /area/maintenance/asmaint4)
 "qok" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
@@ -90595,7 +88917,7 @@
 	},
 /area/hallway/primary/port/west)
 "qox" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/kitchenspike,
 /obj/machinery/camera{
 	c_tag = "Kitchen Backroom"
@@ -90655,7 +88977,7 @@
 	name = "Secure Tech Storage";
 	req_access = list(19,23)
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
@@ -90664,7 +88986,7 @@
 	dir = 8
 	},
 /obj/machinery/alarm/directional/west,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	desc = "Труба содержит дыхательную смесь для подачи на станцию";
 	dir = 8;
@@ -90706,7 +89028,7 @@
 /area/maintenance/fpmaint)
 "qpk" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "KPPS"
 	},
@@ -90728,7 +89050,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
 /obj/structure/chair/sofa/bench/right{
@@ -90785,7 +89107,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -90796,9 +89118,7 @@
 	pixel_y = 2
 	},
 /obj/item/stock_parts/cell/high,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/alarm/directional/south,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
@@ -90845,13 +89165,14 @@
 	},
 /area/security/permabrig)
 "qqG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/warning_stripes/west{
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "siding2"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "qqM" = (
@@ -90859,6 +89180,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -90995,7 +89317,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
@@ -91007,7 +89329,7 @@
 /turf/simulated/wall,
 /area/medical/surgery/north)
 "qsi" = (
-/obj/structure/plasticflaps/opaque,
+/obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "cargodelivery"
@@ -91128,6 +89450,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -91250,7 +89573,7 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -91288,7 +89611,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -91316,7 +89639,7 @@
 /area/security/permahallway)
 "qui" = (
 /obj/structure/dispenser/oxygen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -91364,9 +89687,7 @@
 	},
 /area/bridge/meeting_room)
 "quy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "quC" = (
@@ -91451,7 +89772,6 @@
 /obj/item/storage/secure/safe{
 	pixel_x = 32
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/carpet/royalblue,
 /area/crew_quarters/captain/bedroom)
 "qvA" = (
@@ -91462,9 +89782,11 @@
 "qvF" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -91555,11 +89877,11 @@
 /area/medical/surgery/south)
 "qwK" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/eastnorthwest,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	dir = 2;
 	id_tag = "engsm"
@@ -91586,9 +89908,7 @@
 /area/maintenance/consarea_virology)
 "qwQ" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "qwW" = (
@@ -91613,9 +89933,7 @@
 	},
 /area/medical/surgery/north)
 "qxe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -91675,7 +89993,7 @@
 /area/security/prison/cell_block/A)
 "qxY" = (
 /obj/effect/landmark/spawner/late/cyborg,
-/obj/effect/turf_decal/delivery/partial,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /obj/machinery/light_switch/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -91684,9 +90002,7 @@
 /area/assembly/chargebay)
 "qyg" = (
 /obj/structure/closet/secure_closet/captains,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain/bedroom)
 "qyB" = (
@@ -91697,9 +90013,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -91781,6 +90095,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
@@ -91817,7 +90132,7 @@
 	},
 /area/medical/virology)
 "qAw" = (
-/obj/machinery/jukebox/bar,
+/obj/machinery/computer/arcade,
 /turf/simulated/floor/carpet/red,
 /area/crew_quarters/bar/atrium)
 "qAH" = (
@@ -91835,6 +90150,8 @@
 /area/security/prison/cell_block/A)
 "qAK" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
@@ -91860,7 +90177,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -91883,18 +90200,14 @@
 "qBb" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/alarm/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "qBc" = (
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -91902,7 +90215,7 @@
 /area/crew_quarters/chief)
 "qBn" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -92078,17 +90391,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/banya)
-"qDj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	desc = "Труба проводящая газ по фильтрам, где он перемещается в камеры хранения";
-	dir = 4;
-	name = "Труба фильтрации"
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/atmos)
 "qDm" = (
 /obj/machinery/ticket_machine{
 	layer = 4;
@@ -92101,7 +90403,7 @@
 /area/bridge/vip)
 "qDz" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -92174,12 +90476,8 @@
 /area/teleporter)
 "qEj" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "qEo" = (
@@ -92223,7 +90521,7 @@
 	},
 /area/hallway/primary/central/east)
 "qEK" = (
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -92292,7 +90590,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "qFn" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -92473,7 +90771,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -92496,9 +90793,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/customs)
 "qHl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -92511,13 +90806,6 @@
 	icon_state = "dark"
 	},
 /area/medical/virology/lab)
-"qHr" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/wood,
-/area/library)
 "qHP" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet,
@@ -92568,7 +90856,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -92628,9 +90916,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "qJh" = (
@@ -92703,11 +90989,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
 "qKI" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -93026,9 +91313,7 @@
 "qNX" = (
 /obj/item/reagent_containers/food/snacks/meat/humanoid/human,
 /obj/item/reagent_containers/food/snacks/meat/humanoid/human,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/effect/spawner/random_spawners/blood_5,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -93036,7 +91321,7 @@
 /area/maintenance/kitchen)
 "qNZ" = (
 /obj/item/robot_parts/robot_suit,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -93068,12 +91353,6 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
-"qOm" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
-	},
-/area/hallway/primary/starboard/east)
 "qOo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -93176,12 +91455,6 @@
 	icon_state = "dark"
 	},
 /area/security/permabrig)
-"qPq" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/entry/westarrival)
 "qPr" = (
 /obj/machinery/door/airlock/security/glass{
 	id = "execution";
@@ -93345,9 +91618,7 @@
 /area/ntrep)
 "qRa" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "QMLoad"
@@ -93385,7 +91656,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -93395,10 +91666,8 @@
 	},
 /area/security/permabrig)
 "qRN" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -93418,10 +91687,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/wood/fancy/light,
 /area/ntrep)
-"qSv" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/miningdock)
 "qSG" = (
 /obj/item/phone{
 	pixel_x = -3;
@@ -93448,9 +91713,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -93472,10 +91735,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/light{
 	dir = 1
@@ -93525,9 +91786,7 @@
 	req_access = list(10,13)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "qTP" = (
@@ -93559,9 +91818,7 @@
 /obj/structure/sign/electricshock{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -93579,7 +91836,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/gravitygenerator)
 "qUi" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -93593,7 +91850,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -93626,9 +91883,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -93672,6 +91927,7 @@
 	pixel_y = -10
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -93718,9 +91974,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "qVN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -93775,9 +92029,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -93848,9 +92100,7 @@
 /area/maintenance/asmaint4)
 "qXH" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
 /area/aisat/maintenance)
 "qXI" = (
@@ -93869,20 +92119,18 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "qYb" = (
 /obj/structure/closet/secure_closet/personal/mining,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -93966,7 +92214,7 @@
 	},
 /area/crew_quarters/hor)
 "qZy" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -94016,11 +92264,10 @@
 /area/maintenance/garden)
 "rac" = (
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -94059,7 +92306,7 @@
 /area/crew_quarters/cabin3)
 "rax" = (
 /obj/structure/plasticflaps,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "cargodisposals"
@@ -94085,7 +92332,7 @@
 	},
 /area/engineering/aienter)
 "raR" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "raW" = (
@@ -94148,9 +92395,7 @@
 	},
 /area/security/range)
 "rbs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkblue"
@@ -94174,7 +92419,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -94327,9 +92572,7 @@
 /area/crew_quarters/theatre)
 "rcI" = (
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "rcM" = (
@@ -94348,9 +92591,7 @@
 /area/engineering/break_room)
 "rcO" = (
 /obj/machinery/r_n_d/protolathe,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -94375,9 +92616,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -94400,9 +92639,7 @@
 	},
 /area/hallway/secondary/exit)
 "rdo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/box/lights/mixed,
@@ -94461,7 +92698,7 @@
 /obj/structure/table/reinforced,
 /obj/item/analyzer,
 /obj/item/assembly/signaler,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "reD" = (
@@ -94473,6 +92710,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -94522,6 +92760,7 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -94539,6 +92778,7 @@
 	icon_state = "c"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -94555,6 +92795,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -94582,7 +92823,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "rfs" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12;
@@ -94627,7 +92868,7 @@
 /area/maintenance/asmaint3)
 "rfQ" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "rfV" = (
@@ -94644,9 +92885,7 @@
 	},
 /area/maintenance/kitchen)
 "rfZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "rgj" = (
@@ -94772,9 +93011,7 @@
 	},
 /area/turret_protected/aisat_interior)
 "ric" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -94813,10 +93050,8 @@
 	},
 /area/security/warden)
 "riR" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -94849,13 +93084,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
-"rju" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
-	},
-/area/hallway/secondary/entry/commercial)
 "rjy" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -94939,9 +93167,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "rkA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/suit_storage_unit/atmos,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -94953,13 +93179,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitepurple"
@@ -95027,7 +93251,7 @@
 /area/crew_quarters/courtroom)
 "rlE" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -95075,9 +93299,7 @@
 	},
 /area/engineering/engine/monitor)
 "rmK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "rmQ" = (
@@ -95131,9 +93353,7 @@
 /area/hallway/primary/central/west)
 "rnH" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /obj/item/paper_bin,
 /obj/item/pen/red,
 /obj/structure/window/reinforced/polarized{
@@ -95152,12 +93372,8 @@
 	},
 /area/medical/virology/lab)
 "rnJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -95334,7 +93550,6 @@
 /area/maintenance/starboard)
 "rpd" = (
 /obj/item/radio/intercom/directional/west,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -95378,7 +93593,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "rpF" = (
@@ -95410,9 +93625,7 @@
 	},
 /area/bridge)
 "rpS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -95455,11 +93668,11 @@
 	},
 /area/engineering/mechanic_workshop/hangar)
 "rqI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light/small,
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -95496,7 +93709,7 @@
 /obj/machinery/vending/wallmed{
 	pixel_x = 25
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/sign/poster/official/enlist{
 	pixel_y = 32
 	},
@@ -95638,10 +93851,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -95649,7 +93860,7 @@
 /area/toxins/storage)
 "rtb" = (
 /obj/structure/closet/coffin,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -95689,15 +93900,6 @@
 	icon_state = "red"
 	},
 /area/security/prison/cell_block/A)
-"rtr" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/bridge/meeting_room)
 "rtB" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall,
@@ -95754,7 +93956,7 @@
 	},
 /area/bridge)
 "rup" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -95851,18 +94053,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "rvn" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "rvt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkblue"
@@ -96067,24 +94265,10 @@
 	icon_state = "darkred"
 	},
 /area/security/securearmory)
-"ryj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research/nhallway)
 "rym" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "ryn" = (
@@ -96128,7 +94312,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1379;
@@ -96138,7 +94322,6 @@
 	pixel_x = 24;
 	pixel_y = 28
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "ryp" = (
@@ -96226,9 +94409,7 @@
 	},
 /area/maintenance/kitchen)
 "rzf" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -96341,9 +94522,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/closet/secure_closet/brig,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -96364,9 +94543,12 @@
 "rBh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -96524,9 +94706,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -96563,9 +94743,7 @@
 	},
 /area/engineering/engine)
 "rDp" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "rDA" = (
@@ -96594,12 +94772,8 @@
 	},
 /area/toxins/xenobiology)
 "rDF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
@@ -96687,9 +94861,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "rED" = (
@@ -96718,7 +94890,7 @@
 /area/quartermaster/qm)
 "rEM" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -96726,11 +94898,11 @@
 	},
 /area/hallway/secondary/entry/commercial)
 "rEO" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/secure_closet/engineering_welding,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/glasses/welding,
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/rack,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "rES" = (
@@ -96781,9 +94953,7 @@
 	},
 /area/maintenance/kitchen)
 "rFw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box/full,
 /obj/item/storage/fancy/candle_box/full{
@@ -96824,11 +94994,9 @@
 	},
 /area/security/prison/cell_block/A)
 "rFD" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -96840,17 +95008,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
 /area/toxins/xenobiology)
 "rFS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -96870,13 +95034,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
-"rGj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/storage)
 "rGs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -96953,7 +95110,7 @@
 	frequency = 1379;
 	id_tag = "solar_xeno_pump"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "solar_xeno_airlock";
 	layer = 3.3;
@@ -97031,7 +95188,7 @@
 /obj/structure/closet/crate{
 	name = "solar pack crate"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/paper/solar,
 /obj/item/circuitboard/solar_control,
 /obj/item/solar_assembly,
@@ -97143,9 +95300,7 @@
 	},
 /area/chapel/main)
 "rIZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -97177,7 +95332,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "rJJ" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/radiation,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -97196,10 +95351,8 @@
 	},
 /area/medical/research/nhallway)
 "rKc" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -97209,7 +95362,7 @@
 /area/atmos)
 "rKg" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/door_control{
 	id = "Briefing";
 	name = "Briefing room Shutters Control";
@@ -97247,7 +95400,7 @@
 /obj/item/assembly/timer,
 /obj/item/multitool,
 /obj/item/multitool,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "rKL" = (
@@ -97260,7 +95413,7 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -97550,7 +95703,7 @@
 /area/medical/research/shallway)
 "rNT" = (
 /obj/structure/closet/secure_closet/injection,
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/machinery/newscaster/security_unit/directional/west,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/simulated/floor/plasteel{
@@ -97598,9 +95751,7 @@
 /area/bridge/vip)
 "rOR" = (
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -97608,7 +95759,7 @@
 /area/medical/virology/lab)
 "rOW" = (
 /obj/machinery/alarm/directional/south,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -97629,6 +95780,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -97636,7 +95788,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -97656,9 +95808,7 @@
 /area/security/execution)
 "rPj" = (
 /obj/machinery/field/generator/anchored,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "rPs" = (
@@ -97704,9 +95854,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/customs)
 "rPU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "rQf" = (
@@ -97754,7 +95902,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/pen,
@@ -97786,9 +95934,7 @@
 	},
 /area/security/securehallway)
 "rQP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Singularity";
 	name = "Singularity Blast Doors"
@@ -97824,6 +95970,8 @@
 	pixel_y = 33
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -97882,12 +96030,6 @@
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/toxins/sm_test_chamber)
-"rRN" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/atmos)
 "rRO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -97924,9 +96066,7 @@
 	},
 /area/crew_quarters/locker)
 "rSa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -97970,9 +96110,7 @@
 /area/medical/research/shallway)
 "rSt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "rSH" = (
@@ -98157,8 +96295,8 @@
 /obj/item/stack/rods{
 	amount = 10
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/stack/sheet/glass{
 	amount = 10
 	},
@@ -98171,9 +96309,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "rVe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -98234,9 +96370,7 @@
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "rVM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_y = -30
@@ -98250,7 +96384,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
@@ -98292,7 +96426,7 @@
 	c_tag = "Cargo Shuttle Airlock";
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -98366,9 +96500,7 @@
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
 "rXc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	frequency = 1379;
@@ -98427,10 +96559,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
-"rXE" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel,
-/area/security/range)
 "rXZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/confetti,
@@ -98462,13 +96590,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/reception)
-"rYK" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/red,
-/area/crew_quarters/bar/atrium)
 "rYP" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -98515,7 +96636,7 @@
 /area/medical/virology/lab)
 "rZI" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -98688,7 +96809,7 @@
 /obj/item/analyzer,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "sbF" = (
@@ -98714,7 +96835,7 @@
 	name = "Primary Tool Storage Console";
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "sci" = (
@@ -98743,7 +96864,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "scB" = (
@@ -98808,7 +96929,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "scZ" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -98885,7 +97006,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "sei" = (
@@ -98949,7 +97070,7 @@
 	},
 /area/medical/medbay)
 "seF" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -99019,7 +97140,6 @@
 "seU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/wood,
 /area/crew_quarters/cabin2)
 "sfb" = (
@@ -99063,7 +97183,7 @@
 /turf/simulated/floor/carpet/red,
 /area/crew_quarters/bar/atrium)
 "sfU" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -99109,10 +97229,8 @@
 /area/medical/virology/lab)
 "sgx" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/northwest,
 /obj/item/radio/intercom/directional/south,
 /obj/item/stack/sheet/metal{
 	amount = 50
@@ -99225,12 +97343,8 @@
 	id_tag = "roboticsshutters";
 	name = "Mech Bay Shutters"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -99263,7 +97377,7 @@
 /area/security/execution)
 "six" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -99278,9 +97392,7 @@
 /area/bridge/vip)
 "siH" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -99300,9 +97412,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/detectives_office)
 "siL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "siM" = (
@@ -99321,6 +97431,7 @@
 	icon_state = "grass_edge_medium"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -99349,9 +97460,7 @@
 	c_tag = "Teleporter";
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /obj/machinery/light_switch/directional/east,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
@@ -99506,7 +97615,7 @@
 "slb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
@@ -99604,7 +97713,7 @@
 /area/security/checkpoint)
 "smf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -99683,7 +97792,7 @@
 /area/medical/cmo)
 "snl" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -99714,9 +97823,7 @@
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating/airless,
 /area/medical/virology/lab)
 "snH" = (
@@ -99774,13 +97881,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central/west)
-"sol" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/central/east)
 "sot" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -99959,9 +98059,7 @@
 /area/toxins/sm_test_chamber)
 "spH" = (
 /obj/structure/closet/secure_closet/RD,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -99988,7 +98086,7 @@
 /area/engineering/mechanic_workshop/expedition)
 "spL" = (
 /obj/machinery/alarm/directional/south,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/cargotech,
 /obj/item/stamp/granted,
 /obj/item/stamp/denied,
@@ -100112,7 +98210,7 @@
 /area/bridge)
 "sqZ" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -100144,7 +98242,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "srp" = (
-/obj/effect/turf_decal/delivery/partial,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
@@ -100155,7 +98253,7 @@
 /area/bridge/vip)
 "srA" = (
 /obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/sign/securearea{
 	pixel_y = -32
 	},
@@ -100282,7 +98380,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
@@ -100316,7 +98414,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/partial,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /obj/structure/chair/sofa/bench/right,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -100396,9 +98494,7 @@
 	},
 /area/crew_quarters/locker)
 "suf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -100463,7 +98559,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -100475,7 +98570,7 @@
 /obj/structure/table/reinforced,
 /obj/item/aicard,
 /obj/item/circuitboard/aicore,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "svo" = (
@@ -100498,7 +98593,7 @@
 	},
 /area/toxins/misc_lab)
 "svJ" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -100530,7 +98625,7 @@
 	},
 /area/hallway/secondary/exit)
 "svN" = (
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
@@ -100583,9 +98678,7 @@
 	locked = 1;
 	name = "West Maintenance External Access"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -100631,7 +98724,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/serviceyard)
 "swV" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -100667,12 +98760,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
-"sxi" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "purple"
-	},
-/area/quartermaster/miningdock)
 "sxk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -100692,9 +98779,11 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "sxp" = (
@@ -100898,15 +98987,6 @@
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
-"syZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel,
-/area/bridge/vip)
 "szb" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -100914,7 +98994,7 @@
 	},
 /area/security/processing)
 "szc" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "szd" = (
@@ -100991,7 +99071,7 @@
 /area/maintenance/tourist)
 "sAv" = (
 /obj/machinery/light/small,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -101051,9 +99131,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "sAQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -101075,7 +99153,7 @@
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/securearmory)
 "sBj" = (
@@ -101091,9 +99169,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "sBk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/camera{
 	c_tag = "Brig Storage";
@@ -101116,7 +99192,7 @@
 	},
 /area/bridge/vip)
 "sBx" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -101176,9 +99252,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/computer/station_alert,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -101190,7 +99264,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door_control{
 	id = "xeno4";
 	name = "Containment Control";
@@ -101236,7 +99310,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "sCB" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
@@ -101267,7 +99341,6 @@
 	pixel_x = 9;
 	pixel_y = 2
 	},
-/obj/structure/closet/walllocker/emerglocker/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkblue"
@@ -101275,7 +99348,7 @@
 /area/aisat)
 "sCN" = (
 /obj/item/trash/cheesie,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -101296,7 +99369,7 @@
 	},
 /area/security/execution)
 "sDl" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -101395,7 +99468,7 @@
 /area/bridge/vip)
 "sEa" = (
 /obj/machinery/vending/snack,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -101433,9 +99506,7 @@
 	},
 /area/toxins/xenobiology)
 "sEO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
 "sEW" = (
@@ -101497,7 +99568,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -101522,9 +99593,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -101580,24 +99649,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"sHe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/locker)
 "sHq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -101632,9 +99683,7 @@
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "sHY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -101658,10 +99707,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -101676,14 +99725,16 @@
 	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "sIJ" = (
 /obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -101790,9 +99841,9 @@
 /area/maintenance/kitchen)
 "sKF" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -101804,9 +99855,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
@@ -101854,11 +99903,11 @@
 /area/engineering/mechanic_workshop)
 "sLV" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -101878,7 +99927,7 @@
 /area/security/securearmory)
 "sMh" = (
 /obj/structure/table,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs{
 	pixel_x = -3;
@@ -101890,7 +99939,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -101981,7 +100030,7 @@
 	},
 /area/hallway/primary/port/west)
 "sNa" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -102022,6 +100071,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -102078,10 +100128,10 @@
 /area/construction/hallway)
 "sOE" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -102109,7 +100159,7 @@
 /area/turret_protected/aisat)
 "sOS" = (
 /obj/machinery/disposal,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -102453,11 +100503,12 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
 "sSa" = (
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/structure/closet/l3closet/security,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -102589,7 +100640,7 @@
 "sUb" = (
 /obj/structure/target_stake,
 /obj/machinery/magnetic_module,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/range)
 "sUd" = (
@@ -102645,9 +100696,7 @@
 	},
 /area/bridge/vip)
 "sUZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -102660,7 +100709,6 @@
 	},
 /area/quartermaster/storage)
 "sVh" = (
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -102696,13 +100744,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/lawoffice)
-"sVE" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/fitness)
 "sVH" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/structure/cable{
@@ -102740,7 +100781,7 @@
 "sWh" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -102827,7 +100868,7 @@
 /area/engineering/break_room)
 "sXH" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
@@ -102900,7 +100941,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -102933,13 +100974,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/fore)
-"sYs" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/aft)
 "sYB" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -103009,7 +101043,7 @@
 /obj/structure/closet/secure_closet/medical1{
 	req_access = list(5,62)
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/simulated/floor/plasteel,
 /area/gateway)
@@ -103037,7 +101071,7 @@
 	},
 /area/crew_quarters/bar)
 "sZn" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/bridge/vip)
 "sZC" = (
@@ -103078,7 +101112,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -103142,9 +101176,7 @@
 	},
 /area/hallway/primary/fore)
 "taw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -103202,25 +101234,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/south)
-"tbp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/entry/commercial)
 "tbq" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	dir = 2;
 	id_tag = "engsm"
@@ -103252,9 +101273,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/chair/stool{
 	dir = 8
 	},
@@ -103319,9 +101338,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "tct" = (
@@ -103331,7 +101348,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
 "tcv" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/computer/supplyquest/workers{
 	pixel_y = 28
 	},
@@ -103349,7 +101366,7 @@
 /obj/machinery/atmospherics/unary/thermomachine/freezer{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -103366,17 +101383,9 @@
 	id = "portsolar";
 	name = "South-West Solar Control"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
-"tcG" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/quartermaster/storage)
 "tcH" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/door_control{
@@ -103506,9 +101515,7 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
 "tdv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -103535,9 +101542,7 @@
 	},
 /area/storage/tech)
 "tdT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
 	},
@@ -103553,7 +101558,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
@@ -103625,14 +101630,12 @@
 /area/aisat)
 "teJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "teS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/closet/secure_closet/brig,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -103664,6 +101667,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -103686,7 +101690,7 @@
 /area/maintenance/electrical)
 "tfI" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -103699,7 +101703,7 @@
 /obj/machinery/sleeper{
 	pixel_x = 3
 	},
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -103727,9 +101731,7 @@
 	},
 /area/crew_quarters/fitness)
 "tgf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Singularity South-East";
 	dir = 8;
@@ -103802,15 +101804,15 @@
 /area/toxins/sm_test_chamber)
 "tgT" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "tgY" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "thk" = (
@@ -103843,21 +101845,15 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "thA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -103878,9 +101874,7 @@
 /area/security/customs)
 "thP" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/westarrival)
 "tid" = (
@@ -103888,9 +101882,7 @@
 /obj/item/clothing/suit/storage/hazardvest,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/gloves/color/black,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -103904,7 +101896,7 @@
 /turf/simulated/wall/r_wall,
 /area/security/detectives_office)
 "tig" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/shield/riot{
 	pixel_x = -6;
 	pixel_y = -6
@@ -103964,7 +101956,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -103979,7 +101971,7 @@
 /area/security/reception)
 "tin" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -104007,15 +101999,11 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "tiz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "tiG" = (
@@ -104065,9 +102053,7 @@
 	},
 /area/maintenance/library)
 "tja" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "tjc" = (
@@ -104083,9 +102069,7 @@
 "tje" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
 "tjh" = (
@@ -104102,9 +102086,7 @@
 /area/hallway/primary/fore)
 "tjq" = (
 /obj/machinery/vending/snack,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -104118,9 +102100,7 @@
 	},
 /area/toxins/sm_test_chamber)
 "tjA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /mob/living/carbon/human/lesser/monkey,
 /turf/simulated/floor/plasteel{
@@ -104211,7 +102191,7 @@
 /area/security/permahallway)
 "tkW" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -104225,7 +102205,7 @@
 /area/bridge/checkpoint/south)
 "tlc" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -104300,9 +102280,7 @@
 	dir = 8
 	},
 /obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -104323,7 +102301,7 @@
 	},
 /area/security/interrogation)
 "tmB" = (
-/obj/effect/turf_decal/delivery/blue,
+/obj/effect/decal/warning_stripes/blue,
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
@@ -104363,9 +102341,12 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -104416,7 +102397,7 @@
 /turf/simulated/floor/carpet,
 /area/lawoffice)
 "tni" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "tnm" = (
@@ -104457,9 +102438,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "tnE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/doppler_array{
 	dir = 8
 	},
@@ -104535,9 +102514,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "toL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -104748,12 +102725,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "tsB" = (
@@ -104785,9 +102758,7 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
 "tsW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -104863,7 +102834,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/power/smes/full,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -104920,9 +102891,7 @@
 "tuK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "tuP" = (
@@ -105096,9 +103065,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "twm" = (
@@ -105220,9 +103187,7 @@
 	},
 /area/security/permabrig)
 "txD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/consarea_virology)
@@ -105318,9 +103283,7 @@
 /area/engineering/break_room)
 "tzg" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/camera{
 	c_tag = "Engineering Entrance";
 	dir = 4;
@@ -105334,9 +103297,7 @@
 /area/security/warden)
 "tzi" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "tzk" = (
@@ -105383,7 +103344,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/snack,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -105508,9 +103469,7 @@
 /turf/simulated/floor/plating,
 /area/teleporter)
 "tAB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/engineering/break_room)
 "tAC" = (
@@ -105535,13 +103494,6 @@
 	icon_state = "darkredfull"
 	},
 /area/crew_quarters/fitness)
-"tBf" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellow"
-	},
-/area/atmos)
 "tBn" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/directional/east,
@@ -105600,7 +103552,7 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/crate/plastic{
 	desc = "В ящике хранится оборудование для осуществления уборки станции гражданским персоналом в случае нужды или безработицы";
 	name = "Ящик оборудования для уборки"
@@ -105659,7 +103611,7 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/freezer,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/seeds/wheat,
 /obj/item/seeds/wheat,
 /obj/item/seeds/wheat,
@@ -105779,7 +103731,7 @@
 	dir = 1;
 	network = list("Engineering","SS13")
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -105788,7 +103740,7 @@
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "tDv" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/airlock/external{
 	id_tag = "admin_home";
 	locked = 1
@@ -105859,7 +103811,7 @@
 	dir = 4;
 	pixel_x = -3
 	},
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -105951,7 +103903,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm/directional/south,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "tEP" = (
@@ -105967,15 +103919,12 @@
 	},
 /area/toxins/xenobiology)
 "tFa" = (
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/crew_quarters/theatre)
 "tFd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/storage/eva)
@@ -106032,10 +103981,8 @@
 	},
 /area/security/processing)
 "tFO" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/table/reinforced,
 /obj/item/crowbar/red,
 /turf/simulated/floor/plasteel{
@@ -106050,7 +103997,7 @@
 /obj/machinery/alarm/directional/east,
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -106069,9 +104016,7 @@
 /area/toxins/test_area)
 "tGb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/door/airlock/external{
 	hackProof = 1;
 	id_tag = "emergency_home";
@@ -106086,9 +104031,7 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -106218,7 +104161,7 @@
 	},
 /area/medical/virology/lab)
 "tHC" = (
-/obj/effect/turf_decal/delivery/partial,
+/obj/effect/decal/warning_stripes/yellow/partial,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "tHH" = (
@@ -106253,13 +104196,15 @@
 	},
 /area/medical/genetics)
 "tIx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
@@ -106303,7 +104248,7 @@
 	},
 /area/medical/reception)
 "tIS" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
@@ -106340,7 +104285,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
@@ -106356,7 +104301,7 @@
 /obj/item/assembly/igniter,
 /obj/item/assembly/igniter,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -106408,19 +104353,12 @@
 /area/security/evidence)
 "tKa" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/sw)
-"tKd" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/hallway/primary/fore)
 "tKj" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -106499,9 +104437,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -106528,7 +104464,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/toxins/test_chamber)
@@ -106589,9 +104525,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/item/flag/atmos{
 	name = "Atmosia Flag"
 	},
@@ -106686,7 +104620,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "tNh" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -106705,7 +104639,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery/blue,
+/obj/effect/decal/warning_stripes/blue,
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
 /obj/item/pen,
@@ -106769,6 +104703,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -106802,9 +104737,7 @@
 /turf/simulated/floor/plating,
 /area/medical/chemistry)
 "tOg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
@@ -106852,6 +104785,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -106924,9 +104858,7 @@
 	},
 /area/hallway/primary/central/ne)
 "tPh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "tPj" = (
@@ -106940,9 +104872,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "tPv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "tPD" = (
@@ -106960,13 +104890,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard/east)
-"tPP" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
-	},
-/area/hallway/secondary/entry)
 "tQe" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/power/apc/directional/north,
@@ -107029,16 +104952,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/reflector/box/anchored,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "tQA" = (
@@ -107146,8 +105063,8 @@
 	},
 /area/crew_quarters/fitness)
 "tRm" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -107156,7 +105073,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -107281,16 +105198,12 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
-"tSN" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/engine,
-/area/toxins/explab)
 "tSQ" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/electrical)
 "tSU" = (
 /obj/machinery/teleport/station,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/light{
 	dir = 1
@@ -107427,7 +105340,7 @@
 /area/maintenance/starboard)
 "tUd" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "tUh" = (
@@ -107468,7 +105381,7 @@
 /area/maintenance/kitchen)
 "tUB" = (
 /obj/machinery/vending/snack,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/brigstaff)
 "tUI" = (
@@ -107677,7 +105590,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/oil,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "tXf" = (
@@ -107743,10 +105656,10 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
 "tXJ" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
 /obj/effect/landmark/start/shaft_miner,
@@ -107812,7 +105725,7 @@
 /obj/effect/turf_decal/caution{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
@@ -107896,7 +105809,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -107964,7 +105877,7 @@
 	dir = 8;
 	network = list("Engineering","SS13")
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
 "tZN" = (
@@ -107981,7 +105894,7 @@
 /area/maintenance/detectives_office)
 "tZR" = (
 /obj/machinery/pipedispenser,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "tZU" = (
@@ -107990,7 +105903,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/toxins/xenobiology)
 "uaf" = (
@@ -108009,7 +105922,7 @@
 /area/security/visiting_room)
 "uaF" = (
 /obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/item/seeds/ambrosia/cruciatus,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -108128,7 +106041,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "uca" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -108199,7 +106112,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -108231,6 +106144,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/crew_quarters/trading)
@@ -108322,6 +106236,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/mimeoffice)
@@ -108359,11 +106274,11 @@
 "ufl" = (
 /obj/structure/grille,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "ufn" = (
@@ -108403,13 +106318,6 @@
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"ufu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel,
-/area/engineering/engine)
 "ufw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -108495,7 +106403,7 @@
 	name = "Creature Pen";
 	req_access = list(47)
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -108668,9 +106576,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/bar/atrium)
 "uim" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/engineering/controlroom)
@@ -108766,7 +106672,7 @@
 /area/crew_quarters/fitness)
 "ujF" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/westleft{
 	dir = 1;
 	name = "Cargo Bay Desk";
@@ -108900,7 +106806,7 @@
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
 "ukJ" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -109049,7 +106955,7 @@
 	name = "E.V.A.";
 	req_access = list(18)
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -109083,9 +106989,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/consarea_virology)
 "unx" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -109168,19 +107074,17 @@
 /area/maintenance/asmaint)
 "unX" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "unZ" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/northeastsouth,
 /obj/machinery/newscaster/directional/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
@@ -109211,7 +107115,7 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "uou" = (
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/machinery/suit_storage_unit/security,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -109275,13 +107179,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/storage)
 "upr" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -109467,7 +107371,7 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/maintenance/asmaint3)
 "usp" = (
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/smartfridge/secure/medbay_blood,
 /turf/simulated/floor/plasteel{
@@ -109475,7 +107379,7 @@
 	},
 /area/medical/sleeper)
 "ust" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -109504,13 +107408,6 @@
 	icon_state = "red"
 	},
 /area/security/brigstaff)
-"usI" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/chair/stool/bar{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/red,
-/area/crew_quarters/bar/atrium)
 "usM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/body_bag,
@@ -109567,7 +107464,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -109780,7 +107676,7 @@
 "uvo" = (
 /obj/structure/closet/emcloset,
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "uvp" = (
@@ -109851,9 +107747,7 @@
 	},
 /area/library)
 "uvW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/light,
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/plasteel{
@@ -109919,9 +107813,7 @@
 /obj/machinery/atmospherics/trinary/mixer{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/window/plasmareinforced{
 	dir = 1
 	},
@@ -109947,7 +107839,7 @@
 /area/crew_quarters/bar/atrium)
 "uxL" = (
 /obj/machinery/recharge_station,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/brigstaff)
 "uxS" = (
@@ -109973,7 +107865,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -110014,9 +107906,7 @@
 /turf/simulated/floor/plating,
 /area/security/execution)
 "uyr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -110099,9 +107989,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "uyI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "uyQ" = (
@@ -110139,7 +108027,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -110285,7 +108173,7 @@
 "uAo" = (
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plasteel,
@@ -110294,9 +108182,7 @@
 /turf/simulated/wall,
 /area/medical/cmo)
 "uAL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 1
 	},
@@ -110333,7 +108219,7 @@
 	},
 /area/security/securehallway)
 "uBu" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
 	name = "Труба на фильтрацию"
@@ -110350,6 +108236,8 @@
 /area/atmos)
 "uBx" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -110428,9 +108316,7 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "uBX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -110452,7 +108338,7 @@
 /turf/simulated/wall,
 /area/maintenance/asmaint)
 "uCv" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/suit_storage_unit/security,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -110470,7 +108356,7 @@
 /area/hallway/secondary/entry/commercial)
 "uCO" = (
 /obj/structure/bookcase/random,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "caution"
@@ -110487,14 +108373,12 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/bar/atrium)
 "uDa" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/aft)
 "uDf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -110539,7 +108423,7 @@
 "uDF" = (
 /obj/machinery/alarm/directional/west,
 /obj/machinery/disposal,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -110558,12 +108442,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/east,
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -110597,7 +108477,6 @@
 	},
 /area/maintenance/bar)
 "uEz" = (
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreencorner"
 	},
@@ -110618,7 +108497,7 @@
 /area/medical/virology/lab)
 "uEX" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -110647,9 +108526,7 @@
 /area/medical/medbay2)
 "uFl" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
@@ -110871,7 +108748,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -110954,7 +108831,7 @@
 /obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/computer/atmoscontrol,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -110966,7 +108843,7 @@
 	dir = 1;
 	network = list("Research","SS13")
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light,
 /obj/machinery/computer/roboquest,
 /turf/simulated/floor/plasteel{
@@ -110985,9 +108862,7 @@
 /area/medical/research/nhallway)
 "uJa" = (
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/rack,
 /obj/item/lock_buster,
 /turf/simulated/floor/plasteel{
@@ -111012,9 +108887,11 @@
 /area/crew_quarters/theatre)
 "uJi" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "uJo" = (
@@ -111066,7 +108943,7 @@
 	pixel_x = -1;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -111078,7 +108955,7 @@
 	layer = 3.1;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -111114,7 +108991,7 @@
 	pixel_y = 4
 	},
 /obj/item/radio,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "uKB" = (
@@ -111140,9 +109017,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/window/plasmareinforced{
 	dir = 1
 	},
@@ -111166,7 +109041,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -111179,10 +109054,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/banya)
 "uLk" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -111215,7 +109088,7 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/test_chamber)
 "uLG" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/chair/sofa/bench/left,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -111245,10 +109118,8 @@
 /turf/simulated/floor/plating,
 /area/medical/research)
 "uLW" = (
-/obj/effect/turf_decal/delivery/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/blue,
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/shower{
 	dir = 8
 	},
@@ -111270,9 +109141,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
 "uMn" = (
@@ -111335,9 +109204,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -111377,9 +109244,7 @@
 /area/security/brigstaff)
 "uNJ" = (
 /obj/machinery/alarm/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "uNK" = (
@@ -111393,7 +109258,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plating,
 /area/security/visiting_room)
 "uNV" = (
@@ -111403,9 +109267,7 @@
 /area/maintenance/tourist)
 "uNZ" = (
 /obj/machinery/computer/pandemic,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
 	id = "vir_work_zone2"
@@ -111431,9 +109293,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -111494,7 +109354,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellow"
@@ -111567,7 +109427,7 @@
 	},
 /area/security/permabrig)
 "uPg" = (
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/structure/closet/bombclosetsecurity,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -111583,7 +109443,7 @@
 	},
 /area/crew_quarters/hor)
 "uPl" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -111615,9 +109475,7 @@
 /obj/machinery/vending/wallmed{
 	pixel_x = 26
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -111630,9 +109488,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint4)
 "uPO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -111708,7 +109564,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/flashlight,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "uQA" = (
@@ -111730,10 +109586,8 @@
 	name = "Robotics Requests Console";
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -111814,13 +109668,14 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/item/beacon,
 /obj/effect/landmark/spawner/blob,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "uRn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -111877,7 +109732,6 @@
 	},
 /area/medical/genetics)
 "uRT" = (
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluecorner"
 	},
@@ -111913,9 +109767,7 @@
 /area/aisat/aihallway)
 "uTj" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/reagentgrinder{
 	pixel_x = -1;
 	pixel_y = 9
@@ -111973,8 +109825,7 @@
 /area/security/securearmory)
 "uTU" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/landmark/start/hangover,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -112039,7 +109890,7 @@
 	name = "Research Division Access";
 	req_access = list(47)
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "uVh" = (
@@ -112061,9 +109912,7 @@
 "uVl" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -112076,7 +109925,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -112084,7 +109933,7 @@
 /area/medical/medbay2)
 "uVC" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "uVY" = (
@@ -112228,6 +110077,7 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -112277,11 +110127,10 @@
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/secondary/exit)
 "uYL" = (
+/obj/structure/punching_bag,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
 	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/punching_bag,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -112431,24 +110280,13 @@
 	locked = 1;
 	name = "Arrivals External Access"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"vaw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/secondary/entry/additional)
 "vaH" = (
 /obj/structure/closet/secure_closet/research_reagents,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = -28
@@ -112606,12 +110444,10 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/serviceyard)
 "vct" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -112623,7 +110459,7 @@
 /area/crew_quarters/captain)
 "vcx" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -112680,7 +110516,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "vdv" = (
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 8
 	},
 /obj/structure/chair/sofa/bench{
@@ -112824,9 +110660,7 @@
 	id = "QMLoad";
 	name = "Upload"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "vfE" = (
@@ -112865,9 +110699,7 @@
 	name = "Bomb Mix Monitor";
 	sensors = list("burn_sensor"="Burn Mix")
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -112927,12 +110759,6 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/chief)
-"vgn" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/lab)
 "vgq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -113035,7 +110861,7 @@
 /area/crew_quarters/fitness)
 "vhD" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -113076,7 +110902,7 @@
 	},
 /area/security/hos)
 "vhQ" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -113084,14 +110910,12 @@
 	},
 /area/crew_quarters/locker)
 "vhV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/item/twohanded/required/kirbyplants,
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_y = -30
 	},
-/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "vib" = (
@@ -113314,7 +111138,7 @@
 /obj/structure/chair/e_chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light,
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/engine,
@@ -113323,9 +111147,7 @@
 /obj/structure/chair/comfy/purp{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
@@ -113361,11 +111183,11 @@
 /area/crew_quarters/mrchangs)
 "vly" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -113381,9 +111203,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "vlH" = (
@@ -113469,9 +111289,7 @@
 /obj/item/clothing/head/welding,
 /obj/item/assembly/voice,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
@@ -113517,6 +111335,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/vending_refill/youtool,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -113572,7 +111391,7 @@
 /obj/item/extinguisher,
 /obj/item/clothing/mask/gas,
 /obj/item/grenade/chem_grenade/firefighting,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light/small,
 /obj/machinery/light_switch/directional/west,
 /turf/simulated/floor/plasteel{
@@ -113608,7 +111427,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/main)
 "vnI" = (
@@ -113631,16 +111450,16 @@
 	},
 /area/medical/genetics)
 "vor" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/northwestcorner,
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
 /area/toxins/sm_test_chamber)
 "vos" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -113662,6 +111481,7 @@
 /obj/item/stack/sheet/cardboard,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -113742,7 +111562,7 @@
 /area/security/brig)
 "vpz" = (
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -113887,7 +111707,7 @@
 /obj/structure/chair/sofa/bench{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -113901,12 +111721,6 @@
 	icon_state = "red"
 	},
 /area/security/brigstaff)
-"vri" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/locker)
 "vrl" = (
 /obj/machinery/camera{
 	c_tag = "Primary Security Hallway"
@@ -113947,9 +111761,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -113964,7 +111776,6 @@
 	},
 /area/security/prisonershuttle)
 "vrP" = (
-/obj/effect/landmark/start/hangover,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -114048,9 +111859,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -114061,9 +111870,7 @@
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/serviceyard)
 "vsE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen/toxin_chamber{
 	pixel_y = 2
@@ -114098,9 +111905,7 @@
 /area/quartermaster/sorting)
 "vsM" = (
 /obj/machinery/disposal,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -114232,7 +112037,7 @@
 	},
 /area/hallway/secondary/exit)
 "vuD" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -114263,7 +112068,7 @@
 /area/chapel/office)
 "vvE" = (
 /obj/machinery/alarm/directional/south,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel,
 /area/engineering/gravitygenerator)
@@ -114487,7 +112292,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -114511,7 +112316,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -114705,7 +112510,7 @@
 "vyK" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "caution"
@@ -114728,7 +112533,7 @@
 /area/turret_protected/aisat)
 "vyO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/east,
 /turf/simulated/floor/plasteel,
@@ -114821,7 +112626,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -114927,9 +112732,7 @@
 /obj/item/clipboard,
 /obj/item/gps/engineering,
 /obj/item/lighter/zippo/ce,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -114948,9 +112751,7 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "vBm" = (
@@ -115041,7 +112842,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -115095,9 +112896,7 @@
 /area/chapel/office)
 "vCC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/door/airlock/external{
 	hackProof = 1;
 	id_tag = "emergency_home";
@@ -115202,6 +113001,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -115268,7 +113068,7 @@
 /obj/structure/railing{
 	dir = 10
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -115285,9 +113085,7 @@
 	},
 /area/maintenance/kitchen)
 "vEy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
@@ -115317,7 +113115,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/vending/assist,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "vFi" = (
@@ -115380,9 +113178,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -115414,7 +113210,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitehall"
@@ -115430,7 +113226,7 @@
 	layer = 2.9
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/item/restraints/handcuffs/toy,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -115461,7 +113257,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "vHi" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
@@ -115487,7 +113283,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -115513,10 +113309,6 @@
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/hop)
-"vId" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/wood/fancy/cherry,
-/area/crew_quarters/bar/atrium)
 "vIi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -115547,7 +113339,7 @@
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/hop)
 "vIE" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -115698,7 +113490,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "vKa" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -115764,11 +113556,10 @@
 "vLd" = (
 /obj/machinery/power/energy_accumulator/rad_collector/anchored,
 /obj/structure/cable/yellow{
+	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "vLh" = (
@@ -115844,7 +113635,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "vMS" = (
@@ -115938,9 +113729,7 @@
 	},
 /area/turret_protected/ai_upload)
 "vNE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "vNF" = (
@@ -115954,9 +113743,7 @@
 "vNL" = (
 /obj/machinery/alarm/directional/east,
 /obj/machinery/suit_storage_unit/ce,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/light_switch/directional/south,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/chief)
@@ -115980,7 +113767,7 @@
 /turf/simulated/floor/plating,
 /area/security/securearmory)
 "vNZ" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purple"
@@ -116007,7 +113794,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "vOE" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
@@ -116072,9 +113859,7 @@
 	dir = 4
 	},
 /obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -116124,7 +113909,7 @@
 /area/hallway/primary/central/ne)
 "vPZ" = (
 /obj/machinery/alarm/directional/south,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -116159,7 +113944,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -116307,6 +114091,7 @@
 /area/security/nuke_storage)
 "vRl" = (
 /obj/structure/table/reinforced,
+/obj/machinery/defibrillator_mount/loaded,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -116329,11 +114114,11 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "vSm" = (
@@ -116341,6 +114126,7 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/window/plasmareinforced{
@@ -116377,7 +114163,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
@@ -116450,9 +114236,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -116460,9 +114244,7 @@
 "vTj" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/snacks/sliceable/braincake,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -116538,7 +114320,7 @@
 /turf/simulated/floor/plating,
 /area/security/reception)
 "vTG" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/table/reinforced,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -116687,7 +114469,7 @@
 	},
 /area/crew_quarters/fitness)
 "vUJ" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -116700,7 +114482,7 @@
 	frequency = 1379;
 	id_tag = "vir_pump"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "vir_airlock";
 	layer = 3.1;
@@ -116773,9 +114555,7 @@
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "vVv" = (
@@ -116797,33 +114577,24 @@
 /area/hallway/primary/starboard/east)
 "vVL" = (
 /obj/structure/cable/yellow{
+	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/toxins/sm_test_chamber)
 "vVR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/northeast,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/chem_heater,
 /obj/structure/window/plasmareinforced{
 	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
-"vVV" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
-	},
-/area/medical/research/restroom)
 "vWf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	desc = "Труба ведёт газ на фильтрацию";
@@ -116895,7 +114666,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/spawner/xeno,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "vWI" = (
@@ -116972,9 +114743,7 @@
 	},
 /area/security/securearmory)
 "vXL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -117065,7 +114834,7 @@
 "vZi" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/sunflower,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/garden)
 "vZk" = (
@@ -117107,9 +114876,7 @@
 	c_tag = "West-South Solars"
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "vZG" = (
@@ -117155,11 +114922,11 @@
 /area/maintenance/bar)
 "waI" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "waL" = (
@@ -117194,6 +114961,7 @@
 /obj/item/trash/candy,
 /obj/effect/spawner/random_spawners/grille_13,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -117378,7 +115146,7 @@
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/reagent_containers/spray/plantbgone{
 	pixel_x = -5;
 	pixel_y = 6
@@ -117405,7 +115173,7 @@
 /area/assembly/chargebay)
 "wcS" = (
 /obj/machinery/atmospherics/unary/tank/air,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/asmaint3)
 "wcV" = (
@@ -117561,7 +115329,7 @@
 /obj/structure/chair/sofa/bench{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -117617,9 +115385,11 @@
 	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "wgt" = (
@@ -117672,7 +115442,6 @@
 	layer = 5;
 	pixel_y = -5
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -117685,7 +115454,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm/directional/north,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/bridge/checkpoint/south)
 "wgX" = (
@@ -117730,9 +115499,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -117753,7 +115520,7 @@
 /area/hallway/secondary/exit)
 "wio" = (
 /obj/item/flag/species,
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/security/main)
@@ -117891,6 +115658,7 @@
 	},
 /obj/random/tool,
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -117924,13 +115692,6 @@
 	icon_state = "darkred"
 	},
 /area/security/warden)
-"wkm" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellow"
-	},
-/area/storage/primary)
 "wkn" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -118005,7 +115766,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/wood/fancy/light,
 /area/medical/psych)
 "wlm" = (
@@ -118061,7 +115821,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "wmm" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -118071,9 +115831,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -118140,8 +115898,7 @@
 	frequency = 1379;
 	id_tag = "engineering_east_pump"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/walllocker/emerglocker/directional/south,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "wnc" = (
@@ -118153,7 +115910,7 @@
 	},
 /area/hallway/primary/central/south)
 "wnh" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/computer/operating{
 	name = "Robotics Operating Computer"
 	},
@@ -118420,6 +116177,7 @@
 	id = "comdel"
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -118432,9 +116190,7 @@
 	},
 /area/medical/medbay)
 "wqb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
@@ -118486,7 +116242,7 @@
 	pixel_x = -24;
 	req_access = list(62)
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "wqx" = (
@@ -118514,7 +116270,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -118685,14 +116441,12 @@
 "wsA" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/flashlight,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "wsC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/muffin{
 	pixel_y = 9
@@ -118846,7 +116600,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/folder,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -118947,6 +116701,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 5;
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
@@ -118971,11 +116726,11 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
@@ -118986,7 +116741,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -119043,11 +116797,11 @@
 /obj/effect/decal/cleanable/blood/writing,
 /obj/effect/spawner/random_spawners/rodent,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
 "wwb" = (
-/obj/effect/landmark/start/hangover,
 /obj/structure/railing,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
@@ -119106,7 +116860,7 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "wwp" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/gateway)
 "wws" = (
@@ -119180,9 +116934,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastsouth,
 /turf/simulated/floor/plasteel{
 	icon_state = "escape"
 	},
@@ -119211,7 +116963,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/magistrateoffice)
 "wxC" = (
@@ -119400,7 +117152,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "wAL" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/research_reagents,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -119429,9 +117181,11 @@
 /area/crew_quarters/fitness)
 "wAW" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -119586,9 +117340,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/prison/cell_block/A)
 "wDx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -119616,6 +117368,7 @@
 /area/toxins/xenobiology)
 "wDS" = (
 /obj/structure/cable{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/window/reinforced/polarized{
@@ -119666,12 +117419,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/lab)
-"wEg" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/bridge/vip)
 "wEh" = (
 /turf/simulated/wall/r_wall,
 /area/teleporter/abandoned)
@@ -119742,10 +117489,8 @@
 	},
 /area/medical/research/nhallway)
 "wEK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/northwest,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/chem_dispenser,
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
@@ -119755,7 +117500,7 @@
 	},
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/double,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -119914,6 +117659,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
@@ -119973,9 +117719,7 @@
 	},
 /area/quartermaster/miningdock)
 "wGU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -119985,7 +117729,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/cryopod,
-/obj/effect/turf_decal/delivery/green,
+/obj/effect/decal/warning_stripes/green,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -120010,7 +117754,7 @@
 "wHz" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/tripple,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "wHC" = (
@@ -120031,12 +117775,6 @@
 "wHM" = (
 /turf/simulated/wall/r_wall/coated,
 /area/toxins/storage)
-"wHQ" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/bridge/meeting_room)
 "wHR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -120052,11 +117790,10 @@
 "wHY" = (
 /obj/structure/bed,
 /obj/structure/curtain/black,
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -120148,13 +117885,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/ai)
-"wKf" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/weightmachine/horizontalbar,
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
-	},
-/area/crew_quarters/fitness)
 "wKi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -120302,9 +118032,7 @@
 /area/maintenance/consarea_virology)
 "wLQ" = (
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/door/window/brigdoor/northleft{
 	armor = list("melee"=85,"bullet"=20,"laser"=0,"energy"=0,"bomb"=60,"bio"=100,"fire"=99,"acid"=100);
 	damage_deflection = 21
@@ -120386,9 +118114,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Area";
 	network = list("SS13","Engineering")
@@ -120450,11 +118176,11 @@
 /area/library/game_zone)
 "wNB" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Singularity";
 	name = "Singularity Blast Doors"
@@ -120490,14 +118216,14 @@
 /area/security/permabrig)
 "wNR" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard/east)
 "wNW" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/chem_master/condimaster,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -120642,7 +118368,7 @@
 /obj/item/assembly/timer,
 /obj/item/assembly/voice,
 /obj/item/assembly/voice,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
 "wPy" = (
@@ -120679,7 +118405,7 @@
 	},
 /area/medical/reception)
 "wPC" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/newscaster/directional/south,
 /obj/structure/chair/office/light{
 	dir = 8
@@ -120734,7 +118460,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/storage/tech)
@@ -120778,9 +118504,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel,
 /area/toxins/test_chamber)
 "wQL" = (
@@ -120799,9 +118523,7 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
 "wQO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stock_parts/manipulator,
@@ -120815,7 +118537,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/the_singularitygen,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -120837,7 +118559,7 @@
 /area/security/reception)
 "wRg" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/warning_stripes/red,
 /obj/machinery/alarm/directional/west,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
@@ -120853,10 +118575,7 @@
 /obj/structure/sign/pods{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/landmark/start/hangover,
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "wRq" = (
@@ -121015,13 +118734,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/paramedic)
-"wTa" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/aisat/aihallway)
 "wTe" = (
 /obj/machinery/power/apc/directional/east,
 /obj/structure/cable{
@@ -121049,7 +118761,7 @@
 /area/maintenance/ai)
 "wTs" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "wTz" = (
@@ -121066,7 +118778,7 @@
 	},
 /area/security/permabrig)
 "wTS" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
@@ -121109,6 +118821,8 @@
 /area/maintenance/tourist)
 "wUB" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/engineer,
@@ -121117,7 +118831,7 @@
 	},
 /area/engineering/engine)
 "wUC" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/suit_storage_unit/engine,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
@@ -121130,7 +118844,7 @@
 	},
 /area/security/permabrig)
 "wUU" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/mouse,
 /turf/simulated/floor/plasteel,
@@ -121298,18 +119012,10 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cloning)
-"wWJ" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "red"
-	},
-/area/security/brig)
 "wWP" = (
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/papershredder,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -121384,7 +119090,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -121462,11 +119168,11 @@
 /area/ntrep)
 "wZb" = (
 /obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -121485,7 +119191,7 @@
 	},
 /area/bridge)
 "wZB" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	dir = 4;
@@ -121578,7 +119284,7 @@
 	},
 /area/security/prisonershuttle)
 "xaP" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -121632,7 +119338,6 @@
 /area/toxins/mixing)
 "xbv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -121658,8 +119363,7 @@
 /area/security/prison/cell_block/A)
 "xbE" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/landmark/start/hangover,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -121677,7 +119381,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/cryopod,
-/obj/effect/turf_decal/delivery/green,
+/obj/effect/decal/warning_stripes/green,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -121760,9 +119464,7 @@
 	pixel_x = -1;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "xcu" = (
@@ -121771,7 +119473,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -121794,7 +119496,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "xcN" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -121805,9 +119507,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/closet/secure_closet/brig,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -121826,8 +119526,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/library)
 "xdb" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -121878,16 +119578,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/hor)
 "xdB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -121920,9 +119616,7 @@
 /area/maintenance/asmaint4)
 "xdP" = (
 /obj/machinery/computer/pandemic,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
 	id = "vir_work_zone1"
@@ -121952,9 +119646,7 @@
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "xdY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/binary/valve/digital{
 	dir = 4
 	},
@@ -122012,7 +119704,7 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "xeN" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -122026,7 +119718,7 @@
 /area/maintenance/tourist)
 "xeQ" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
 "xeT" = (
@@ -122051,13 +119743,11 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "xfm" = (
-/obj/effect/turf_decal/delivery/hollow/right,
+/obj/effect/turf_decal/bot/right,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -122148,9 +119838,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "xfX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/item/twohanded/required/kirbyplants,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -122179,7 +119867,6 @@
 	},
 /area/security/customs)
 "xgh" = (
-/obj/effect/landmark/start/hangover,
 /obj/machinery/camera{
 	c_tag = "Central Ring Hallway West 3";
 	dir = 8
@@ -122190,14 +119877,11 @@
 	},
 /area/hallway/primary/central/west)
 "xgj" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
+/obj/item/twohanded/required/kirbyplants,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/crowbar,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "xgm" = (
@@ -122228,9 +119912,7 @@
 /area/security/detectives_office)
 "xgv" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/computer/security/telescreen/singularity{
 	dir = 8;
 	pixel_x = -32
@@ -122348,9 +120030,7 @@
 	},
 /area/hallway/primary/central/se)
 "xhK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	desc = "Труба содержит газ для обработки и после возвращает его обратно в трубу смешивания";
 	name = "Труба обработки"
@@ -122505,7 +120185,6 @@
 /area/aisat/aihallway)
 "xkg" = (
 /obj/structure/table/wood,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/serviceyard)
 "xkm" = (
@@ -122658,14 +120337,13 @@
 /area/security/detectives_office)
 "xmw" = (
 /obj/machinery/computer/mech_bay_power_console,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/security/securearmory)
 "xmz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "xmJ" = (
@@ -122679,7 +120357,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
 "xmM" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -122706,10 +120384,8 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
@@ -123005,7 +120681,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -123063,9 +120739,7 @@
 /area/security/range)
 "xqA" = (
 /obj/machinery/power/port_gen/pacman,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/item/radio/intercom/directional/north,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -123190,6 +120864,8 @@
 /area/medical/virology/lab)
 "xsj" = (
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -123215,7 +120891,7 @@
 /area/maintenance/bar)
 "xsv" = (
 /obj/machinery/computer/rdconsole/robotics,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -123254,8 +120930,8 @@
 /area/chapel/main)
 "xsK" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/delivery/green/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -123291,7 +120967,7 @@
 	},
 /area/medical/sleeper)
 "xts" = (
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/atmospherics/unary/tank/air,
 /turf/simulated/floor/plating,
 /area/aisat/maintenance)
@@ -123299,7 +120975,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/closet/bombcloset,
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
@@ -123328,7 +121004,7 @@
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/heads/hop)
 "xtL" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -123421,6 +121097,10 @@
 /turf/simulated/wall/r_wall,
 /area/security/detectives_office)
 "xuA" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open/shower,
 /obj/machinery/door_control{
 	id = "showers";
 	name = "Door Bolt Control";
@@ -123428,11 +121108,6 @@
 	pixel_x = 24;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/curtain/open/shower,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -123501,9 +121176,7 @@
 	},
 /area/turret_protected/aisat)
 "xvt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/sign/double/no_idiots/right{
 	pixel_y = 32
 	},
@@ -123588,9 +121261,7 @@
 	},
 /area/security/warden)
 "xwd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/light_switch/directional/east,
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -123599,7 +121270,7 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/launch)
 "xwf" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/bombcloset,
 /obj/machinery/light/small{
 	dir = 1
@@ -123612,7 +121283,7 @@
 "xwj" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/tower,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/maintenance/garden)
 "xwq" = (
@@ -123666,9 +121337,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "xwL" = (
@@ -123738,7 +121407,7 @@
 /area/solar/starboard)
 "xxk" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/item/transfer_valve{
 	pixel_x = 8;
 	pixel_y = -6
@@ -123833,10 +121502,8 @@
 /turf/simulated/floor/plasteel,
 /area/security/permabrig)
 "xxH" = (
-/obj/effect/turf_decal/delivery/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/blue,
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/sink{
 	pixel_y = 22
 	},
@@ -123850,9 +121517,7 @@
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "xxJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/closet/l3closet/scientist,
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel,
@@ -123903,9 +121568,7 @@
 /area/crew_quarters/locker)
 "xyJ" = (
 /obj/machinery/teleport/hub,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -123926,9 +121589,7 @@
 /area/maintenance/fpmaint)
 "xyS" = (
 /obj/machinery/computer/teleporter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -124007,14 +121668,13 @@
 /area/maintenance/asmaint2)
 "xzt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/quartermaster/qm)
 "xzw" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/plasticflaps/opaque,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/plasticflaps,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
@@ -124032,16 +121692,10 @@
 	},
 /area/hallway/secondary/entry/commercial)
 "xzK" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
-"xzP" = (
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research/restroom)
 "xAb" = (
 /obj/structure/cable,
 /obj/effect/spawner/window/reinforced/polarized{
@@ -124108,7 +121762,7 @@
 /area/security/brig)
 "xBc" = (
 /obj/machinery/disposal,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -124169,9 +121823,7 @@
 /turf/simulated/floor/carpet,
 /area/security/detectives_office)
 "xBS" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/northeastcorner,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -124221,12 +121873,12 @@
 	},
 /area/medical/medbay)
 "xCD" = (
-/obj/effect/turf_decal/arrows/black,
+/obj/effect/decal/warning_stripes/arrow,
 /obj/structure/disposaloutlet,
 /obj/structure/window/plasmareinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -124342,7 +121994,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
 "xDU" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/wardrobe/robotics_black,
 /obj/item/clothing/head/welding{
 	pixel_x = -3;
@@ -124406,7 +122058,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
 /obj/structure/chair/sofa/bench/left{
@@ -124422,9 +122074,7 @@
 	},
 /area/turret_protected/aisat)
 "xEu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/west,
 /obj/machinery/power/apc/directional/west,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -124521,9 +122171,7 @@
 /area/turret_protected/ai)
 "xFp" = (
 /obj/structure/morgue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/effect/landmark/spawner/revenant,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -124563,9 +122211,7 @@
 	network = list("SS13","Engineering")
 	},
 /obj/machinery/power/apc/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -124622,6 +122268,8 @@
 /area/medical/virology/lab)
 "xGf" = (
 /obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/table/reinforced,
@@ -124668,9 +122316,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/commercial)
 "xGL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -124692,9 +122338,7 @@
 /turf/space,
 /area/space)
 "xHa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -124756,9 +122400,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "xHM" = (
@@ -124798,11 +122440,9 @@
 	},
 /area/security/securehallway)
 "xHY" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /obj/structure/rack,
 /obj/item/stack/cable_coil{
 	pixel_x = -2;
@@ -124936,7 +122576,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -124979,10 +122619,8 @@
 /area/medical/research/nhallway)
 "xJC" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/northeast,
 /obj/item/stack/sheet/glass{
 	amount = 50
 	},
@@ -125063,12 +122701,12 @@
 /area/security/processing)
 "xKq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/field/generator,
 /turf/simulated/floor/plasteel,
 /area/storage/secure)
 "xKu" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
@@ -125203,7 +122841,7 @@
 "xLL" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/coffin,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -125212,9 +122850,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
 "xLY" = (
@@ -125229,9 +122865,7 @@
 "xMc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plasteel,
 /area/medical/research/nhallway)
 "xMd" = (
@@ -125239,9 +122873,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -125304,7 +122936,7 @@
 /area/engineering/engine/monitor)
 "xMs" = (
 /obj/machinery/disposal,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -125347,7 +122979,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/courtroom)
 "xMX" = (
@@ -125359,9 +122991,7 @@
 	name = "Engineering Junction";
 	sortType = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -125384,7 +123014,7 @@
 	},
 /area/maintenance/starboard)
 "xNt" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -125392,9 +123022,7 @@
 	},
 /area/engineering/engine)
 "xNu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/decal/warning_stripes/northeast,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
@@ -125520,7 +123148,7 @@
 	},
 /area/medical/chemistry)
 "xOM" = (
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "xOQ" = (
@@ -125611,9 +123239,7 @@
 	},
 /area/hallway/primary/starboard/east)
 "xPj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -125624,7 +123250,7 @@
 	},
 /area/medical/virology/lab)
 "xPl" = (
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 1
 	},
 /obj/structure/chair/sofa/bench{
@@ -125648,9 +123274,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
@@ -125688,7 +123312,7 @@
 	},
 /area/hallway/primary/fore)
 "xPQ" = (
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/camera{
 	c_tag = "Escape Shuttle Command Point";
 	dir = 6
@@ -125785,8 +123409,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/yellow,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -125799,9 +123423,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -125905,7 +123527,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -125945,9 +123567,7 @@
 	},
 /area/maintenance/electrical)
 "xRY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -126064,9 +123684,7 @@
 /turf/simulated/floor/plating,
 /area/security/reception)
 "xTL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/light{
 	dir = 8
@@ -126096,9 +123714,7 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
 "xTU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigpack_robust{
 	pixel_x = 6;
@@ -126177,10 +123793,8 @@
 /obj/item/stack/sheet/plasteel{
 	amount = 10
 	},
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -126305,22 +123919,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"xWk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/central/se)
 "xWm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "KPPN"
 	},
@@ -126332,9 +123934,7 @@
 /area/bridge/checkpoint/south)
 "xWo" = (
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/eastarrival)
 "xWr" = (
@@ -126343,14 +123943,13 @@
 	c_tag = "Mech Bay External";
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
 "xWx" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/structure/morgue{
 	dir = 8
 	},
@@ -126393,6 +123992,8 @@
 	network = list("SS13","Engineering")
 	},
 /obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -126409,10 +124010,10 @@
 	},
 /area/teleporter/abandoned)
 "xXi" = (
-/obj/effect/turf_decal/arrows/black{
+/obj/effect/decal/warning_stripes/arrow{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/partial{
+/obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -126424,7 +124025,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/effect/landmark/spawner/revenant,
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
@@ -126638,7 +124239,7 @@
 "xYO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -126665,7 +124266,7 @@
 /area/maintenance/library)
 "xZk" = (
 /obj/structure/morgue,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/effect/landmark/spawner/revenant,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -126747,7 +124348,7 @@
 /area/security/main)
 "xZT" = (
 /obj/machinery/vending/snack,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -126845,16 +124446,10 @@
 /obj/structure/reflector/box/anchored{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/engine,
 /area/engineering/controlroom)
 "yaz" = (
@@ -126868,7 +124463,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
 "yaI" = (
@@ -126940,6 +124535,7 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -126976,12 +124572,8 @@
 /area/maintenance/engineering)
 "ybU" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
 "ybW" = (
@@ -127090,6 +124682,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "tranquillite"
 	},
 /area/crew_quarters/theatre)
@@ -127104,7 +124697,7 @@
 /turf/simulated/floor/wood,
 /area/security/detectives_office)
 "ycP" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/toxins/misc_lab)
 "ycV" = (
@@ -127174,7 +124767,7 @@
 	},
 /area/hallway/primary/central/se)
 "ydv" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -127309,7 +124902,7 @@
 /area/aisat/maintenance)
 "yeI" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -127321,17 +124914,15 @@
 	name = "Chapel Launcher Door";
 	protected = 0
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "yeL" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -127363,7 +124954,7 @@
 /area/maintenance/asmaint4)
 "yff" = (
 /obj/machinery/bodyscanner,
-/obj/effect/turf_decal/delivery/blue/hollow,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -127409,7 +125000,7 @@
 /turf/simulated/floor/engine,
 /area/maintenance/incinerator)
 "yfG" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -127425,10 +125016,8 @@
 /area/maintenance/starboard)
 "yfQ" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
@@ -127576,13 +125165,12 @@
 /mob/living/simple_animal/frog,
 /obj/item/reagent_containers/syringe/steroids,
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "cmo"
 	},
 /area/security/permabrig)
 "yhO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -127638,13 +125226,10 @@
 /turf/space,
 /area/solar/starboard)
 "yii" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/decal/warning_stripes/east,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry/additional)
 "yio" = (
@@ -127812,9 +125397,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
 "yjG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
@@ -127856,7 +125439,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/warning_stripes/south,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 6
@@ -127882,7 +125465,7 @@
 /turf/simulated/wall/r_wall,
 /area/assembly/robotics)
 "yky" = (
-/obj/effect/turf_decal/delivery/red/hollow,
+/obj/effect/decal/warning_stripes/red/hollow,
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -127914,7 +125497,7 @@
 	pixel_x = 12;
 	pixel_y = -25
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -137714,7 +135297,7 @@ qrT
 oKs
 wgX
 uTb
-wTa
+uwP
 ybH
 bXR
 dZq
@@ -149248,7 +146831,7 @@ fLz
 fYB
 gGx
 hrb
-rRN
+ihm
 iNS
 jub
 xpJ
@@ -149532,7 +147115,7 @@ cwu
 cwu
 cwu
 exf
-unX
+hrS
 hWL
 unX
 oKO
@@ -150003,7 +147586,7 @@ nrc
 oQk
 gIq
 cxd
-qDj
+iNS
 bIP
 bMS
 cfm
@@ -150300,7 +147883,7 @@ mrH
 tdv
 tPh
 dDP
-tPh
+mXx
 tXp
 eAh
 nnT
@@ -150308,7 +147891,7 @@ aIo
 sog
 cqQ
 tXp
-tPh
+hIt
 dDP
 tPh
 rDF
@@ -150823,7 +148406,7 @@ uPO
 dwt
 bXU
 fFR
-jAq
+tzM
 tzM
 guS
 uyI
@@ -151042,7 +148625,7 @@ gFR
 jti
 ihm
 dYY
-tBf
+bwY
 cow
 mKO
 nSt
@@ -151071,7 +148654,7 @@ dUI
 dCy
 tzM
 mJD
-dQD
+jJc
 bXU
 bXU
 nCi
@@ -151091,7 +148674,7 @@ pgt
 qac
 lpm
 vEh
-eKF
+dah
 dah
 dah
 dah
@@ -151594,7 +149177,7 @@ dSF
 tPh
 tPh
 tPh
-ufu
+tPh
 tPh
 tPh
 cPX
@@ -152381,7 +149964,7 @@ dah
 qTt
 dah
 dah
-eKF
+dah
 sUj
 lpm
 prC
@@ -152578,7 +150161,7 @@ ihm
 ihm
 ihm
 ihm
-rRN
+ihm
 ihm
 ihm
 ihm
@@ -153561,7 +151144,7 @@ aaq
 etQ
 kaO
 bjg
-tbp
+aXM
 bsC
 aXM
 aXM
@@ -154081,7 +151664,7 @@ aUr
 aUr
 qcW
 bNS
-rju
+aPg
 bjs
 etQ
 coE
@@ -154975,7 +152558,7 @@ jrc
 pzS
 lbz
 jPf
-oNa
+jIA
 jIA
 vlG
 nSW
@@ -156712,7 +154295,7 @@ tdH
 uaK
 tdH
 tdH
-kUp
+tdH
 mxf
 bxh
 cLX
@@ -157750,7 +155333,7 @@ bYj
 cfu
 xBo
 cAq
-mLM
+cAq
 cAq
 cAq
 mhK
@@ -158022,7 +155605,7 @@ nJx
 gUa
 frN
 rgA
-giy
+frN
 dBH
 gMw
 nQm
@@ -158252,7 +155835,7 @@ dis
 sOV
 tCu
 tCu
-wkm
+tCu
 tCu
 wou
 wTs
@@ -158308,7 +155891,7 @@ uHt
 dju
 jTZ
 oDB
-npq
+oDB
 vsA
 hBX
 iKy
@@ -158545,7 +156128,7 @@ qUe
 ddi
 uNo
 tHr
-tSN
+tHr
 tHr
 fXQ
 cNl
@@ -158601,7 +156184,7 @@ xLL
 dHi
 pzG
 cjs
-jyE
+iJw
 iJw
 rFw
 llI
@@ -158703,7 +156286,7 @@ aIC
 aIC
 aIC
 aIC
-vaw
+aIC
 aIC
 bDS
 bPr
@@ -159305,7 +156888,7 @@ lIo
 rcr
 gMw
 xks
-qHr
+fYZ
 rgA
 fYZ
 agj
@@ -159357,7 +156940,7 @@ dIv
 dBh
 iNC
 spW
-gkb
+rxL
 xvO
 rxL
 lhr
@@ -159837,7 +157420,7 @@ cOY
 cPd
 vkS
 jcR
-vVV
+fJp
 bDP
 fEg
 uJo
@@ -160020,7 +157603,7 @@ tDT
 cFO
 nlF
 hpR
-mHr
+oPj
 gtF
 oPj
 roI
@@ -160304,7 +157887,7 @@ nAu
 vTx
 qtU
 uWQ
-pEn
+qMp
 qMp
 cKv
 cMP
@@ -160313,7 +157896,7 @@ qMp
 qMp
 rqO
 six
-bEc
+bOw
 vse
 dPt
 dPt
@@ -160506,7 +158089,7 @@ yhg
 acC
 acC
 acC
-tPP
+bhN
 aRQ
 cAz
 aXJ
@@ -160604,7 +158187,7 @@ ybR
 yhX
 vam
 hgH
-xzP
+tKj
 cQS
 nPX
 tKj
@@ -160811,7 +158394,7 @@ bKU
 jYe
 wVn
 boi
-lsW
+oBf
 bMH
 mMd
 mMd
@@ -160822,7 +158405,7 @@ lKE
 mMd
 tDc
 jcc
-nwW
+mMd
 mMd
 mMd
 eYe
@@ -160843,7 +158426,7 @@ eJR
 eRU
 dWK
 gfQ
-bYh
+iHE
 dWK
 gfQ
 gfQ
@@ -161099,7 +158682,7 @@ bSE
 bSE
 jPB
 jPB
-gCd
+uTU
 uzy
 uEX
 csK
@@ -161318,7 +158901,7 @@ dCK
 pDM
 eaZ
 fVY
-gTo
+xBC
 bKU
 bdz
 bKU
@@ -161821,7 +159404,7 @@ aHB
 hpR
 oPj
 gtF
-mHr
+oPj
 wSb
 gWF
 gWF
@@ -161897,7 +159480,7 @@ xKu
 sjW
 pAy
 hCs
-ryj
+qGf
 nmp
 xJf
 nbx
@@ -162591,7 +160174,7 @@ xeI
 uGn
 sfF
 sfF
-usI
+sfF
 sfF
 ydD
 lAL
@@ -162800,13 +160383,13 @@ ahe
 dZo
 ayB
 amj
-qPq
+asi
 aqB
 asi
 aul
 aBc
 aBc
-qlj
+aBc
 aLX
 aBc
 ahQ
@@ -162855,7 +160438,7 @@ iRF
 vQV
 wNe
 vQM
-vId
+wNe
 wNe
 gEk
 czq
@@ -162933,13 +160516,13 @@ avZ
 sjm
 vnI
 rmK
-gcI
+kaX
 utT
 xUz
 hJX
 qNZ
 xdb
-oYC
+nzN
 xeT
 cbI
 fqN
@@ -163070,7 +160653,7 @@ aNS
 aXL
 aah
 aah
-fst
+aah
 buP
 pcD
 aah
@@ -163108,7 +160691,7 @@ isU
 cvQ
 bQO
 dFR
-rYK
+bLj
 enm
 mLL
 agM
@@ -163155,7 +160738,7 @@ wFJ
 cIi
 sZn
 mfs
-oWL
+ciD
 lRu
 mup
 csK
@@ -163179,7 +160762,7 @@ cRb
 dAW
 fVX
 oIq
-vgn
+oIq
 oIq
 oXK
 rcO
@@ -163377,7 +160960,7 @@ pyq
 uik
 pyq
 pyq
-leU
+pyq
 kho
 bcc
 cQK
@@ -163389,7 +160972,7 @@ coE
 pBK
 rpj
 snq
-gHv
+byU
 odI
 bwf
 kyL
@@ -163590,7 +161173,7 @@ aaq
 aaq
 aaq
 bPA
-eBf
+bhN
 bjK
 dPy
 lZy
@@ -163879,7 +161462,7 @@ beW
 cUx
 cvQ
 tJn
-rYK
+bLj
 eoM
 tbv
 jwa
@@ -163915,7 +161498,7 @@ aaq
 aaq
 aaq
 bHj
-rtr
+tdn
 ddy
 vmr
 aaM
@@ -164112,7 +161695,7 @@ bvL
 byh
 bvL
 bvL
-les
+bvL
 bvL
 wee
 aQx
@@ -164134,7 +161717,7 @@ aFA
 vEa
 jSy
 aXA
-ekX
+cvQ
 dPF
 bLj
 eoM
@@ -164143,7 +161726,7 @@ lRO
 bOH
 qfs
 exZ
-puR
+lAQ
 lAQ
 uxH
 lAQ
@@ -164175,7 +161758,7 @@ bHj
 tgc
 nvt
 gQD
-wHQ
+kiG
 snH
 uyB
 hMR
@@ -164409,7 +161992,7 @@ jHQ
 qiF
 xDu
 aEp
-lsW
+oBf
 luQ
 aaq
 pBK
@@ -164442,7 +162025,7 @@ nrh
 ssw
 lMI
 geG
-syZ
+fYm
 fYm
 rcA
 fYm
@@ -164893,7 +162476,7 @@ bNz
 xPP
 xPP
 xPP
-lUj
+xPP
 xPP
 xPP
 cOn
@@ -164917,7 +162500,7 @@ aGz
 xPP
 xPP
 xPP
-lUj
+xPP
 xPP
 pUp
 bcn
@@ -165156,7 +162739,7 @@ xxC
 cOs
 dqq
 dqq
-jzS
+kLZ
 djM
 pux
 dqq
@@ -165237,7 +162820,7 @@ ogb
 doy
 pRB
 pRB
-llA
+pRB
 pRB
 pRB
 pRB
@@ -165274,7 +162857,7 @@ qBn
 dTD
 pBJ
 pBJ
-hIq
+xQY
 pBJ
 dWm
 gds
@@ -165405,7 +162988,7 @@ bBG
 bEN
 qDz
 gwB
-tKd
+cwd
 tav
 ktz
 cwd
@@ -165420,12 +163003,12 @@ cwd
 cwd
 cwd
 cwd
-tKd
+cwd
 uwH
 cwd
 cwd
 fsz
-tKd
+cwd
 cwd
 mhO
 cwd
@@ -165487,7 +163070,7 @@ xUV
 xUV
 xUV
 ycB
-sYs
+pgL
 pgL
 upS
 dvk
@@ -165699,7 +163282,7 @@ hHa
 coE
 bwf
 jOq
-gHv
+byU
 odi
 bUt
 mUS
@@ -166167,7 +163750,7 @@ buO
 bKc
 aMT
 bKc
-mbK
+bKc
 bKc
 bKc
 bKc
@@ -166254,7 +163837,7 @@ xcb
 liV
 ixo
 hmB
-oKg
+cPy
 rYG
 dFQ
 cPy
@@ -166463,7 +164046,7 @@ bju
 dLX
 dZg
 fjY
-iEL
+bnc
 jya
 kow
 luQ
@@ -166674,7 +164257,7 @@ aaq
 aaq
 aaq
 bPA
-eBf
+bhN
 dwy
 dPy
 sme
@@ -166742,7 +164325,7 @@ bwf
 aaq
 aaq
 bHj
-wHQ
+kiG
 vKk
 bST
 bST
@@ -166755,7 +164338,7 @@ dAE
 bST
 tIK
 wDT
-wEg
+vjx
 csV
 rFS
 goP
@@ -167514,7 +165097,7 @@ irG
 gLq
 cKS
 dAU
-lhM
+cKS
 bST
 wMB
 owP
@@ -168520,7 +166103,7 @@ mCF
 cqB
 cqB
 duW
-ndi
+jya
 kow
 luQ
 aaq
@@ -168563,7 +166146,7 @@ lWj
 ely
 gHM
 cCT
-fpY
+xMi
 liV
 qMm
 gTx
@@ -168574,7 +166157,7 @@ cXj
 cZE
 cRj
 sZT
-baW
+vtu
 rcy
 yff
 sZT
@@ -168787,7 +166370,7 @@ bwf
 mMQ
 srd
 mMQ
-jvd
+mMQ
 pty
 vcb
 pUb
@@ -169014,7 +166597,7 @@ eZs
 djV
 djV
 eZs
-tcG
+eZs
 djV
 djV
 wTS
@@ -169349,7 +166932,7 @@ vtu
 xik
 wjo
 xte
-fhN
+vpP
 rcy
 gsN
 dfy
@@ -169560,14 +167143,14 @@ sss
 rBg
 tPe
 rRB
-aJN
+pXO
 pXO
 pXO
 aDw
 dfk
 wML
 ofr
-sol
+wML
 qEF
 wML
 puJ
@@ -169776,7 +167359,7 @@ avk
 uQA
 bUf
 bYJ
-tcG
+eZs
 bkV
 aCf
 cOR
@@ -169841,7 +167424,7 @@ sRr
 mgb
 rai
 ydj
-xWk
+wPQ
 wPQ
 lTQ
 wPQ
@@ -170067,7 +167650,7 @@ ivV
 bNc
 bOX
 uXz
-pSr
+uXz
 qwW
 uXz
 mKL
@@ -170076,7 +167659,7 @@ odl
 uXz
 anP
 uXz
-pSr
+uXz
 uXz
 bNc
 tmc
@@ -170086,7 +167669,7 @@ xHe
 xHe
 qOs
 xHe
-fxZ
+xHe
 xHe
 oGV
 xHe
@@ -170829,7 +168412,7 @@ kMn
 bYB
 mfh
 jMn
-sxi
+uIe
 qYb
 cqB
 coE
@@ -171149,11 +168732,11 @@ jHI
 pEi
 pfs
 wVd
-bMU
+uLv
 pRj
 rDQ
 ehw
-fOf
+wQu
 xEF
 mGt
 tnr
@@ -171581,7 +169164,7 @@ cLd
 mHQ
 mHQ
 dHr
-rGj
+dHr
 dHr
 vfD
 qRa
@@ -171590,7 +169173,7 @@ dNr
 qbl
 uDx
 bgT
-lDz
+vft
 vjO
 vft
 gfk
@@ -171623,7 +169206,7 @@ xnx
 xnx
 vrl
 vVv
-fzd
+pOC
 cyK
 iVC
 kUh
@@ -171673,7 +169256,7 @@ mGt
 tnr
 qPG
 pLM
-nuS
+tRG
 vpc
 vSn
 woE
@@ -171855,7 +169438,7 @@ dDb
 aZp
 iRP
 mfh
-qSv
+mfh
 djR
 uIe
 nKf
@@ -171890,7 +169473,7 @@ krh
 hYl
 krh
 aMq
-gSV
+fLk
 fFL
 nDq
 sxM
@@ -172141,7 +169724,7 @@ pOC
 ydS
 arm
 fLk
-jiU
+fNq
 mqV
 izf
 pIL
@@ -172665,7 +170248,7 @@ iWw
 eNC
 ewF
 ydS
-lnk
+fre
 mfE
 fvU
 cxn
@@ -172693,7 +170276,7 @@ gHp
 wVd
 kSH
 rZI
-mEV
+sHA
 sHA
 vMk
 sHA
@@ -172906,7 +170489,7 @@ lsw
 jun
 wwT
 xnx
-eRT
+xPg
 dLN
 pOC
 ydS
@@ -172956,7 +170539,7 @@ vxs
 dxT
 ebI
 dGa
-lEw
+dxT
 dxT
 uTP
 dGa
@@ -173679,7 +171262,7 @@ xmo
 xmo
 scB
 qze
-qOm
+wPK
 glJ
 bEa
 bgN
@@ -173691,7 +171274,7 @@ jLn
 bYM
 uIo
 vSD
-mtS
+fcN
 sJc
 uHf
 tUh
@@ -173954,7 +171537,7 @@ hgR
 bUH
 vSD
 vSD
-vri
+vSD
 vSD
 vSD
 vwy
@@ -174746,7 +172329,7 @@ kUz
 cKY
 ikS
 wFR
-fJf
+ufP
 wrn
 dqR
 dqR
@@ -175236,7 +172819,7 @@ cYQ
 ccs
 cnP
 vzr
-sHe
+cAk
 fcN
 fHj
 tzL
@@ -175476,7 +173059,7 @@ qtN
 qtN
 oLp
 iXu
-cPp
+ncC
 vTk
 ezf
 gDB
@@ -175566,7 +173149,7 @@ axo
 fTk
 wfx
 qXI
-opf
+uux
 aAw
 jks
 aaq
@@ -177024,7 +174607,7 @@ ecU
 thO
 mlQ
 glR
-owe
+tpt
 glR
 eTe
 xJj
@@ -178046,7 +175629,7 @@ ocu
 vsb
 vsb
 vsb
-aLk
+vsb
 wQr
 ecU
 thO
@@ -178842,7 +176425,7 @@ fsK
 fsK
 fsK
 cVX
-duz
+tbb
 pVy
 cFw
 xhV
@@ -180136,7 +177719,7 @@ gYX
 qjY
 xoK
 cQj
-kGC
+cQj
 nZa
 lyM
 wkE
@@ -180361,7 +177944,7 @@ qNH
 lhS
 oyc
 tLv
-wWJ
+tMU
 faY
 aEY
 bPv
@@ -180627,7 +178210,7 @@ stL
 sVU
 pEe
 gGh
-rXE
+hdG
 bBt
 hdG
 sMh
@@ -180644,7 +178227,7 @@ gXG
 jot
 bxK
 jot
-wKf
+kTj
 wuk
 gYX
 jUU
@@ -181937,7 +179520,7 @@ dZa
 dZa
 dZa
 dZa
-sVE
+hqP
 wkE
 qEC
 yhg
@@ -182958,7 +180541,7 @@ lER
 lER
 lER
 lER
-jWW
+lER
 lER
 lER
 rIU
@@ -183421,7 +181004,7 @@ ffK
 ibF
 chy
 fjL
-mRK
+chy
 bMB
 chy
 syC
@@ -183683,7 +181266,7 @@ ugN
 eHP
 mnQ
 xmf
-fKO
+xan
 hGa
 aru
 oIn
@@ -183723,7 +181306,7 @@ csj
 wkE
 hjz
 lER
-jWW
+lER
 lER
 lER
 lER
@@ -184221,7 +181804,7 @@ rDA
 lsH
 wuv
 nXz
-lZn
+vTL
 hfM
 uom
 pLz


### PR DESCRIPTION

## Что этот ПР делает
Зачем то в меде настенные дефибы которые были на столах на самом деле были НА ПОЛУ и пиксельшифтом смещены на стол, исправляем
## Почему это хорошо для игры
А смысл им быть на полу? Еще и префабом
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
map: Настольные дефибрилляторы в меде больше не стоят на полу и не смещены на стол префабом.
/:cl:
