### PR TITLE
Пипетка на ПКМ для флур пеинтера

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -244,6 +244,8 @@ GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(
 
 #define isfloorturf(A) (istype(A, /turf/simulated/floor))
 
+#define isplasteelfloor(A) (istype(A, /turf/simulated/floor/plasteel))
+
 #define iswallturf(A) (istype(A, /turf/simulated/wall))
 
 #define isreinforcedwallturf(A) (istype(A, /turf/simulated/wall/r_wall))

--- a/code/game/objects/items/devices/floor_painter.dm
+++ b/code/game/objects/items/devices/floor_painter.dm
@@ -63,6 +63,18 @@
 	ui_interact(user)
 	return 1
 
+/obj/item/floor_painter/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!isplasteelfloor(interacting_with))
+		return ITEM_INTERACT_BLOCKING
+	var/turf/simulated/floor/plasteel/picked_floor = interacting_with
+	if(!(picked_floor.icon_state in allowed_states))
+		user.balloon_alert(user, "невозможно скопировать!")
+		return ITEM_INTERACT_BLOCKING
+	floor_state = picked_floor.icon_state
+	SStgui.update_uis(src)
+	user.balloon_alert(user, "пол скопирован")
+	return ITEM_INTERACT_SUCCESS
+
 /obj/item/floor_painter/ui_state(mob/user)
 	return GLOB.inventory_state
 

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -215,7 +215,7 @@
 	taste_description = "старого ковра"
 
 /datum/reagent/carpet/reaction_turf(turf/simulated/target_turf, volume)
-	if(istype(target_turf, /turf/simulated/floor/plating) || istype(target_turf, /turf/simulated/floor/plasteel))
+	if(istype(target_turf, /turf/simulated/floor/plating) || isplasteelfloor(target_turf))
 		var/turf/simulated/floor/target_floor = target_turf
 		target_floor.ChangeTurf(/turf/simulated/floor/carpet)
 	..()


### PR DESCRIPTION

## Что этот ПР делает
Добавляет возможность скопировать цвет пола с помощью floor painter при клике по полу ПКМ
## Почему это хорошо для игры
Удобство
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
tweak: Пипетка текстурки пола на ПКМ для floor painter'а.
/:cl:
