### PR TITLE
Сюрплюс и его содержимое нормально логируется для ГТ

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -2583,10 +2583,9 @@
 		remaining_TC -= chosen_item.cost
 		itemlog += chosen_item.name // To make the name more readable for the log compared to just i.item
 
-	target_uplink.purchase_log += "<big>[icon2base64html(crate)]</big>"
 	for(var/bought_item in bought_items)
-		var/obj/purchased = new bought_item(crate)
-		target_uplink.purchase_log += "<big>[icon2base64html(purchased)]</big>"
+		new bought_item(crate)
+	crate.log_contents_to_uplink(target_uplink)
 	add_game_logs("purchased a surplus crate with [jointext(itemlog, ", ")]", buyer)
 
 /datum/uplink_item/bundles_TC/telecrystal

--- a/code/game/objects/structures/crates_lockers/crate.dm
+++ b/code/game/objects/structures/crates_lockers/crate.dm
@@ -246,3 +246,9 @@
 			return
 		shelf.load(src, user, y_offset)
 		return
+
+/obj/structure/closet/crate/get_uplink_log_items()
+	. = list()
+	. += src
+	for(var/obj/item/contained_item in contents)
+		. += contained_item.get_uplink_log_items()


### PR DESCRIPTION

## Что этот ПР делает
Содержимое сюрплюсов (те что за 100/200 ТК со случайными вещами на 250/625 ТК) нормально логируется в purchase_log аплинка
## Почему это хорошо для игры
Чего-то забыл что у сюрплюсов отдельная логика при покупке. Больше информаци для гринтекста!
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
tweak: Нормальное отображение содержимого сюрплюсов после гринтекста.
/:cl:
