### PR TITLE
Фикс электрокьюта (и тесла кэнона ибо он его использует)

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -486,7 +486,7 @@
 		return .
 	if(!(flags & SHOCK_ILLUSION))
 		if(shock_damage * siemens_coeff >= 5)
-			forcesay()
+			INVOKE_ASYNC(src, PROC_REF(forcesay))
 		if(undergoing_cardiac_arrest() && (shock_damage * siemens_coeff >= 1) && prob(25))
 			if(set_heartattack(FALSE) && stat == CONSCIOUS)
 				to_chat(src, span_warning("Вы чувствуете, как ваше сердце вновь бьётся!"))


### PR DESCRIPTION

## Что этот ПР делает
Заменяет прямой вызов прока forcesay() на асинхронный. Встроенный прок winset работает немного странно, и из-за этого (и того что у кэнона хитскан) происходит множество Bump'ов цели об снаряд и перерасчет урона.
## Почему это хорошо для игры
Ваншоты это ОЧЕНЬ смешно но не круто
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
bugfix: Фикс множественного нанесения урона от electrocute_act (в т.ч. от tesla caтnon)ю
/:cl:
