### PR TITLE
Фикс пропадающего icon_state у стола с шелтера

### DIFF
--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -253,6 +253,8 @@
 //Table
 /obj/structure/table/survival_pod
 	icon = 'icons/obj/lavaland/survival_pod.dmi'
+	smoothing_groups = null
+	canSmoothWith = null
 	smooth = NONE
 	can_be_flipped = FALSE
 


### PR DESCRIPTION

## Что этот ПР делает
Сглаживание убивало айкон_стейт стола. Сглаживание убито в ответ
Фикс этого бага: https://discord.com/channels/617003227182792704/1526231050559160543
## Почему это хорошо для игры
Багфиксы круто
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
<img width="123" height="120" alt="изображение" src="https://github.com/user-attachments/assets/c6332995-850c-4d24-9160-e6042c87d65d" />

</p>
</details>

## Список изменений
:cl:

bugfix: Возвращена текстурка стола с убежища шахтеров.

/:cl:
