### PR TITLE
Исправление накладывающихся картин в картинной галерее

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -23703,6 +23703,16 @@
 	icon_state = "dark"
 	},
 /area/station/ai/satellite/exterior)
+"feG" = (
+/obj/structure/sign/painting/large/library{
+	dir = 8;
+	pixel_x = -28;
+	pixel_y = -25
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/service/library)
 "feI" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -119960,7 +119970,7 @@
 /obj/structure/sign/painting/large/library{
 	dir = 8;
 	pixel_x = -28;
-	pixel_y = -16
+	pixel_y = -8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -155812,9 +155822,9 @@ rWR
 pwX
 oMI
 lxJ
+feG
 lxJ
 wOF
-lxJ
 vTY
 lQS
 fHJ

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -119959,7 +119959,8 @@
 "wOF" = (
 /obj/structure/sign/painting/large/library{
 	dir = 8;
-	pixel_x = -28
+	pixel_x = -28;
+	pixel_y = -16
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -155813,7 +155814,7 @@ oMI
 lxJ
 lxJ
 wOF
-wOF
+lxJ
 vTY
 lQS
 fHJ


### PR DESCRIPTION

## Что этот ПР делает
Убирает одну из двух больших картин на западе картинной галереи из-за того, что те накладываются друг на друга. Блин
## Демонстрация изменений
в мап-ченджлоге гляньте
## Список изменений
:cl:
bugfix: Картины в галерее больше друг на друга не накладываются

/:cl:
