### PR TITLE
balance: Нёрф оружейки

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -148,22 +148,6 @@
 	icon_state = "red"
 	},
 /area/security/processing)
-"aau" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Armory_sprava";
-	location = "Armory_South"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/mob/living/simple_animal/bot/secbot/armsky,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "aav" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2083,7 +2067,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/warden)
 "auo" = (
@@ -4583,15 +4567,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engineering/mechanic_workshop)
-"aMD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/security/securearmory)
 "aMF" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -10452,13 +10427,10 @@
 	},
 /area/atmos)
 "bzj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/flasher/portable,
+/obj/structure/closet/secure_closet/guncabinet/secspear,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	dir = 5;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "bzl" = (
@@ -13516,9 +13488,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
 "bQd" = (
-/obj/machinery/vending/ammo,
+/obj/item/radio/intercom/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/mod/module/quick_cuff{
+	pixel_x = -8;
+	pixel_y = -6
+	},
+/obj/item/mod/module/quick_cuff{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/mod/module/pepper_shoulders{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/item/mod/module/hat_stabilizer{
+	pixel_x = 8;
+	pixel_y = -6
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "bQf" = (
@@ -17003,9 +16992,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "cjk" = (
-/obj/machinery/computer/brigcells,
+/obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "darkred"
 	},
 /area/security/warden)
@@ -17320,11 +17308,14 @@
 /turf/simulated/floor/grass,
 /area/maintenance/fpmaint)
 "clG" = (
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/gun/energy/ionrifle,
-/obj/structure/rack/gunrack,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredfull"
 	},
 /area/security/securearmory)
 "clH" = (
@@ -19227,16 +19218,6 @@
 	icon_state = "dark"
 	},
 /area/hydroponics)
-"cxk" = (
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/spawner/random_spawners/security_shotguns,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "cxn" = (
 /turf/simulated/wall,
 /area/crew_quarters/locker/locker_toilet)
@@ -25303,14 +25284,6 @@
 "dcA" = (
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
-"dcB" = (
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/structure/window/reinforced,
-/obj/effect/spawner/random_spawners/security_ballistics,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "dcC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -39326,14 +39299,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
-"ePU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "ePX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -40510,6 +40475,20 @@
 	icon_state = "browncorner"
 	},
 /area/quartermaster/storage)
+"fci" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/securearmory)
 "fcG" = (
 /obj/item/stock_parts/capacitor,
 /obj/machinery/constructable_frame/machine_frame,
@@ -40705,14 +40684,10 @@
 	},
 /area/crew_quarters/locker)
 "ffp" = (
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/flasher/portable,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/effect/spawner/random_spawners/security_lasers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "ffr" = (
@@ -42612,19 +42587,9 @@
 	},
 /area/security/medbay)
 "fzy" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/key/security{
-	pixel_y = 13
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/west,
+/obj/machinery/firealarm/directional/west,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -42810,20 +42775,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
 "fCr" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/clothing/shoes/combat/riot,
-/obj/item/clothing/shoes/combat/riot,
-/obj/item/clothing/shoes/combat/riot,
-/obj/item/clothing/shoes/combat/riot,
+/obj/machinery/suit_storage_unit/security,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredfull"
 	},
 /area/security/securearmory)
 "fCs" = (
@@ -42855,7 +42809,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkred"
 	},
 /area/security/warden)
 "fCH" = (
@@ -44346,6 +44301,7 @@
 "fUT" = (
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/alarm/directional/east,
+/obj/structure/closet/bombclosetsecurity,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
@@ -45124,12 +45080,9 @@
 	},
 /area/maintenance/kitchen)
 "gcY" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
+	dir = 4;
+	icon_state = "darkredcorners"
 	},
 /area/security/securearmory)
 "gdk" = (
@@ -45721,21 +45674,6 @@
 	icon_state = "dark"
 	},
 /area/maintenance/fpmaint)
-"gmi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/camera{
-	c_tag = "Secure Armory West";
-	dir = 4;
-	network = list("SS13","Security")
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/security/securearmory)
 "gmk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46801,20 +46739,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/library)
-"gxx" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/clothing/gloves/combat/riot,
-/obj/item/clothing/gloves/combat/riot,
-/obj/item/clothing/gloves/combat/riot,
-/obj/item/clothing/gloves/combat/riot,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "gxI" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -47283,20 +47207,9 @@
 	},
 /area/medical/medbay)
 "gDu" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredfull"
 	},
 /area/security/securearmory)
 "gDy" = (
@@ -47412,15 +47325,6 @@
 	icon_state = "darkred"
 	},
 /area/security/prison/cell_block/A)
-"gES" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
-	},
-/area/security/securearmory)
 "gFa" = (
 /obj/item/twohanded/required/kirbyplants,
 /obj/machinery/camera{
@@ -48680,20 +48584,6 @@
 	icon_state = "neutral"
 	},
 /area/maintenance/consarea_virology)
-"gRA" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "gRN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49879,8 +49769,10 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+	pixel_x = -5
+	},
+/obj/item/folder/red{
+	pixel_x = 5
 	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
@@ -50493,17 +50385,12 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/crew_quarters/serviceyard)
 "how" = (
-/obj/structure/sign/poster/contraband/random{
+/obj/structure/sign/poster/contraband/fun_police{
 	pixel_y = -32
 	},
-/obj/structure/rack/gunrack,
-/obj/item/twohanded/spear/secspear,
-/obj/item/twohanded/spear/secspear,
-/obj/item/twohanded/spear/secspear,
-/obj/item/twohanded/spear/secspear,
-/obj/item/twohanded/spear/secspear,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "hox" = (
@@ -50580,14 +50467,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/effect/landmark/start/warden,
 /turf/simulated/floor/plasteel{
-	icon_state = "darkredfull"
+	icon_state = "dark"
 	},
 /area/security/warden)
 "hoX" = (
@@ -52711,6 +52595,7 @@
 	},
 /area/quartermaster/storage)
 "hOI" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -53140,23 +53025,6 @@
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
 /area/library)
-"hTw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/warden)
 "hTO" = (
 /turf/simulated/floor/plasteel,
 /area/security/brig)
@@ -54368,7 +54236,18 @@
 	},
 /area/hallway/secondary/entry/commercial)
 "ijD" = (
-/obj/machinery/suit_storage_unit/security/warden,
+/obj/structure/table/reinforced,
+/obj/item/toy/russian_revolver{
+	pixel_y = -5
+	},
+/obj/item/key/security{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/stamp/warden{
+	pixel_x = -5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -57458,15 +57337,6 @@
 	icon_state = "white"
 	},
 /area/medical/sleeper)
-"iTk" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Armory_South";
-	location = "Armory_North"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "iTw" = (
 /obj/machinery/alarm/directional/east,
 /obj/item/twohanded/required/kirbyplants,
@@ -58103,20 +57973,7 @@
 /turf/simulated/floor/plasteel,
 /area/medical/virology/lab)
 "jbH" = (
-/obj/structure/bookcase,
-/obj/item/book/manual/security_space_law,
-/obj/item/book/manual/sop_command,
-/obj/item/book/manual/sop_engineering,
-/obj/item/book/manual/sop_general,
-/obj/item/book/manual/sop_legal,
-/obj/item/book/manual/sop_medical,
-/obj/item/book/manual/sop_science,
-/obj/item/book/manual/sop_security,
-/obj/item/book/manual/sop_service,
-/obj/item/book/manual/sop_supply,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -59528,16 +59385,29 @@
 /turf/simulated/wall,
 /area/maintenance/casino)
 "jqx" = (
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/machinery/camera{
-	c_tag = "Secure Armory East";
+/obj/structure/rack{
 	dir = 8;
-	network = list("SS13","Security")
+	layer = 2.9
 	},
-/obj/machinery/newscaster/security_unit/directional/east,
-/obj/vehicle/ridden/secway,
+/obj/item/shield/riot{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/closet/gun_stand/sechammer{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "jqE" = (
@@ -59786,18 +59656,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"jtg" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "Warden";
-	name = "Warden Privacy Shutters"
-	},
-/turf/simulated/floor/plating,
-/area/security/warden)
 "jti" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59904,20 +59762,9 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
 "juw" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/clothing/head/helmet/alt,
-/obj/item/clothing/head/helmet/alt,
-/obj/item/clothing/head/helmet/alt,
-/obj/item/clothing/head/helmet/alt,
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkredfull"
 	},
 /area/security/securearmory)
 "juy" = (
@@ -60937,13 +60784,10 @@
 	},
 /area/quartermaster/office)
 "jEO" = (
-/obj/machinery/flasher/portable,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/effect/spawner/random_spawners/security_shotguns,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "jET" = (
@@ -61773,6 +61617,15 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
+"jOW" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Armory_South";
+	location = "Armory_North"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
+	},
+/area/security/securearmory)
 "jOX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/delivery/hollow,
@@ -65186,7 +65039,6 @@
 	},
 /area/medical/research)
 "kGr" = (
-/obj/machinery/alarm/directional/north,
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/security/securearmory)
 "kGC" = (
@@ -65852,14 +65704,7 @@
 	},
 /area/security/interrogation)
 "kPb" = (
-/obj/machinery/photocopier,
-/obj/machinery/power/apc/directional/east,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/item/flag/nt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -66353,20 +66198,6 @@
 	icon_state = "dark"
 	},
 /area/chapel/office)
-"kWx" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/clothing/gloves/color/black/ballistic,
-/obj/item/clothing/gloves/color/black/ballistic,
-/obj/item/clothing/gloves/color/black/ballistic,
-/obj/item/clothing/gloves/color/black/ballistic,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "kWH" = (
 /obj/structure/sign/nosmoking_1,
 /turf/simulated/wall,
@@ -66723,16 +66554,11 @@
 	},
 /area/medical/cryo)
 "lck" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/showcase,
+/obj/machinery/light,
+/obj/machinery/computer/brigcells,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	dir = 6;
+	icon_state = "darkred"
 	},
 /area/security/warden)
 "lcq" = (
@@ -67141,27 +66967,22 @@
 "lhe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "darkred"
-	},
-/area/security/warden)
-"lhf" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
 /obj/machinery/requests_console{
 	department = "Warden";
 	departmentType = 7;
 	name = "Warden's Requests Console";
-	pixel_x = 29;
-	pixel_y = 25
+	pixel_x = -32;
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/warden)
+"lhf" = (
+/obj/structure/closet/secure_closet/warden,
+/turf/simulated/floor/plasteel{
+	dir = 1;
 	icon_state = "darkred"
 	},
 /area/security/warden)
@@ -68436,13 +68257,15 @@
 /turf/simulated/wall/r_wall,
 /area/medical/cmostore)
 "lvI" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/vending/wallmed{
+	pixel_x = 26;
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	dir = 4;
 	icon_state = "darkred"
 	},
 /area/security/warden)
@@ -68613,12 +68436,14 @@
 	},
 /area/chapel/main)
 "lyD" = (
-/obj/machinery/computer/secure_data,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/toy/figure/warden,
 /turf/simulated/floor/plasteel{
-	dir = 6;
+	dir = 4;
 	icon_state = "darkred"
 	},
 /area/security/warden)
@@ -70545,10 +70370,8 @@
 	},
 /area/security/podbay)
 "lYj" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Armory";
-	req_access = list(3);
-	security_level = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70556,18 +70379,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "ArmoryLock";
-	name = "Armory Lockdown"
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred"
 	},
-/area/security/warden)
+/area/security/securearmory)
 "lYu" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small{
@@ -70662,21 +70478,17 @@
 	},
 /area/hallway/primary/aft)
 "lZG" = (
-/obj/structure/table/reinforced,
-/obj/item/mod/module/hat_stabilizer{
-	pixel_x = 1;
-	pixel_y = -6
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/item/mod/module/hat_stabilizer{
-	pixel_x = -7;
-	pixel_y = 2
-	},
-/obj/item/mod/module/pepper_shoulders{
-	pixel_x = 6;
-	pixel_y = 9
-	},
+/obj/item/clothing/gloves/combat/riot,
+/obj/item/clothing/gloves/combat/riot,
+/obj/item/clothing/gloves/combat/riot,
+/obj/item/clothing/gloves/combat/riot,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "lZI" = (
@@ -70866,12 +70678,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space)
-"mbY" = (
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "darkred"
-	},
-/area/security/securearmory)
 "mcd" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
@@ -70997,21 +70803,18 @@
 	},
 /area/crew_quarters/courtroom)
 "mdH" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/start/warden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkredfull"
+	icon_state = "dark"
 	},
 /area/security/warden)
 "mdT" = (
@@ -71085,16 +70888,6 @@
 	icon_state = "white"
 	},
 /area/medical/research/shallway)
-"meY" = (
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/structure/safe{
-	known_by = list("hos")
-	},
-/obj/item/gun/projectile/bombarda/secgl/x4,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "mfb" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -71912,19 +71705,13 @@
 	},
 /area/security/permabrig)
 "mnY" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
 /obj/machinery/camera{
 	c_tag = "Brig Warden's Office";
 	dir = 4;
 	network = list("SS13","Security")
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light_switch/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -72978,12 +72765,9 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/maintenance/banya)
 "myZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "mzf" = (
@@ -73245,7 +73029,8 @@
 	},
 /area/security/processing)
 "mBR" = (
-/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/disposalpipe/segment,
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -73561,6 +73346,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central/west)
+"mEe" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/securearmory)
 "mEg" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/conveyor{
@@ -73851,23 +73644,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
-"mHR" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/clothing/shoes/jackboots/armored,
-/obj/item/clothing/shoes/jackboots/armored,
-/obj/item/clothing/shoes/jackboots/armored,
-/obj/item/clothing/shoes/jackboots/armored,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "mHX" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
@@ -74370,7 +74146,6 @@
 "mMi" = (
 /obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkred"
 	},
 /area/security/warden)
@@ -76118,21 +75893,6 @@
 	icon_state = "grimy"
 	},
 /area/chapel/main)
-"nfj" = (
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/structure/rack/gunrack,
-/obj/structure/window/reinforced,
-/obj/item/gun/energy/gun{
-	pixel_x = -6
-	},
-/obj/item/gun/energy/gun,
-/obj/item/gun/energy/gun{
-	pixel_x = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "nfm" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -76341,10 +76101,10 @@
 /area/maintenance/fore)
 "nhY" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/security/securearmory)
 "nie" = (
@@ -77417,28 +77177,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tourist)
 "nta" = (
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/lock_buster,
-/obj/item/storage/box/trackimp,
-/obj/item/storage/box/chemimp{
-	pixel_x = 4;
-	pixel_y = 3
+/obj/machinery/alarm/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/storage/lockbox/suppression{
+	pixel_y = -5
 	},
 /obj/item/storage/lockbox/mindshield,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/item/storage/lockbox/suppression,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "ntd" = (
@@ -80161,22 +79907,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/engineering/engine)
-"oan" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 58;
-	pixel_y = 30
-	},
-/obj/structure/bed/dogbed,
-/mob/living/simple_animal/pet/dog/security/warden,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkredcorners"
-	},
-/area/security/warden)
 "oar" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -82043,11 +81773,10 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "ovb" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/suit_storage_unit/security,
+/obj/machinery/flasher/portable,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "ovf" = (
@@ -83869,6 +83598,20 @@
 "oOo" = (
 /turf/simulated/wall/r_wall,
 /area/toxins/xenobiology)
+"oOx" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/gloves/color/black/ballistic,
+/obj/item/clothing/gloves/color/black/ballistic,
+/obj/item/clothing/gloves/color/black/ballistic,
+/obj/item/clothing/gloves/color/black/ballistic,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/securearmory)
 "oOK" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -84739,20 +84482,6 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
-"pal" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "pat" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85313,12 +85042,6 @@
 	icon_state = "wood-broken3"
 	},
 /area/maintenance/kitchen)
-"pgO" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/warden)
 "pgR" = (
 /obj/machinery/door/window/brigdoor/southleft{
 	dir = 4;
@@ -86032,14 +85755,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/wood/fancy/light,
 /area/crew_quarters/captain)
-"ppg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "ppp" = (
 /obj/machinery/computer/card/minor/hos,
 /turf/simulated/floor/wood,
@@ -92847,10 +92562,10 @@
 	},
 /area/hallway/primary/central/nw)
 "qMv" = (
-/obj/machinery/flasher/portable,
+/obj/effect/spawner/random_spawners/security_ballistics,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "qMw" = (
@@ -92954,13 +92669,17 @@
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "qNH" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/syndie_kit/dropwall{
-	pixel_x = -2;
-	pixel_y = 1
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
+/obj/item/clothing/shoes/combat/riot,
+/obj/item/clothing/shoes/combat/riot,
+/obj/item/clothing/shoes/combat/riot,
+/obj/item/clothing/shoes/combat/riot,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "qNI" = (
@@ -93571,16 +93290,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/gravitygenerator)
-"qUi" = (
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/dispenser/oxygen,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "qUz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -94797,9 +94506,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -94880,6 +94586,14 @@
 "rjT" = (
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"rjV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
+	},
+/area/security/securearmory)
 "rjW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -95275,7 +94989,7 @@
 	},
 /area/hallway/primary/central/east)
 "roC" = (
-/obj/item/twohanded/required/kirbyplants,
+/obj/structure/closet/bombclosetsecurity,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "red"
@@ -95402,14 +95116,6 @@
 	icon_state = "dark"
 	},
 /area/bridge)
-"rpS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "rpX" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -96055,9 +95761,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/casino)
 "ryd" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/security/securearmory)
 "ryj" = (
@@ -96466,28 +96174,20 @@
 	id = "ArmorySec";
 	name = "Armory Security Window Control";
 	pixel_x = 7;
-	pixel_y = 7;
+	pixel_y = -2;
 	req_access = list(3)
 	},
 /obj/machinery/door_control{
 	id = "ArmorySecAccess";
 	name = "Armory Security Access Control";
-	pixel_x = 7;
-	pixel_y = -2;
-	req_access = list(3)
-	},
-/obj/machinery/door_control{
-	id = "Warden";
-	name = "Warden Privacy Shutters Control";
 	pixel_x = -7;
-	pixel_y = 7;
+	pixel_y = -2;
 	req_access = list(3)
 	},
 /obj/machinery/door_control{
 	id = "ArmoryLock";
 	name = "Armory Lockdown";
-	pixel_x = -7;
-	pixel_y = -2;
+	pixel_y = 7;
 	req_access = list(3)
 	},
 /obj/structure/cable{
@@ -96739,10 +96439,22 @@
 	},
 /area/hallway/primary/starboard/east)
 "rEV" = (
-/obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
+/obj/machinery/power/apc/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/syndie_kit/dropwall{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/storage/box/trackimp{
+	pixel_x = 8
+	},
+/obj/item/storage/box/chemimp{
+	pixel_x = 8;
+	pixel_y = 6
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "rFj" = (
@@ -96817,13 +96529,10 @@
 	},
 /area/security/prison/cell_block/A)
 "rFD" = (
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/machinery/flasher/portable,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "rFG" = (
@@ -98881,19 +98590,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
-"sei" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/security/securearmory)
 "sek" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -100775,15 +100471,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"syf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
-	},
-/area/security/warden)
 "syj" = (
 /turf/simulated/floor/plating,
 /area/maintenance/brig)
@@ -100941,12 +100628,6 @@
 	icon_state = "dark"
 	},
 /area/library)
-"szM" = (
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "darkred"
-	},
-/area/security/securearmory)
 "szQ" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
@@ -101674,13 +101355,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/engineering/engine)
-"sIJ" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/delivery/red,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "sIL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -101858,13 +101532,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "sMb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Armory_sprava";
+	location = "Armory_South"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
+/mob/living/simple_animal/bot/secbot/armsky,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -102450,10 +102122,15 @@
 	},
 /area/crew_quarters/theatre)
 "sSa" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/structure/closet/l3closet/security,
+/obj/structure/sign/poster/contraband/armor{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "sSj" = (
@@ -102893,22 +102570,10 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Secure Armory";
-	req_access = list(1)
-	},
-/obj/item/clothing/shoes/reflector,
-/obj/item/clothing/gloves/reflector,
-/obj/item/clothing/suit/armor/reflector,
-/obj/item/clothing/head/helmet/reflector,
+/obj/item/gun/energy/ionrifle,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "sYb" = (
@@ -103807,14 +103472,26 @@
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "thk" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/alarm/directional/west,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/window/reinforced,
-/obj/structure/showcase,
-/turf/simulated/floor/plasteel{
+/obj/structure/rack{
 	dir = 8;
-	icon_state = "vault"
+	layer = 2.9
+	},
+/obj/item/bodybag/environmental/prisoner/pressurized{
+	pixel_x = -9
+	},
+/obj/item/bodybag/environmental/prisoner/pressurized{
+	pixel_x = 7
+	},
+/obj/item/lock_buster{
+	pixel_y = 10
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkred"
 	},
 /area/security/warden)
 "thl" = (
@@ -103897,35 +103574,14 @@
 /turf/simulated/wall/r_wall,
 /area/security/detectives_office)
 "tig" = (
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/shield/riot{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Secure Armory";
-	req_access = list(1)
-	},
+/obj/item/gun/projectile/bombarda/secgl/x4,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "tij" = (
@@ -104093,6 +103749,20 @@
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/fore)
+"tjn" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/shoes/jackboots/armored,
+/obj/item/clothing/shoes/jackboots/armored,
+/obj/item/clothing/shoes/jackboots/armored,
+/obj/item/clothing/shoes/jackboots/armored,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/securearmory)
 "tjq" = (
 /obj/machinery/vending/snack,
 /obj/effect/turf_decal/stripes/line{
@@ -104777,15 +104447,6 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
-"tsW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/security/securearmory)
 "tsY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -107325,20 +106986,13 @@
 	},
 /area/medical/medbay)
 "tTn" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/toy/figure/warden,
+/obj/machinery/power/apc/directional/west,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/obj/item/bodybag/environmental/prisoner/pressurized{
-	pixel_x = 7
-	},
-/obj/item/bodybag/environmental/prisoner/pressurized{
-	pixel_x = -9
-	},
+/obj/vehicle/ridden/secway,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 8;
 	icon_state = "darkred"
 	},
 /area/security/warden)
@@ -107572,26 +107226,17 @@
 	},
 /area/engineering/break_room)
 "tVQ" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/obj/item/mod/module/megaphone{
-	pixel_x = 6;
-	pixel_y = -3
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/item/mod/module/megaphone{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/mod/module/quick_cuff{
-	pixel_x = -6;
-	pixel_y = -4
-	},
-/obj/item/mod/module/quick_cuff{
-	pixel_x = -7;
-	pixel_y = 9
-	},
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "tVV" = (
@@ -108257,6 +107902,7 @@
 	},
 /area/medical/paramedic)
 "ues" = (
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "red"
@@ -109188,10 +108834,11 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "darkred"
 	},
 /area/security/warden)
 "uom" = (
@@ -109203,13 +108850,6 @@
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood,
 /area/security/hos)
-"uou" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/machinery/suit_storage_unit/security,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "uoA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -109365,18 +109005,17 @@
 	},
 /area/hallway/primary/port)
 "uqu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/security/securearmory)
 "uqO" = (
@@ -111560,10 +111199,17 @@
 	},
 /area/security/permabrig)
 "uPg" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/structure/closet/bombclosetsecurity,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/head/helmet/alt,
+/obj/item/clothing/head/helmet/alt,
+/obj/item/clothing/head/helmet/alt,
+/obj/item/clothing/head/helmet/alt,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 9;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "uPh" = (
@@ -111958,12 +111604,6 @@
 	icon_state = "white"
 	},
 /area/medical/medbay)
-"uTS" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
-	},
-/area/security/securearmory)
 "uTU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -112691,16 +112331,6 @@
 	icon_state = "darkblue"
 	},
 /area/tcommsat/chamber)
-"vdJ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Armory_North";
-	location = "Armory_sprava"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
-	},
-/area/security/securearmory)
 "vdW" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
@@ -113247,11 +112877,8 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
 "vkj" = (
-/obj/structure/table/reinforced,
-/obj/item/toy/russian_revolver,
-/obj/item/stamp/warden{
-	pixel_y = 10
-	},
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/dog/security/warden,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -114589,7 +114216,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "darkredcorners"
+	icon_state = "dark"
 	},
 /area/security/warden)
 "vxW" = (
@@ -115539,16 +115166,6 @@
 /obj/structure/dresser,
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/heads/hop)
-"vIE" = (
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/spawner/random_spawners/security_lasers,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/securearmory)
 "vIQ" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/fire{
@@ -115817,6 +115434,20 @@
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/carpet/royalblack,
 /area/ntrep)
+"vMa" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/security/securearmory)
 "vMk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -115969,8 +115600,13 @@
 	},
 /area/assembly/chargebay)
 "vNX" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
+	},
 /area/security/securearmory)
 "vNZ" = (
 /obj/effect/turf_decal/delivery/hollow,
@@ -116643,11 +116279,9 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/lawoffice)
 "vUr" = (
-/obj/structure/closet/gun_stand/sechammer{
-	pixel_y = -30
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "vUu" = (
@@ -116847,12 +116481,15 @@
 	},
 /area/medical/surgery/north)
 "vWq" = (
-/obj/machinery/computer/prisoner,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/photocopier,
+/obj/machinery/door_control{
+	id = "Warden";
+	name = "Warden Privacy Shutters Control";
+	pixel_x = -26;
+	req_access = list(3)
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 8;
 	icon_state = "darkred"
 	},
 /area/security/warden)
@@ -116954,15 +116591,11 @@
 	},
 /area/crew_quarters/fitness)
 "vXH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/security/securearmory)
 "vXL" = (
@@ -117027,8 +116660,9 @@
 	},
 /area/tcommsat/chamber)
 "vYt" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Armory_North";
+	location = "Armory_sprava"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
@@ -117912,7 +117546,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "wkl" = (
-/obj/structure/closet/secure_closet/warden,
+/obj/item/flag/sec,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -118217,14 +117851,14 @@
 /turf/simulated/floor/plasteel,
 /area/maintenance/electrical)
 "wnX" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/suit_storage_unit/security/warden,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/window/reinforced,
-/obj/structure/showcase,
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	dir = 5;
+	icon_state = "darkred"
 	},
 /area/security/warden)
 "woa" = (
@@ -119401,15 +119035,6 @@
 	icon_state = "whitepurple"
 	},
 /area/toxins/misc_lab)
-"wAM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
-	},
-/area/security/warden)
 "wAT" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/boxing/blue,
@@ -121843,16 +121468,11 @@
 	},
 /area/turret_protected/aisat_interior)
 "xdp" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/showcase,
+/obj/machinery/computer/prisoner,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	dir = 10;
+	icon_state = "darkred"
 	},
 /area/security/warden)
 "xds" = (
@@ -122556,8 +122176,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/alarm/directional/south,
-/obj/machinery/light_switch/directional/north,
+/obj/machinery/door/airlock/security/glass{
+	name = "Armory";
+	req_access = list(3);
+	security_level = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "ArmoryLock";
+	name = "Armory Lockdown"
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -122652,7 +122280,9 @@
 /area/security/detectives_office)
 "xmw" = (
 /obj/machinery/computer/mech_bay_power_console,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/security/securearmory)
 "xmz" = (
@@ -122910,14 +122540,6 @@
 	icon_state = "red"
 	},
 /area/security/processing)
-"xpx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/warden)
 "xpz" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -124945,11 +124567,10 @@
 /turf/simulated/wall/r_wall,
 /area/security/customs)
 "xJl" = (
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/flasher/portable,
+/obj/machinery/vending/ammo,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "vault"
+	dir = 6;
+	icon_state = "darkred"
 	},
 /area/security/securearmory)
 "xJo" = (
@@ -178545,13 +178166,13 @@ tLv
 tMU
 tzh
 tzh
-jtg
+tzh
 tzh
 tQs
 unM
 lTn
 tzh
-jtg
+tzh
 tzh
 tzh
 nRT
@@ -179059,13 +178680,13 @@ ija
 tMU
 hgM
 lhe
-syf
+vxU
 hIB
 hIB
 riJ
-pgO
-xpx
-wAM
+hIB
+hIB
+hIB
 mMi
 xWZ
 nRT
@@ -179573,7 +179194,7 @@ tcP
 oau
 qIz
 lhf
-oan
+vxU
 hIB
 hIB
 uoW
@@ -179833,7 +179454,7 @@ wnX
 lvI
 vkj
 kPb
-hTw
+riJ
 jbH
 ijD
 lyD
@@ -180344,11 +179965,11 @@ pLm
 qhn
 lhS
 uPg
-toP
-toP
-tzh
+fci
+oOx
+tjn
 lYj
-tzh
+vMa
 tVQ
 lZG
 qNH
@@ -180601,11 +180222,11 @@ tLv
 tMU
 lhS
 sSa
-szM
-aMD
-gmi
+toP
+toP
+toP
 uqu
-sei
+vXH
 vXH
 ryd
 how
@@ -180858,13 +180479,13 @@ eQZ
 juZ
 lhS
 ovb
-tHS
-dIj
-vIE
+toP
+jOW
+toP
 clG
-nfj
+toP
 sMb
-wCH
+mEe
 bQd
 lhS
 foB
@@ -181114,13 +180735,13 @@ oIn
 qug
 mml
 lhS
-uou
-tHS
-iTk
-mHR
+ovb
+toP
+toP
+fCr
 vNX
 fCr
-aau
+toP
 nhY
 rEV
 lhS
@@ -181371,14 +180992,14 @@ uEd
 mqz
 aSX
 lhS
-sIJ
-tHS
+ovb
 toP
-kWx
-vNX
-gxx
-ePU
-wCH
+toP
+toP
+rjV
+toP
+toP
+toP
 nta
 lhS
 jBq
@@ -181628,14 +181249,14 @@ oIn
 qug
 mfd
 lhS
-qUi
-tHS
+ovb
 toP
-pal
-vNX
-gRA
-ePU
-wCH
+toP
+toP
+rjV
+toP
+toP
+toP
 vUr
 lhS
 vcX
@@ -181891,9 +181512,9 @@ toP
 juw
 vNX
 gDu
-ePU
+toP
+toP
 wCH
-ppg
 xXC
 vcX
 nHu
@@ -182143,13 +181764,13 @@ qug
 mml
 lhS
 xmw
-tsW
+tHS
 hOI
-cxk
-meY
-dcB
+toP
+dIj
+toP
 vYt
-wCH
+toP
 myZ
 xXZ
 oNP
@@ -182400,14 +182021,14 @@ qug
 mml
 lhS
 kGr
-gES
-uTS
-uTS
-vdJ
-uTS
-uTS
-mbY
-rpS
+tHS
+toP
+toP
+toP
+toP
+toP
+toP
+wCH
 sXN
 vcX
 nHu

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -96442,9 +96442,8 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/south,
 /obj/structure/table/reinforced,
-/obj/item/storage/box/syndie_kit/dropwall{
-	pixel_x = -6;
-	pixel_y = 3
+/obj/item/storage/box/syndie_kit/dropwall/sec{
+	pixel_x = -6
 	},
 /obj/item/storage/box/trackimp{
 	pixel_x = 8

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -3945,15 +3945,12 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/storage/box/syndie_kit/dropwall{
-	pixel_x = -2;
-	pixel_y = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Secure Armory East";
 	dir = 8;
 	network = list("SS13","Security")
 	},
+/obj/item/storage/box/syndie_kit/dropwall/sec,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -48969,12 +48966,6 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/storage/lockbox/mindshield,
-/obj/item/storage/box/trackimp,
-/obj/item/storage/box/chemimp{
-	pixel_x = 4;
-	pixel_y = 3
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -48984,6 +48975,10 @@
 	req_access = list(1)
 	},
 /obj/effect/turf_decal/delivery/red/hollow,
+/obj/item/storage/lockbox/suppression{
+	pixel_y = -4
+	},
+/obj/item/storage/lockbox/mindshield,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -66807,10 +66802,11 @@
 "oaf" = (
 /obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/table/reinforced,
-/obj/item/storage/lockbox/suppression{
-	pixel_y = -4
+/obj/item/storage/box/trackimp,
+/obj/item/storage/box/chemimp{
+	pixel_x = 4;
+	pixel_y = 3
 	},
-/obj/item/storage/lockbox/mindshield,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkred"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -3477,6 +3477,7 @@
 /area/security/permabrig)
 "aqv" = (
 /obj/structure/closet/secure_closet/warden,
+/obj/item/lock_buster,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -19071,15 +19072,12 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bFA" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/rack/gunrack,
+/obj/effect/turf_decal/delivery/red/hollow,
+/obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
 /obj/item/gun/energy/ionrifle{
 	pixel_x = 3
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -35934,22 +35932,9 @@
 /area/engineering/engine)
 "cXZ" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/obj/item/mod/module/megaphone{
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/mod/module/megaphone{
-	pixel_x = 6;
-	pixel_y = 8
-	},
+/obj/item/mod/module/quick_cuff,
 /obj/item/mod/module/quick_cuff{
-	pixel_x = -6;
-	pixel_y = -4
-	},
-/obj/item/mod/module/quick_cuff{
-	pixel_x = -7;
-	pixel_y = 9
+	pixel_y = 7
 	},
 /obj/structure/sign/poster/official/twelve_gauge{
 	pixel_x = 32
@@ -48904,6 +48889,14 @@
 "gIQ" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
+"gJb" = (
+/obj/effect/turf_decal/delivery/red/hollow,
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/security/securearmory)
 "gJF" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -48982,7 +48975,6 @@
 	pixel_x = 4;
 	pixel_y = 3
 	},
-/obj/item/lock_buster,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -48992,7 +48984,6 @@
 	req_access = list(1)
 	},
 /obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/storage/lockbox/suppression,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -56867,9 +56858,6 @@
 "jYt" = (
 /obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/spawner/random_spawners/security_shotguns,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -61142,11 +61130,7 @@
 "lDE" = (
 /obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/window/reinforced,
-/obj/structure/rack/gunrack,
-/obj/item/twohanded/spear/secspear,
-/obj/item/twohanded/spear/secspear,
-/obj/item/twohanded/spear/secspear,
-/obj/item/twohanded/spear/secspear,
+/obj/effect/spawner/random_spawners/security_ballistics,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -65942,11 +65926,11 @@
 	name = "Secure Armory";
 	req_access = list(1)
 	},
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
 /obj/effect/turf_decal/delivery/red/hollow,
+/obj/item/clothing/head/helmet/reflector,
+/obj/item/clothing/suit/armor/reflector,
+/obj/item/clothing/gloves/reflector,
+/obj/item/clothing/shoes/reflector,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -66822,7 +66806,11 @@
 /area/maintenance/apmaint)
 "oaf" = (
 /obj/effect/turf_decal/delivery/red/hollow,
-/obj/machinery/flasher/portable,
+/obj/structure/table/reinforced,
+/obj/item/storage/lockbox/suppression{
+	pixel_y = -4
+	},
+/obj/item/storage/lockbox/mindshield,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkred"
@@ -68214,10 +68202,7 @@
 /area/hallway/primary/starboard/east)
 "oHJ" = (
 /obj/effect/turf_decal/delivery/red/hollow,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/spawner/random_spawners/security_ballistics,
+/obj/structure/closet/secure_closet/guncabinet/secspear,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -68508,10 +68493,20 @@
 /turf/simulated/floor/wood,
 /area/security/hos)
 "oOa" = (
-/obj/structure/safe{
-	known_by = list("hos")
+/obj/item/shield/riot{
+	pixel_x = -6;
+	pixel_y = -6
 	},
-/obj/item/gun/projectile/bombarda/secgl/x4,
+/obj/structure/rack,
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -78361,19 +78356,10 @@
 	},
 /area/solar/port)
 "sQg" = (
-/obj/structure/rack/gunrack,
-/obj/item/gun/energy/gun{
-	pixel_x = -3
-	},
-/obj/item/gun/energy/gun,
-/obj/item/gun/energy/gun{
-	pixel_x = 3
-	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/delivery/red/hollow,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/structure/rack,
+/obj/item/gun/projectile/bombarda/secgl/x4,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -83233,8 +83219,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/dispenser/oxygen,
 /obj/effect/turf_decal/delivery/red/hollow,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -87519,14 +87505,6 @@
 	icon_state = "white"
 	},
 /area/assembly/robotics)
-"wwm" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery/red/hollow,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/security/securearmory)
 "wwy" = (
 /obj/structure/rack{
 	dir = 8;
@@ -90955,22 +90933,8 @@
 	},
 /area/hallway/secondary/entry/north)
 "xRQ" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	name = "Secure Armory";
-	req_access = list(1)
-	},
 /obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/clothing/shoes/reflector,
-/obj/item/clothing/gloves/reflector,
-/obj/item/clothing/suit/armor/reflector,
-/obj/item/clothing/head/helmet/reflector,
+/obj/machinery/flasher/portable,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkred"
@@ -119752,7 +119716,7 @@ lTl
 aiv
 abO
 aiv
-wwm
+cRE
 qzT
 lDE
 exW
@@ -120266,7 +120230,7 @@ lTl
 aiv
 abO
 aiv
-sqj
+gJb
 qzT
 kKX
 oOa

--- a/_maps/map_files/nova/nova.dmm
+++ b/_maps/map_files/nova/nova.dmm
@@ -89611,9 +89611,15 @@
 "nKV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/reinforced,
-/obj/item/storage/box/syndie_kit/dropwall{
-	pixel_x = -2;
-	pixel_y = 1
+/obj/item/storage/box/syndie_kit/dropwall/sec{
+	pixel_x = -6
+	},
+/obj/item/storage/box/chemimp{
+	pixel_x = 6
+	},
+/obj/item/storage/box/trackimp{
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -97412,6 +97418,7 @@
 /obj/item/key/security{
 	pixel_y = 5
 	},
+/obj/item/lock_buster,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -103937,14 +103944,10 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/delivery/red/hollow,
-/obj/item/storage/box/chemimp{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/storage/box/trackimp,
-/obj/item/lock_buster,
-/obj/item/storage/lockbox/mindshield,
 /obj/item/storage/lockbox/suppression,
+/obj/item/storage/lockbox/mindshield{
+	pixel_y = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/nova/nova.dmm
+++ b/_maps/map_files/nova/nova.dmm
@@ -89478,11 +89478,7 @@
 /turf/simulated/wall/r_wall,
 /area/medical/biostorage)
 "nJS" = (
-/obj/item/gun/projectile/bombarda/secgl/x4,
-/obj/item/gun/projectile/bombarda/secgl/x4,
-/obj/structure/safe{
-	known_by = list("hos")
-	},
+/obj/machinery/vending/ammo,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -111966,13 +111962,6 @@
 "rdX" = (
 /obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/rack/gunrack,
-/obj/item/gun/energy/gun{
-	pixel_x = -3
-	},
-/obj/item/gun/energy/gun,
-/obj/item/gun/energy/gun{
-	pixel_x = 3
-	},
 /obj/structure/window/reinforced{
 	color = "red"
 	},
@@ -111982,6 +111971,8 @@
 	name = "Secure Armory";
 	req_access = list(1)
 	},
+/obj/item/gun/projectile/bombarda/secgl/x4,
+/obj/item/gun/projectile/bombarda/secgl/x4,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -113639,12 +113630,7 @@
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
 "rqp" = (
-/obj/structure/rack/gunrack,
-/obj/item/twohanded/spear/secspear,
-/obj/item/twohanded/spear/secspear,
-/obj/item/twohanded/spear/secspear,
-/obj/item/twohanded/spear/secspear,
-/obj/item/twohanded/spear/secspear,
+/obj/structure/closet/secure_closet/guncabinet/secspear,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -157258,19 +157244,6 @@
 	icon_state = "ramptop"
 	},
 /area/hallway/secondary/exit)
-"xTO" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1;
-	in_use = 1
-	},
-/obj/machinery/vending/ammo,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkredfull"
-	},
-/area/security/securearmory)
 "xTQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -239061,7 +239034,7 @@ uJG
 xoL
 ajW
 xoL
-xTO
+fVS
 fsx
 fsx
 fsx

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -379,22 +379,11 @@
 
 /datum/station_trait/looted_armory
 	name = "Разграбленная оружейная"
-	report_message = "Из-за острой нехватки финансирования, часть снаряжения в оружейной объекта была списана. В качестве компенсации стоимость заказа вооружения была снижена."
+	report_message = "Из-за острой нехватки финансирования, часть снаряжения в оружейной объекта была списана."
 	trait_type = STATION_TRAIT_NEGATIVE
 	show_in_report = TRUE
 	trait_to_give = STATION_TRAIT_LOOTED_ARMORY
-	weight = 2
-	blacklist = list(/datum/station_trait/upgraded_armory)
-
-/datum/station_trait/looted_armory/on_round_start()
-	. = ..()
-	for(var/set_name in SSshuttle.supply_packs)
-		var/datum/supply_packs/pack = SSshuttle.supply_packs[set_name]
-		if(pack.group != SUPPLY_SECURITY)
-			continue
-		pack.cost *= 0.6
-
-	INVOKE_ASYNC(src, PROC_REF(loot_armory))
+	weight = 20
 
 /datum/station_trait/looted_armory/proc/loot_armory()
 	for(var/area/security/securearmory/armory in GLOB.areas)

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -385,6 +385,10 @@
 	trait_to_give = STATION_TRAIT_LOOTED_ARMORY
 	weight = 2
 
+/datum/station_trait/looted_armory/on_round_start()
+	. = ..()
+	INVOKE_ASYNC(src, PROC_REF(loot_armory))
+
 /datum/station_trait/looted_armory/proc/loot_armory()
 	for(var/area/security/securearmory/armory in GLOB.areas)
 		for(var/list/zlevel_turfs as anything in armory.get_zlevel_turf_lists())

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -383,7 +383,7 @@
 	trait_type = STATION_TRAIT_NEGATIVE
 	show_in_report = TRUE
 	trait_to_give = STATION_TRAIT_LOOTED_ARMORY
-	weight = 20
+	weight = 2
 
 /datum/station_trait/looted_armory/proc/loot_armory()
 	for(var/area/security/securearmory/armory in GLOB.areas)

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -6386,8 +6386,8 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/contraband/ammobox545
 	name = "Патроны 5,45x39 мм"
 	contains = list(
-		/obj/item/ammo_box/a545x39,
-		/obj/item/ammo_box/a545x39,
+		/obj/item/ammo_box/a545x39/fusty,
+		/obj/item/ammo_box/a545x39/fusty,
 	)
 	credits_cost = 4500
 	containername = "ящик патронов 5,45x39 мм"

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -450,6 +450,10 @@
 		PREPOSITIONAL = "коробкой с генераторами энергощита"
 	)
 
+/obj/item/storage/box/syndie_kit/dropwall/sec
+	icon_state = "box_security"
+	item_state = "sec"
+
 /obj/item/storage/box/syndie_kit/dropwall/populate_contents()
 	for(var/I in 1 to 5)
 		new /obj/item/grenade/barrier/dropwall(src)

--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -464,6 +464,7 @@
 	result = list(
 		/obj/structure/closet/secure_closet/guncabinet/lasergun = 50,
 		/obj/structure/closet/secure_closet/guncabinet/lr30 = 50,
+		/obj/structure/closet/secure_closet/guncabinet/energygun = 50,
 	)
 
 /obj/effect/spawner/random_spawners/security_lasers/Initialize(mapload)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -178,7 +178,7 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/wt550/populate_contents()
-	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 2) : 4
 	for(var/i in 1 to gun_count)
 		new /obj/item/gun/projectile/automatic/smg/wt550(src)
 
@@ -198,7 +198,7 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/sp91/populate_contents()
-	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 2) : 4
 	for(var/i in 1 to gun_count)
 		new /obj/item/gun/projectile/automatic/smg/sp91rc(src)
 
@@ -218,7 +218,7 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/sparkle_a12/populate_contents()
-	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 2) : 4
 	for(var/i in 1 to gun_count)
 		new /obj/item/gun/projectile/automatic/smg/sparkle_a12(src)
 
@@ -238,7 +238,7 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/sfg/populate_contents()
-	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 2) : 4
 	for(var/i in 1 to gun_count)
 		new /obj/item/gun/projectile/automatic/smg/sfg(src)
 	new /obj/item/disk/design_disk/security/sfg5_mag(src)
@@ -259,7 +259,7 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/saber/populate_contents()
-	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 2) : 4
 	for(var/i in 1 to gun_count)
 		new /obj/item/gun/projectile/automatic/smg/saber/rubber(src)
 	new /obj/item/disk/design_disk/security/saber_mag(src)
@@ -280,7 +280,7 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/ak814/populate_contents()
-	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 2) : 4
 	for(var/i in 1 to gun_count)
 		new /obj/item/gun/projectile/automatic/ak814/weakened(src)
 	new /obj/item/disk/design_disk/security/ak814_mag(src)
@@ -302,7 +302,7 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/secspear/populate_contents()
-	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 2) : 4
 	for(var/i in 1 to gun_count)
 		new /obj/item/twohanded/spear/secspear(src)
 
@@ -322,7 +322,7 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/lasergun/populate_contents()
-	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 2) : 4
 	for(var/i in 1 to gun_count)
 		new /obj/item/gun/energy/laser(src)
 
@@ -342,7 +342,7 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/energygun/populate_contents()
-	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 2) : 4
 	for(var/i in 1 to gun_count)
 		new /obj/item/gun/energy/gun(src)
 
@@ -362,7 +362,7 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/lr30/populate_contents()
-	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 2) : 4
 	for(var/i in 1 to gun_count)
 		new /obj/item/gun/projectile/automatic/lr30(src)
 
@@ -382,7 +382,7 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/lasercarbine/populate_contents()
-	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 2) : 4
 	for(var/i in 1 to gun_count)
 		new /obj/item/gun/projectile/automatic/ik60(src)
 	new /obj/item/disk/design_disk/security/laser_carbine_mag(src)
@@ -402,7 +402,7 @@
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/plasma_pistols/populate_contents()
-	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 2) : 4
 	for(var/i in 1 to gun_count)
 		new /obj/item/gun/energy/plasma_pistol(src)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -286,6 +286,26 @@
 	new /obj/item/disk/design_disk/security/ak814_mag(src)
 	new /obj/item/disk/design_disk/security/aksu_ammo(src)
 
+/obj/structure/closet/secure_closet/guncabinet/secspear
+	name = "security telescopic energy spear cabinet"
+	desc = "Защищённый шкаф для хранения энергетических копий. Шкаф прикручен к полу."
+	req_access = list(ACCESS_ARMORY)
+
+/obj/structure/closet/secure_closet/guncabinet/secspear/get_ru_names()
+	return list(
+		NOMINATIVE = "шкаф энергетических копий",
+		GENITIVE = "шкафа энергетических копий",
+		DATIVE = "шкафу энергетических копий",
+		ACCUSATIVE = "шкаф энергетических копий",
+		INSTRUMENTAL = "шкафом энергетических копий",
+		PREPOSITIONAL = "шкафе энергетических копий",
+	)
+
+/obj/structure/closet/secure_closet/guncabinet/secspear/populate_contents()
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	for(var/i in 1 to gun_count)
+		new /obj/item/twohanded/spear/secspear(src)
+
 /obj/structure/closet/secure_closet/guncabinet/lasergun
 	name = "security laser gun cabinet"
 	desc = "Защищённый шкаф для хранения лазерных винтовок. Шкаф прикручен к полу."
@@ -305,6 +325,26 @@
 	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
 	for(var/i in 1 to gun_count)
 		new /obj/item/gun/energy/laser(src)
+
+/obj/structure/closet/secure_closet/guncabinet/energygun
+	name = "security energy gun cabinet"
+	desc = "Защищённый шкаф для хранения энергетических карабинов. Шкаф прикручен к полу."
+	req_access = list(ACCESS_ARMORY)
+
+/obj/structure/closet/secure_closet/guncabinet/energygun/get_ru_names()
+	return list(
+		NOMINATIVE = "шкаф энергетических карабинов",
+		GENITIVE = "шкафа энергетических карабинов",
+		DATIVE = "шкафу энергетических карабинов",
+		ACCUSATIVE = "шкаф энергетических карабинов",
+		INSTRUMENTAL = "шкафом энергетических карабинов",
+		PREPOSITIONAL = "шкафе энергетических карабинов",
+	)
+
+/obj/structure/closet/secure_closet/guncabinet/energygun/populate_contents()
+	var/gun_count = HAS_TRAIT(SSstation, STATION_TRAIT_LOOTED_ARMORY) ? rand(1, 3) : 5
+	for(var/i in 1 to gun_count)
+		new /obj/item/gun/energy/gun(src)
 
 /obj/structure/closet/secure_closet/guncabinet/lr30
 	name = "security LR-30 gun cabinet"

--- a/code/modules/vending/ammo.dm
+++ b/code/modules/vending/ammo.dm
@@ -33,12 +33,12 @@
 			"name" = "Магазины",
 			"icon" = "gun",
 			"products" = list(
-				/obj/item/ammo_box/magazine/wt550m9  = 5,
-				/obj/item/ammo_box/magazine/sp91rc = 5,
-				/obj/item/ammo_box/magazine/sparkle_a12 = 5,
-				/obj/item/ammo_box/magazine/enforcer/lethal = 5,
-				/obj/item/ammo_box/magazine/lr30mag = 5,
-				/obj/item/weapon_cell/specter = 5,
+				/obj/item/ammo_box/magazine/wt550m9  = 4,
+				/obj/item/ammo_box/magazine/sp91rc = 4,
+				/obj/item/ammo_box/magazine/sparkle_a12 = 4,
+				/obj/item/ammo_box/magazine/enforcer/lethal = 4,
+				/obj/item/ammo_box/magazine/lr30mag = 4,
+				/obj/item/weapon_cell/specter = 4,
 			),
 		),
 		list(

--- a/code/modules/vending/ammo.dm
+++ b/code/modules/vending/ammo.dm
@@ -33,12 +33,12 @@
 			"name" = "Магазины",
 			"icon" = "gun",
 			"products" = list(
-				/obj/item/ammo_box/magazine/wt550m9  = 10,
-				/obj/item/ammo_box/magazine/sp91rc = 10,
-				/obj/item/ammo_box/magazine/sparkle_a12 = 10,
-				/obj/item/ammo_box/magazine/enforcer/lethal = 10,
-				/obj/item/ammo_box/magazine/lr30mag = 10,
-				/obj/item/weapon_cell/specter = 10,
+				/obj/item/ammo_box/magazine/wt550m9  = 5,
+				/obj/item/ammo_box/magazine/sp91rc = 5,
+				/obj/item/ammo_box/magazine/sparkle_a12 = 5,
+				/obj/item/ammo_box/magazine/enforcer/lethal = 5,
+				/obj/item/ammo_box/magazine/lr30mag = 5,
+				/obj/item/weapon_cell/specter = 5,
 			),
 		),
 		list(


### PR DESCRIPTION
## Что этот ПР делает
Оружие каждого типа вернулось к 4 вместо 5 в базе.
Кол-во магазинов в вендоре "Liberty" уменьшено с 10 до 4.
Переносит еганы в ящик лазерок, который рандомит тип оружия раундстартом.
Копья перенесены в ящик для использования трейта "Разграбленная оружейная".
Перестановка оружейной дельты (на остальных картах минимальные изменения).
В ящике "Патроны 5,45x39 мм" (заказывался в карго) патроны заменены на ослабленную версию из оружейки.
Трейт станции "Разграбленная оружейная" теперь может выпасть с трейтом "Модернизация арсенала", а также не даёт скидок на покупку оружия в карго.

## Почему это хорошо для игры
[Обсуждением](https://discord.com/channels/617003227182792704/1510705117148741882/1510705117148741882) пришли к выводу, что оружейка сильная и ей нужны изменения.

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
<img width="1335" height="825" alt="image" src="https://github.com/user-attachments/assets/ed15d47d-0edb-4f62-a9d1-12deb6e6b390" />

</p>
</details>

## Список изменений
:cl:
balance: Изменение оружейки сб.
map: Изменение оружейки дельты (на остальных картах минимальные изменения).
/:cl:
