### PR TITLE
Значительно уменьшено время между автоогнем у КА с репитером

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -482,7 +482,7 @@
 	. = ..()
 	if(.)
 		KA.add_firemode(GUN_FIREMODE_AUTOMATIC, user)
-		KA.set_fire_delay(0.4 SECONDS)
+		KA.set_fire_delay(0.1 SECONDS)
 		KA.balloon_alert(user, "установлено")
 
 /obj/item/borg/upgrade/modkit/cooldown/repeater/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -482,7 +482,7 @@
 	. = ..()
 	if(.)
 		KA.add_firemode(GUN_FIREMODE_AUTOMATIC, user)
-		KA.set_fire_delay(0.1 SECONDS)
+		KA.set_fire_delay(0.2 SECONDS)
 		KA.balloon_alert(user, "установлено")
 
 /obj/item/borg/upgrade/modkit/cooldown/repeater/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)


### PR DESCRIPTION

## Что этот ПР делает
Уменьшил время у КА с репитер модкитом до 0.2 секунд. Теперь скорость автоогня будет такая же, как и при ручном проклике
## Почему это хорошо для игры
Еще удобнее. В оригинальном ПРе на всякий поставил поставил время чуть побольше, но с новой стрельбой (по идеи) даже в теории лагать не будет
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:

tweak: Значительно уменьшено время между автоогнем у КА с репитером.

/:cl:
