### PR TITLE
Tweak+balance heart_cursed

### DIFF
--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -214,7 +214,7 @@
 			if(feedback)
 				owner.balloon_alert(owner, "must stand up!")
 			return FALSE
-		if((check_flags & AB_CHECK_CONSCIOUS) && (stat_allowed < owner.stat)) // If current state is "worse" than allowed
+	if((check_flags & AB_CHECK_CONSCIOUS) && (stat_allowed < owner.stat)) // If current state is "worse" than allowed
 		if(feedback)
 			switch(owner.stat)
 				if(UNCONSCIOUS)

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -214,7 +214,7 @@
 			if(feedback)
 				owner.balloon_alert(owner, "must stand up!")
 			return FALSE
-	if(stat_allowed < owner.stat)   // если текущее состояние "хуже" разрешённого
+		if((check_flags & AB_CHECK_CONSCIOUS) && (stat_allowed < owner.stat)) // If current state is "worse" than allowed
 		if(feedback)
 			switch(owner.stat)
 				if(UNCONSCIOUS)

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -67,7 +67,7 @@
 	var/can_be_shared = TRUE
 	/// Action in targeting mode (use only for overlay)
 	var/targeting_process = FALSE
-
+	///state in which to activate press
 	var/stat_allowed = CONSCIOUS
 
 /datum/action/New(Target)

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -68,6 +68,8 @@
 	/// Action in targeting mode (use only for overlay)
 	var/targeting_process = FALSE
 
+	var/stat_allowed = CONSCIOUS
+
 /datum/action/New(Target)
 	link_to(Target)
 
@@ -212,9 +214,15 @@
 			if(feedback)
 				owner.balloon_alert(owner, "must stand up!")
 			return FALSE
-	if((check_flags & AB_CHECK_CONSCIOUS) && owner.stat != CONSCIOUS)
+	if(stat_allowed < owner.stat)   // если текущее состояние "хуже" разрешённого
 		if(feedback)
-			owner.balloon_alert(owner, "unconscious!")
+			switch(owner.stat)
+				if(UNCONSCIOUS)
+					owner.balloon_alert(owner, "без сознания!")
+				if(DEAD)
+					owner.balloon_alert(owner, "мёртв!")
+				else
+					owner.balloon_alert(owner, "сейчас нельзя использовать!")
 		return FALSE
 	if((check_flags & AB_CHECK_TURF) && !isturf(owner.loc))
 		if(feedback)

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -67,7 +67,7 @@
 	var/can_be_shared = TRUE
 	/// Action in targeting mode (use only for overlay)
 	var/targeting_process = FALSE
-	///the state in which the action is allowed to be used (CONSCIOUS/UNCONSCIOUS/DEAD)
+	/// Action is allowed to be used in this state and any state "better" (for example DEAD means you can use it in any state)
 	var/stat_allowed = CONSCIOUS
 
 /datum/action/New(Target)

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -67,7 +67,7 @@
 	var/can_be_shared = TRUE
 	/// Action in targeting mode (use only for overlay)
 	var/targeting_process = FALSE
-	///state in which to activate press
+	///the state in which the action is allowed to be used (CONSCIOUS/UNCONSCIOUS/DEAD)
 	var/stat_allowed = CONSCIOUS
 
 /datum/action/New(Target)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -838,6 +838,6 @@ GLOBAL_LIST_EMPTY(multiverse)
 
 /obj/item/organ/internal/heart/cursed/wizard
 	pump_delay = 60
-	heal_brute = 25
-	heal_burn = 25
-	heal_oxy = 25
+	heal_brute = 15
+	heal_burn = 15
+	heal_oxy = 15

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -136,6 +136,7 @@
 
 /datum/action/item_action/organ_action/cursed_heart
 	name = "Подкачка крови"
+	stat_allowed = UNCONSCIOUS
 
 //You are now brea- pumping blood manually
 /datum/action/item_action/organ_action/cursed_heart/Trigger(mob/clicker, trigger_flags)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -85,7 +85,7 @@
 	actions_types = list(/datum/action/item_action/organ_action/cursed_heart)
 	var/last_pump = 0
 	var/pump_delay = 30 //you can pump 1 second early, for lag, but no more (otherwise you could spam heal)
-	var/blood_loss = 100 //600 blood is human default, so 5 failures (below 122 blood is where humans die because reasons?)
+	var/blood_loss = 50 //600 blood is human default, so 10 failures (below 122 blood is where humans die because reasons?)
 
 	//How much to heal per pump, negative numbers would HURT the player
 	var/heal_brute = 0


### PR DESCRIPTION

## Что этот ПР делает
даёт жать кнопку будучи во сне и крутит цифры баланса
## Почему это хорошо для игры
сердце имеет овер огромный хил что будто неправильно, и не оч крутую механику что ты умираешь от того что не способен нажать экшен сердца во сне 
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
balance: снижено лечение у проклятого сердца с 25 > 15, штраф по крови за  удар тоже снижен 100 > 50
tweak: heart_cursed можно активировать во сне.
/:cl:
