### PR TITLE
Фикс бага с названием патронов

### DIFF
--- a/code/__HELPERS/string_assoc_lists.dm
+++ b/code/__HELPERS/string_assoc_lists.dm
@@ -12,6 +12,9 @@ GLOBAL_LIST_EMPTY(string_assoc_lists)
 		cache_key_components += "[key]_[input_list[key]]"
 	var/cache_key = cache_key_components.Join("-")
 
+	if(!length(GLOB.string_assoc_lists)) // because we might be accessing this super early in some cases, it might not be set up yet!
+		GLOB.string_assoc_lists = list() // so do that now.
+
 	. = GLOB.string_assoc_lists[cache_key]
 
 	if(.)

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -62,6 +62,14 @@
 	. = ..()
 	if(projectile_type)
 		BB = new projectile_type(src)
+		BB.ru_names = string_assoc_list(alist(
+			NOMINATIVE = "пуля [get_ammo_marking()]",
+			GENITIVE = "пули [get_ammo_marking()]",
+			DATIVE = "пуле [get_ammo_marking()]",
+			ACCUSATIVE = "пулю [get_ammo_marking()]",
+			INSTRUMENTAL = "пулей [get_ammo_marking()]",
+			PREPOSITIONAL = "пуле [get_ammo_marking()]",
+		))
 	pixel_x = rand(-10, 10)
 	pixel_y = rand(-10, 10)
 	dir = pick(GLOB.alldirs)
@@ -146,7 +154,7 @@
 	if(BB)
 		gender = MALE
 		name = "[get_ammo_marking()] cartridge"
-		ru_names = string_list(alist(
+		ru_names = string_assoc_list(alist(
 			NOMINATIVE = "патрон [get_ammo_marking()]",
 			GENITIVE = "патрона [get_ammo_marking()]",
 			DATIVE = "патрону [get_ammo_marking()]",
@@ -157,7 +165,7 @@
 	else
 		gender = FEMALE
 		name = "[caliber] bullet casing"
-		ru_names = string_list(alist(
+		ru_names = string_assoc_list(alist(
 			NOMINATIVE = "гильза [caliber]",
 			GENITIVE = "гильзы [caliber]",
 			DATIVE = "гильзе [caliber]",


### PR DESCRIPTION

## Что этот ПР делает
1. Фикс названий патронов.
2. В string_assoc_list добавлена проверка существования кэша.
3. Пули получают название от патронов (будет нормальное отображение в сканере аутопсии).

## Почему это хорошо для игры
Багфиксы, QoL.

## Список изменений
:cl:
bugfix: Исправлен баг с названиями патронов.
/:cl:
