### PR TITLE
Добавил rpd и rcd для тритор тулбэлта

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -620,6 +620,8 @@
 		/obj/item/wirecutters,
 		/obj/item/wrench,
 		/obj/item/multitool,
+		/obj/item/rcd,
+		/obj/item/rpd,
 	)
 
 /obj/item/storage/belt/military/traitor/hacker/populate_contents()


### PR DESCRIPTION

## Что этот ПР делает
Добавил rpd и rcd в список вещей для тритор тулбэлта
## Почему это хорошо для игры
В обычный тулбэлт можно а в крутой с аплинка нет, не логично
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
bugfix: traitor tool-belt может хранить RPD и RCD
/:cl:
