### PR TITLE
Фикс крайта растяжек, использование дефайна времени детонации на растяжке где надо

### DIFF
--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -120,12 +120,16 @@
 /obj/item/grenade/blob_vore_act(obj/structure/blob/special/core/voring_core)
 	obj_destruction(MELEE)
 
+#define TRIPWIRE_GRENADE_DETONATION_TIME 0.4 SECONDS
+
 /obj/item/grenade/on_tripwire_trigger(obj/item/tripwire/base, mob/user)
 	var/turf/turf = get_turf(base)
 	forceMove(turf)
 	active = TRUE
 	update_appearance(UPDATE_ICON_STATE)
 	playsound(turf, 'sound/weapons/armbomb.ogg', 60, TRUE)
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/grenade, prime)), 1 SECONDS)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/grenade, prime)), TRIPWIRE_GRENADE_DETONATION_TIME)
 	base.attached_item = null
 	base.UnregisterSignal(base, COMSIG_TRIPWIRE_TRIGGERED)
+
+#undef TRIPWIRE_GRENADE_DETONATION_TIME

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -128,7 +128,7 @@
 	active = TRUE
 	update_appearance(UPDATE_ICON_STATE)
 	playsound(turf, 'sound/weapons/armbomb.ogg', 60, TRUE)
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/grenade, prime)), TRIPWIRE_GRENADE_DETONATION_TIME)
+	addtimer(CALLBACK(src, PROC_REF(prime)), TRIPWIRE_GRENADE_DETONATION_TIME)
 	base.attached_item = null
 	base.UnregisterSignal(base, COMSIG_TRIPWIRE_TRIGGERED)
 

--- a/code/modules/assembly/tripwire.dm
+++ b/code/modules/assembly/tripwire.dm
@@ -449,8 +449,6 @@
 ////////////////////////////////////////
 // MARK:	Trigger & payloads
 ////////////////////////////////////////
-#define TRIPWIRE_GRENADE_DETONATION_TIME 1 SECONDS
-
 /obj/item/tripwire/proc/on_payload_activate(datum/source, mob/user)
 	SIGNAL_HANDLER
 	if(!attached_item)
@@ -491,5 +489,3 @@
 		return linked_to
 
 	return
-
-#undef TRIPWIRE_GRENADE_DETONATION_TIME

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -470,7 +470,9 @@
 /datum/crafting_recipe/tripwire
 	name = "Самодельная растяжка"
 	result = /obj/item/tripwire/two_for_craft
-	reqs = list(/obj/item/stack/rods)
+	reqs = list(
+		/obj/item/stack/rods = 1,
+	)
 	tools = list(TOOL_WELDER, TOOL_WIRECUTTER)
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON


### PR DESCRIPTION

## Что этот ПР делает
Черрипикает фиксы с ПРа https://github.com/ss220-space/Paradise/pull/8849. Уменьшает время до взрыва гранаты до 0.4с ибо иначе с растяжками работают только с осколочными или мощными гранатами. Так будет хоть как то вредить от детонации более слабых гранат
## Почему это хорошо для игры
Бубс попросил (а вообще багфиксы круто)
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
bugfix: Исправлен рецепт растяжки.
refactor: Перенос дефайна TRIPWIRE_GRENADE_DETONATION_TIME к гранатам и его использование.
balance: Уменьшено время детонации гранат на растяжках (1с -> 0.4с).
/:cl:
