### PR TITLE
Ассистенты заместо рандом джобки

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -367,7 +367,7 @@ SUBSYSTEM_DEF(jobs)
 			unassigned += player
 			var/datum/preferences/prefs = player.client.prefs
 			if(prefs.alternate_option == RETURN_TO_LOBBY && !prefs.skip_antag)
-				prefs.alternate_option = GET_RANDOM_JOB
+				prefs.alternate_option = BE_ASSISTANT
 
 	Debug("DO, Len: [length(unassigned)]")
 	if(length(unassigned) == 0)

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -367,7 +367,9 @@ SUBSYSTEM_DEF(jobs)
 			unassigned += player
 			var/datum/preferences/prefs = player.client.prefs
 			if(prefs.alternate_option == RETURN_TO_LOBBY && !prefs.skip_antag)
-				prefs.alternate_option = BE_ASSISTANT
+				prefs.final_alternate_option = BE_ASSISTANT
+			else
+				prefs.final_alternate_option = prefs.alternate_option
 
 	Debug("DO, Len: [length(unassigned)]")
 	if(length(unassigned) == 0)
@@ -414,7 +416,7 @@ SUBSYSTEM_DEF(jobs)
 
 	// Loop through all levels from high to low
 	var/list/shuffledoccupations = shuffle(occupations)
-	for(var/level = 1 to 3)
+	for(var/level in 1 to 3)
 		//Check the head jobs first each level
 		CheckHeadPositions(level)
 
@@ -471,7 +473,7 @@ SUBSYSTEM_DEF(jobs)
 	// Hand out random jobs to the people who didn't get any in the last check
 	// Also makes sure that they got their preference correct
 	for(var/mob/new_player/player in unassigned)
-		if(player.client.prefs.alternate_option == GET_RANDOM_JOB)
+		if(player.client.prefs.final_alternate_option == GET_RANDOM_JOB)
 			GiveRandomJob(player)
 
 	Debug("DO, Standard Check end")
@@ -481,7 +483,7 @@ SUBSYSTEM_DEF(jobs)
 	// Antags, who have to get in, come first
 	for(var/mob/new_player/player in unassigned)
 		if(player.mind.special_role)
-			if(player.client.prefs.alternate_option != BE_ASSISTANT)
+			if(player.client.prefs.final_alternate_option != BE_ASSISTANT)
 				GiveRandomJob(player)
 				if(player in unassigned)
 					AssignRole(player, JOB_TITLE_CIVILIAN)
@@ -490,10 +492,10 @@ SUBSYSTEM_DEF(jobs)
 
 	// Then we assign what we can to everyone else.
 	for(var/mob/new_player/player in unassigned)
-		if(player.client.prefs.alternate_option == BE_ASSISTANT)
+		if(player.client.prefs.final_alternate_option == BE_ASSISTANT)
 			Debug("AC2 Assistant located, Player: [player]")
 			AssignRole(player, JOB_TITLE_CIVILIAN)
-		else if(player.client.prefs.alternate_option == RETURN_TO_LOBBY)
+		else if(player.client.prefs.final_alternate_option == RETURN_TO_LOBBY)
 			to_chat(player, span_danger("Unfortunately, none of the round start roles you selected had a free slot. Please join the game by using \"Join Game!\" button and selecting a role with a free slot."))
 			player.ready = 0
 			unassigned -= player

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -206,6 +206,7 @@ GLOBAL_LIST_INIT(special_role_times, list(//minimum age (in days) for accounts t
 
 	//Keeps track of preferrence for not getting any wanted jobs
 	var/alternate_option = 2
+	var/final_alternate_option
 
 	// maps each organ to either null(intact), "cyborg" or "amputated"
 	// will probably not be able to do this for head and torso ;)


### PR DESCRIPTION
## Список изменений
:cl:
tweak: Теперь заместо  рандомной профы при jотсутствии skip_antag и наличии префа на выход в лобби выбирается  профа цивила(ассистента).
/:cl:
