### PR TITLE
Изменения размера поясов перенесен на компонент для стореджей

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -357,3 +357,9 @@
 
 /// Called when card decal applied to ID card.
 #define COMSIG_CARD_DECAL_APPLIED "card_decal_applied"
+
+/// Called when item inserted into storage. [/obj/item/storage/proc/handle_item_insertion()]: (obj/item/W, prevent_warning = FALSE)
+#define COMSIG_ITEM_INSERTED_INTO_STORAGE "inserted_into_storage"
+
+/// Called when item removed from storage. [/obj/item/storage/proc/remove_from_storage()]: (obj/item/W, atom/new_location)
+#define COMSIG_ITEM_REMOVED_FROM_STORAGE "removed_from_storage"

--- a/code/datums/components/storage_size_differentiate.dm
+++ b/code/datums/components/storage_size_differentiate.dm
@@ -1,4 +1,3 @@
-//
 /datum/component/differentiate_storage_size
 	dupe_mode = COMPONENT_DUPE_UNIQUE
 	var/obj/item/storage/storage
@@ -11,8 +10,6 @@
 		return COMPONENT_INCOMPATIBLE
 
 	storage = parent
-	if(!storage.dynamic_storage_size)
-		return
 
 	initial_size = initial(storage.w_class)
 	expanded_size = expanded_size_init
@@ -20,6 +17,10 @@
 
 	RegisterSignals(storage, list(COMSIG_ITEM_REMOVED_FROM_STORAGE, COMSIG_ITEM_INSERTED_INTO_STORAGE), PROC_REF(update_weight))
 	update_weight()
+
+/datum/component/differentiate_storage_size/Destroy()
+	storage = null
+	return ..()
 
 /datum/component/differentiate_storage_size/proc/update_weight()
 	SIGNAL_HANDLER

--- a/code/datums/components/storage_size_differentiate.dm
+++ b/code/datums/components/storage_size_differentiate.dm
@@ -1,0 +1,32 @@
+//
+/datum/component/differentiate_storage_size
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	var/obj/item/storage/storage
+	var/initial_size
+	var/expanded_size
+	var/folded_size
+
+/datum/component/differentiate_storage_size/Initialize(expanded_size_init, folded_size_init)
+	if(!isstorage(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	storage = parent
+	if(!storage.dynamic_storage_size)
+		return
+
+	initial_size = initial(storage.w_class)
+	expanded_size = expanded_size_init
+	folded_size = folded_size_init ? folded_size_init : initial_size
+
+	RegisterSignals(storage, list(COMSIG_ITEM_REMOVED_FROM_STORAGE, COMSIG_ITEM_INSERTED_INTO_STORAGE), PROC_REF(update_weight))
+	update_weight()
+
+/datum/component/differentiate_storage_size/proc/update_weight()
+	SIGNAL_HANDLER
+
+	if(initial_size == expanded_size)
+		return
+	if(!length(storage.contents))
+		storage.w_class = folded_size
+		return
+	storage.w_class = expanded_size

--- a/code/datums/components/storage_size_differentiate.dm
+++ b/code/datums/components/storage_size_differentiate.dm
@@ -1,8 +1,15 @@
+/// Component that dynamically toggles a storage item's weight class (w_class) based on whether it is completely empty or contains any items.
+/// Note: This component operates in a strict binary mode, not progressively. It instantly resizes the storage to its maximum expanded size
+/// as soon as a single item is placed inside, rather than scaling up incrementally based on the volume or number of stored items.
 /datum/component/differentiate_storage_size
 	dupe_mode = COMPONENT_DUPE_UNIQUE
+	/// Reference to the parent object cast as a storage item.
 	var/obj/item/storage/storage
+	/// The original weight class of the storage item before the component was attached.
 	var/initial_size
+	/// The weight class of the storage item when it contains at least one item.
 	var/expanded_size
+	/// The weight class of the storage item when it is empty. Falls back to initial_size if not specified.
 	var/folded_size
 
 /datum/component/differentiate_storage_size/Initialize(expanded_size_init, folded_size_init)
@@ -19,9 +26,11 @@
 	update_weight()
 
 /datum/component/differentiate_storage_size/Destroy()
+	UnregisterSignal(storage, list(COMSIG_ITEM_REMOVED_FROM_STORAGE, COMSIG_ITEM_INSERTED_INTO_STORAGE))
 	storage = null
 	return ..()
 
+/// Checks the storage contents and updates its weight class to either folded_size or expanded_size.
 /datum/component/differentiate_storage_size/proc/update_weight()
 	SIGNAL_HANDLER
 

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -52,7 +52,8 @@
 
 /obj/item/storage/bag/trash/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/differentiate_storage_size, WEIGHT_CLASS_BULKY)
+	if(dynamic_storage_size)
+		AddComponent(/datum/component/differentiate_storage_size, WEIGHT_CLASS_BULKY)
 
 /obj/item/storage/bag/trash/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] puts the [name] over [user.p_their()] head and starts chomping at the insides! Disgusting!"))

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -42,7 +42,6 @@
 	icon_state = "trashbag"
 	item_state = "trashbag"
 
-	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = NONE
 	storage_slots = 30
 	max_combined_w_class = 30

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -42,12 +42,17 @@
 	icon_state = "trashbag"
 	item_state = "trashbag"
 
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = NONE
 	storage_slots = 30
 	max_combined_w_class = 30
 	can_hold = list() // any
 	cant_hold = list(/obj/item/disk/nuclear)
+	dynamic_storage_size = TRUE
+
+/obj/item/storage/bag/trash/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/differentiate_storage_size, WEIGHT_CLASS_BULKY)
 
 /obj/item/storage/bag/trash/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] puts the [name] over [user.p_their()] head and starts chomping at the insides! Disgusting!"))

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -15,50 +15,14 @@
 	drop_sound = 'sound/items/handling/drop/toolbelt_drop.ogg'
 	custom_price = PAYCHECK_COMMAND // belts are useful => they're expensive
 	abstract_type = /obj/item/storage/belt
+	dynamic_storage_size = TRUE
 
 	/// Do we have overlays for items held inside the belt?
 	var/use_item_overlays = FALSE
-	/// Won't change it's size even with items inside if TRUE
-	var/storable = FALSE
-	/// Size after putting smth in
-	var/expanded_size = WEIGHT_CLASS_BULKY
-	/// Size when there's no contents
-	var/folded_size = WEIGHT_CLASS_NORMAL
-
-/obj/item/storage/belt/examine(mob/user)
-	. = ..()
-	if(storable || initial(w_class) == expanded_size)
-		. += span_notice("Размер останется <b>неизменным</b> вне зависимости от содержимого.")
-	else if(length(contents))
-		. += span_notice("<b>Уменьшится</b> в размере после извлечения содержимого.")
-	else
-		. += span_notice("<b>Увеличится</b> в размере при наличии содержимого.")
-
-/obj/item/storage/belt/proc/update_weight()
-	if(initial(w_class) == expanded_size) // so initially BULKY belts won't become NORMAL when they get empty
-		return
-	if(!length(contents) || storable)
-		w_class = folded_size
-		return
-	w_class = expanded_size
-
-/obj/item/storage/belt/remove_from_storage(obj/item/I, atom/new_location)
-	. = ..()
-	update_weight()
-
-/obj/item/storage/belt/can_be_inserted(obj/item/I, stop_messages = FALSE)
-	if(isstorage(loc) && !istype(loc, /obj/item/storage/backpack/holding) && !storable)
-		balloon_alert(usr, "сначала вытащите пояс!")
-		return FALSE
-	. = ..()
 
 /obj/item/storage/belt/Initialize(mapload)
 	. = ..()
-	update_weight()
-
-/obj/item/storage/belt/handle_item_insertion(obj/item/I, prevent_warning)
-	. = ..()
-	update_weight()
+	AddComponent(/datum/component/differentiate_storage_size, WEIGHT_CLASS_BULKY)
 
 /obj/item/storage/belt/proc/check_menu(mob/living/user)
 	if(!istype(user))
@@ -201,7 +165,7 @@
 	item_state = "utility_ce"
 	storage_slots = 8
 	max_combined_w_class = 20 // set of tools + RCD/RPD
-	storable = TRUE
+	dynamic_storage_size = FALSE
 
 /obj/item/storage/belt/utility/chief/full/populate_contents()
 	new /obj/item/screwdriver/power(src)
@@ -335,7 +299,7 @@
 	icon = 'icons/obj/abductor.dmi'
 	item_state = "surgical_alien"
 	max_combined_w_class = 19
-	storable = TRUE
+	dynamic_storage_size = FALSE
 	can_hold = list(
 		/obj/item/scalpel,
 		/obj/item/hemostat,
@@ -635,7 +599,7 @@
 	icon_state = "militarybelt"
 	item_state = "military"
 	max_combined_w_class = 18
-	storable = TRUE
+	dynamic_storage_size = FALSE
 	resistance_flags = FIRE_PROOF
 
 /obj/item/storage/belt/military/sst

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -22,7 +22,8 @@
 
 /obj/item/storage/belt/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/differentiate_storage_size, WEIGHT_CLASS_BULKY)
+	if(dynamic_storage_size)
+		AddComponent(/datum/component/differentiate_storage_size, WEIGHT_CLASS_BULKY)
 
 /obj/item/storage/belt/proc/check_menu(mob/living/user)
 	if(!istype(user))

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -701,7 +701,8 @@
 			return FALSE
 
 	if(dynamic_storage_size && isstorage(loc) && !istype(loc, /obj/item/storage/backpack/holding))
-		balloon_alert(usr, "не хватит места!")
+		if(!stop_messages)
+			balloon_alert(usr, "не хватит места!")
 		return FALSE
 
 	return TRUE

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -58,6 +58,8 @@
 	var/foldable_amt = 0
 	/// Lazy list of mobs which are currently viewing the storage inventory.
 	var/list/mobs_viewing
+	/// Increase "w_class" of storage when something inside it
+	var/dynamic_storage_size = FALSE
 
 /obj/item/storage/Initialize(mapload)
 	. = ..()
@@ -698,6 +700,10 @@
 		if(!usr.can_unEquip(W))
 			return FALSE
 
+	if(dynamic_storage_size && isstorage(loc) && !istype(loc, /obj/item/storage/backpack/holding))
+		balloon_alert(usr, "не хватит места!")
+		return FALSE
+
 	return TRUE
 
 /// This proc handles items being inserted. It does not perform any checks of whether an item can or can't be inserted. That's done by can_be_inserted()
@@ -757,6 +763,7 @@
 	W.pixel_x = initial(W.pixel_x)
 	W.mouse_opacity = MOUSE_OPACITY_OPAQUE //So you can click on the area around the item to equip it, instead of having to pixel hunt
 	update_icon()
+	SEND_SIGNAL(src, COMSIG_ITEM_INSERTED_INTO_STORAGE)
 	return TRUE
 
 /// Call this proc to handle the removal of an item from the storage item. The item will be moved to the atom sent as new_target
@@ -798,6 +805,7 @@
 		W.maptext = ""
 	W.on_exit_storage(src)
 	update_icon()
+	SEND_SIGNAL(src, COMSIG_ITEM_REMOVED_FROM_STORAGE)
 	return TRUE
 
 /obj/item/storage/Exited(atom/movable/gone, direction)
@@ -1018,6 +1026,11 @@
 		orient2hud(user)
 		show_to(user)
 	return TRUE
+
+/obj/item/storage/examine(mob/user)
+	. = ..()
+	if(dynamic_storage_size)
+		. += span_notice("Размер <b>изменяется</b> в зависимости от наличия содержимого.")
 
 #undef STORAGE_CAP_WIDTH
 #undef STORED_CAP_WIDTH

--- a/paradise.dme
+++ b/paradise.dme
@@ -808,6 +808,7 @@
 #include "code\datums\components\squashable.dm"
 #include "code\datums\components\squeak.dm"
 #include "code\datums\components\stationloving.dm"
+#include "code\datums\components\storage_size_diff.dm"
 #include "code\datums\components\surgery_initiator.dm"
 #include "code\datums\components\swarming.dm"
 #include "code\datums\components\transforming.dm"

--- a/paradise.dme
+++ b/paradise.dme
@@ -808,7 +808,7 @@
 #include "code\datums\components\squashable.dm"
 #include "code\datums\components\squeak.dm"
 #include "code\datums\components\stationloving.dm"
-#include "code\datums\components\storage_size_diff.dm"
+#include "code\datums\components\storage_size_differentiate.dm"
 #include "code\datums\components\surgery_initiator.dm"
 #include "code\datums\components\swarming.dm"
 #include "code\datums\components\transforming.dm"


### PR DESCRIPTION
<!-- Пишите **ПОД** Заголовками и **НАД** комментариями, иначе Вашего текста будет не видно. -->
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название Вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

## Что этот ПР делает
Переносит изменения веса поясов с ПРа https://github.com/ss220-space/Paradise/issues/7740 на компонент для всех стореджей. Уменьшает размер мешка для мусора и добавляет ему этот компонент
<!-- Опишите, что делает Ваш PR, укажите основные изменения. Учтите, что плохое описание может надолго отложить проверку Вашего PR. -->
<!-- В случае исправления бага, укажите ссылку на репорт в #баг-репорты-v2. В ином случае, опишите баг и его воспроизведение. -->

## Почему это хорошо для игры
Интересная механика, но была ограничена только поясами. Теперь можно в одну строчку добавить ее для любого хранилища
<!-- Опишите, почему, по Вашему, следует добавить эти изменения в кодбазу или почему это хорошо для игры. -->

## Демонстрация изменений

<!-- Разместите изображения внутри блока ниже, если Вы меняли спрайты, карту или ваши изменения требуют визуальной демонстрации изменений. -->

<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений

<!-- Если Ваш PR изменяет аспекты игры, которые могут быть конкретно замечены игроками, Вы должны добавить это в список изменений. Если Ваши изменения НЕ соответствует этому списку изменений, удалите этот раздел. -->

:cl:
tweak: Уменьшен размер !пустого! мешка для мусора.
refactor: Перевод изменения размера поясов на компонент для хранилищ.
/:cl:

<!-- Оба тега :cl: обязательны для работы списка изменений! Вы можете указать своё имя справа от первого :cl:, если хотите переопределить username пользователя GitHub, как автора в игре. -->
<!-- Вы можете использовать несколько одинаковых префиксов (они используются только для иконки в игре) и удалять ненужные. Несмотря на некоторые теги, списки изменений должны в целом отражать то, как изменения могут повлиять на игрока, а не быть кратким содержанием PR. -->
