### PR TITLE
Cyberiad camera move

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -33065,6 +33065,9 @@
 	id = "wloop_atm_meter";
 	name = "Waste Loop"
 	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics North-East"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "cNa" = (
@@ -57531,9 +57534,6 @@
 	name = "Дыхательную смесь в отходы"
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/camera{
-	c_tag = "Atmospherics North-East"
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
 "kmQ" = (


### PR DESCRIPTION

## Что этот ПР делает
Этот ПР двигает камеру на 1 тайл влево, чтобы ИИ мог открывать двери
## Почему это хорошо для игры
Потому что ИИ сможет открывать двери на Кибериаде
Багрепорт: https://discord.com/channels/617003227182792704/1524722756636381185
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
<img width="543" height="225" alt="image" src="https://github.com/user-attachments/assets/5f2c5266-9729-4185-be29-b6336b2ac8e0" />

</p>
</details>

## Список изменений
:cl:
map tweak: Северо-восточная камера в атмосферике Кибериады была сдвинута на 1 тайл на запад
/:cl:
