### PR TITLE
Фикс опечаток

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -6367,7 +6367,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	)
 
 /datum/supply_packs/contraband/ammobox_nagant
-	name = "Патргоны 7,62x38 мм"
+	name = "Патроны 7,62x38 мм"
 	contains = list(
 		/obj/item/ammo_box/n762x38,
 		/obj/item/ammo_box/n762x38,

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -435,7 +435,7 @@ effective or pretty fucking useless.
 	duration = 5
 
 /obj/item/teleporter/admin
-	desc = "A strange syndicate version of a cult veil shifter. \n This one seems EMP proof, and with much better safety protocols."
+	desc = "A strange syndicate version of a cult veil shifter. \nThis one seems EMP proof, and with much better safety protocols."
 	charges = 8
 	max_charges = 8
 	flawless = TRUE


### PR DESCRIPTION

## Что этот ПР делает
Правит кривые буквы
## Список изменений
:cl:
spellcheck: "Патргоны 7,62x38 мм" >>> "Патроны 7,62x38 мм".
spellcheck:  Убрал лишний пробел у админ телепортера.
/:cl:
