### PR TITLE
Укоротил Тайпан в гост меню

### DIFF
--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -1177,7 +1177,7 @@
 /obj/effect/mob_spawn/human/space_base_syndicate/botanist{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet/green,
 /area/syndicate/unpowered/syndicate_space_base/cryo)
 "bbZ" = (
 /obj/structure/lattice,
@@ -9636,7 +9636,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/effect/mob_spawn/human/space_base_syndicate/rd{
+/obj/effect/mob_spawn/human/space_base_syndicate/command/rd{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/black,
@@ -15650,7 +15650,7 @@
 /obj/effect/mob_spawn/human/space_base_syndicate/chef{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet/green,
 /area/syndicate/unpowered/syndicate_space_base/cryo)
 "oOV" = (
 /obj/effect/turf_decal/tile/red{
@@ -15679,7 +15679,7 @@
 /obj/effect/mob_spawn/human/space_base_syndicate/cargotech{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet,
 /area/syndicate/unpowered/syndicate_space_base/cryo)
 "oQj" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -16598,7 +16598,7 @@
 /obj/effect/mob_spawn/human/space_base_syndicate{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet/purple,
 /area/syndicate/unpowered/syndicate_space_base/cryo)
 "pBo" = (
 /turf/simulated/floor/plasteel{
@@ -18499,7 +18499,7 @@
 /obj/effect/mob_spawn/human/space_base_syndicate{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet/purple,
 /area/syndicate/unpowered/syndicate_space_base/cryo)
 "qWC" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -20261,7 +20261,7 @@
 /obj/effect/mob_spawn/human/space_base_syndicate/engineer{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet/orange,
 /area/syndicate/unpowered/syndicate_space_base/cryo)
 "sMs" = (
 /obj/effect/turf_decal/tile/red,
@@ -20288,10 +20288,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/mob_spawn/human/space_base_syndicate/cargotech{
+/obj/effect/mob_spawn/human/space_base_syndicate/medic{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet/cyan,
 /area/syndicate/unpowered/syndicate_space_base/cryo)
 "sNv" = (
 /obj/structure/grille,
@@ -20513,7 +20513,7 @@
 /area/syndicate/unpowered/syndicate_space_base/telecomms/agent_room)
 "tbq" = (
 /obj/machinery/alarm/syndicate/directional/east,
-/obj/effect/mob_spawn/human/space_base_syndicate/comms{
+/obj/effect/mob_spawn/human/space_base_syndicate/command/comms{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/black,
@@ -24886,10 +24886,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/mob_spawn/human/space_base_syndicate/medic{
+/obj/effect/mob_spawn/human/space_base_syndicate/cargotech{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet,
 /area/syndicate/unpowered/syndicate_space_base/cryo)
 "wrs" = (
 /obj/structure/chair/sofa{

--- a/_maps/map_files/generic/syndicatebase.dmm
+++ b/_maps/map_files/generic/syndicatebase.dmm
@@ -15647,10 +15647,10 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/syndicate/directional/north,
-/obj/effect/mob_spawn/human/space_base_syndicate/chef{
+/obj/effect/mob_spawn/human/space_base_syndicate/medic{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green,
+/turf/simulated/floor/carpet/cyan,
 /area/syndicate/unpowered/syndicate_space_base/cryo)
 "oOV" = (
 /obj/effect/turf_decal/tile/red{
@@ -20288,10 +20288,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/mob_spawn/human/space_base_syndicate/medic{
+/obj/effect/mob_spawn/human/space_base_syndicate/chef{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/cyan,
+/turf/simulated/floor/carpet/green,
 /area/syndicate/unpowered/syndicate_space_base/cryo)
 "sNv" = (
 /obj/structure/grille,

--- a/code/controllers/subsystem/non-firing/radio.dm
+++ b/code/controllers/subsystem/non-firing/radio.dm
@@ -35,7 +35,7 @@ SUBSYSTEM_DEF(radio)
 	var/list/CENT_FREQS = list(ERT_FREQ, DTH_FREQ)
 	var/list/ANTAG_FREQS = list(SYND_FREQ, SYNDTEAM_FREQ, SYND_TAIPAN_FREQ, VOX_RAID_FREQ)
 	var/list/DEPT_FREQS = list(AI_FREQ, COMM_FREQ, ENG_FREQ, MED_FREQ, SEC_FREQ, PRS_FREQ, SCI_FREQ, SRV_FREQ, SUP_FREQ, PROC_FREQ, T1_FREQ, T2_FREQ, T3_FREQ)
-	var/list/syndicate_blacklist = list(SPY_SPIDER_FREQ, EVENT_ALPHA_FREQ, EVENT_BETA_FREQ, EVENT_GAMMA_FREQ)	//list of frequencies syndicate headset can't hear
+	var/list/syndicate_blacklist = list(SPY_SPIDER_FREQ, EVENT_ALPHA_FREQ, EVENT_BETA_FREQ, EVENT_GAMMA_FREQ, SYND_TAIPAN_FREQ)	//list of frequencies syndicate headset can't hear
 	var/list/datum/radio_frequency/frequencies = list()
 
 // This is a disgusting hack to stop this tripping CI when this thing needs to FUCKING DIE

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -639,8 +639,6 @@ GLOBAL_LIST_INIT(default_pirate_channels, list(
 	if(freq in SSradio.ANTAG_FREQS)
 		if(!(syndiekey))//Checks to see if it's allowed on that frequency, based on the encryption keys
 			return -1
-		if(freq == SYND_TAIPAN_FREQ && !istype(syndiekey, /obj/item/encryptionkey/syndicate/taipan)) //Чтобы тайпановскую частоту, слышали только тайпановцы
-			return -1
 
 	if(!freq) //received on main frequency
 		if(!listening)
@@ -648,7 +646,7 @@ GLOBAL_LIST_INIT(default_pirate_channels, list(
 	else if(syndiekey && !(freq in SSradio.syndicate_blacklist))
 		return canhear_range
 	else
-		var/accept = (freq==frequency && listening)
+		var/accept = (freq == frequency && listening)
 		if(!accept)
 			for(var/ch_name in channels)
 				var/datum/radio_frequency/RF = LAZYACCESS(secure_radio_connections, ch_name)

--- a/code/modules/ruins/syndicate_space_base.dm
+++ b/code/modules/ruins/syndicate_space_base.dm
@@ -15,7 +15,7 @@
 
 // Space Base Spawners. Исспользуется переделанная копия спавнеров лавалендовских.
 /obj/effect/mob_spawn/human/space_base_syndicate
-	name = "Syndicate Scientist sleeper"
+	name = "Syndicate sleeper"
 	mob_name = "Syndicate Scientist"
 	roundstart = FALSE
 	death = FALSE
@@ -104,7 +104,6 @@
 	return ..()
 
 /obj/effect/mob_spawn/human/space_base_syndicate/medic
-	name = "Syndicate Medic sleeper"
 	mob_name = "Syndicate Medic"
 	id_job = "Syndicate Medic"
 	description = "Проводите медицинские опыты сомнительного содержания. Вылечивайте своих коллег, которые опять поссорились с генералом Синди, или оживляйте неудачливых космических путников, для допросов или киборгизации. Даже \"Синдикату\" нужны врачи!"
@@ -126,12 +125,12 @@
 	)
 
 /obj/effect/mob_spawn/human/space_base_syndicate/botanist
-	name = "Syndicate Botanist sleeper"
 	mob_name = "Syndicate Botanist"
 	id_job = "Syndicate Botanist"
 	description = "Выращивайте сомнительные растения. Помогите повару накормить экипаж, а учёным — создать опаснейшие растения! Наслаждайтесь силой природы в руках \"Синдиката\"!"
 	outfit = /datum/outfit/space_base_syndicate/botanist
 	assignedrole = JOB_TITLE_TAIPAN_BOTANIST
+
 /datum/outfit/space_base_syndicate/botanist
 	name = "Space Base Syndicate Botanist"
 	glasses = /obj/item/clothing/glasses/hud/hydroponic
@@ -142,13 +141,13 @@
 	implants = list(/obj/item/implant/weapons_auth)
 
 /obj/effect/mob_spawn/human/space_base_syndicate/cargotech
-	name = "Syndicate Cargo Technician sleeper"
 	mob_name = "Syndicate Cargo Technician"
 	id_job = "Syndicate Cargo Technician"
 	description = "Даже \"Синдикату\" нужны рабочие руки, приносите людям их посылки, заказывайте и продавайте, наслаждайтесь простой работой среди всех этих учёных. Здесь всё равно платят в разы лучше!"
 	flavour_text = "Вы — грузчик \"Синдиката\", работающий на сверхсекретной научно-наблюдательной станции Тайпан, занимающейся созданием биооружия и взаимодействием с чёрным рынком. К несчастью, ваш самый главный враг, компания \"Нанотрейзен\", имеет собственную массивную научную базу в вашем секторе. Работайте с грузами, заказывайте всё, что может потребоваться станции или вам и зарабатывайте реальные деньги, а не виртуальные очки!"
 	outfit = /datum/outfit/space_base_syndicate/cargotech
 	assignedrole = JOB_TITLE_TAIPAN_CARGO
+
 /datum/outfit/space_base_syndicate/cargotech
 	name = "Space Base Syndicate Cargo Technician"
 	head = /obj/item/clothing/head/soft
@@ -159,7 +158,6 @@
 	back = /obj/item/storage/backpack/syndicate/cargo
 
 /obj/effect/mob_spawn/human/space_base_syndicate/chef
-	name = "Syndicate Chef Sleeper"
 	mob_name = "Syndicate Chef"
 	id_job = "Syndicate Chef"
 	description = "Даже \"Синдикату\" нужны рабочие руки! У вас в распоряжении свой бар, кухня и ботаника. Накормите этих голодных учёных или помогите им создать последнее блюдо для ваших врагов. Здесь всё равно платят в разы лучше!"
@@ -182,7 +180,6 @@
 	back = /obj/item/storage/backpack/syndicate
 
 /obj/effect/mob_spawn/human/space_base_syndicate/engineer
-	name = "Syndicate Atmos Engineer Sleeper"
 	mob_name = "Syndicate Atmos Engineer"
 	id_job = "Syndicate Atmos Engineer"
 	description = "Там, где есть космическая станция, есть и двигатели с трубами, которым нужно своё техобслуживание. Обеспечьте станцию энергией, чините повреждения после неудачных опытов учёных и отдыхайте в баре, пока снова что-нибудь не взорвут. "
@@ -190,6 +187,7 @@
 	outfit = /datum/outfit/space_base_syndicate/engineer
 	assignedrole = JOB_TITLE_TAIPAN_ENGINEER
 	exp_type = EXP_TYPE_ENGINEERING
+
 /datum/outfit/space_base_syndicate/engineer
 	name = "Space Base Syndicate Engineer"
 	head = /obj/item/clothing/head/beret/eng
@@ -199,8 +197,10 @@
 	shoes = /obj/item/clothing/shoes/workboots
 	back = /obj/item/storage/backpack/syndicate/engineer
 
-/obj/effect/mob_spawn/human/space_base_syndicate/comms
-	name = "Syndicate Comms Officer sleeper"
+/obj/effect/mob_spawn/human/space_base_syndicate/command
+	name = "Syndicate elite sleeper"
+
+/obj/effect/mob_spawn/human/space_base_syndicate/command/comms
 	mob_name = "Syndicate Comms Officer"
 	id_job = "Syndicate Comms Officer"
 	description = "Проверяйте камеры и коммуникации, руководите станцией в случае ЧП, старайтесь помогать любым агентам \"Синдиката\" на станции, при этом сохраняя свою базу в секрете от НТ. Вы являетесь единственным агентом с доступом в хранилище и оружейную."
@@ -210,6 +210,7 @@
 	assignedrole = JOB_TITLE_TAIPAN_COMMS
 	min_hours = 50
 	exp_type = EXP_TYPE_COMMAND
+
 /datum/outfit/space_base_syndicate/comms
 	name = "Space Base Syndicate Comms Officer"
 	r_ear = /obj/item/radio/headset/syndicate/taipan/tcomms_agent // See del_types above
@@ -225,8 +226,7 @@
 		/obj/item/ammo_box/magazine/m50 = 3,
 	)
 
-/obj/effect/mob_spawn/human/space_base_syndicate/rd
-	name = "Syndicate Research Director sleeper"
+/obj/effect/mob_spawn/human/space_base_syndicate/command/rd
 	mob_name = "Syndicate Research Director"
 	id_job = "Syndicate Research Director"
 	description = "Следите за тем, чтобы учёные занимались исследованиями и не подорвали всю станцию, предоставьте \"Синдикату\" результаты своих исследований через карго и помните: смерть \"Нанотрейзен\"!"
@@ -236,6 +236,7 @@
 	assignedrole = JOB_TITLE_TAIPAN_RD
 	min_hours = 50
 	exp_type = EXP_TYPE_SCIENCE
+
 /datum/outfit/space_base_syndicate/rd
 	name = "Space Base Syndicate Research Director"
 	r_hand = /obj/item/melee/baton/telescopic
@@ -332,10 +333,10 @@
 			S.setDir(dir)
 			Destroy()
 		if(JOB_TITLE_TAIPAN_COMMS)
-			var/obj/effect/mob_spawn/human/space_base_syndicate/comms/S = new(get_turf(src))
+			var/obj/effect/mob_spawn/human/space_base_syndicate/command/comms/S = new(get_turf(src))
 			S.setDir(dir)
 			Destroy()
 		if(JOB_TITLE_TAIPAN_RD)
-			var/obj/effect/mob_spawn/human/space_base_syndicate/rd/S = new(get_turf(src))
+			var/obj/effect/mob_spawn/human/space_base_syndicate/command/rd/S = new(get_turf(src))
 			S.setDir(dir)
 			Destroy()


### PR DESCRIPTION

## Что этот ПР делает

Меняет пол под слиперами, и меняет их местами, чтобы по виду можно было понять, кто в слипере.
Меняет название слиперов, чтобы они красиво отображались в гост меню. Левой кнопкой мышкой всё ещё можно выбрать желаемую профу. Было выбрано так, ведь геймплей у Тайпановцев не слишком различается между ролями.
Переводит логику кто может слышать частоту Тайпана в один вид. Должно починить проблемы, когда ставишь ключи в другом порядке.

## Почему это хорошо для игры
Удобно гостам. Удобно игрокам - показывает что эти роли похожи между собой.

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
<img width="973" height="769" alt="image" src="https://github.com/user-attachments/assets/ad490330-f6b4-4cbe-82ff-72efb01da0ea" />
Для того чтобы вместить на экран Тайпан, окно гост ролей было увеличено. В ПРе увеличение ТГУИ нет.
<img width="296" height="528" alt="image" src="https://github.com/user-attachments/assets/89151668-cb91-443a-a919-2745edecb5e8" />
Слева: Врач и атмостехник
Справа: Каргонцы, учёные, повар и ботаник

</p>
</details>

## Список изменений
:cl:
qol: Тайпан теперь разделён на два пункта в гост меню, а не каждый пункт на каждую профу
/:cl:
