### PR TITLE
Игнайтер добавлен в гриппер борга

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -36,6 +36,7 @@
 		/obj/item/stack/ore/bluespace_crystal,
 		/obj/item/stack/sheet/plasteel,
 		/obj/item/stack/tile/wood,
+		/obj/item/assembly/igniter,
 	)
 
 	//Item currently being held.

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -32,11 +32,11 @@
 		/obj/item/camera_assembly,
 		/obj/item/tank,
 		/obj/item/circuitboard,
+		/obj/item/assembly/igniter,
 		/obj/item/stack/tile/light,
 		/obj/item/stack/ore/bluespace_crystal,
 		/obj/item/stack/sheet/plasteel,
 		/obj/item/stack/tile/wood,
-		/obj/item/assembly/igniter,
 	)
 
 	//Item currently being held.
@@ -186,6 +186,7 @@
 		/obj/item/camera_assembly,
 		/obj/item/tank,
 		/obj/item/circuitboard,
+		/obj/item/assembly/igniter,
 		/obj/item/stack/tile/light,
 		/obj/item/stack/ore/bluespace_crystal,
 		/obj/item/organ,


### PR DESCRIPTION

## Что этот ПР делает
Добавляет игнайтер в список вещей, которые борг может брать в гриппер
## Почему это хорошо для игры
Теперь борги могут собирать печку
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
tweak: Добавлен игнайтер в список гриппера 
/:cl:
