### PR TITLE
Возвращение запрета использования джаунтера на станции

### DIFF
--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -31,6 +31,9 @@
 	if(!device_turf || !is_teleport_allowed(device_turf.z))
 		return "Ошибка! Телепортация невозможна."
 
+	if(!is_mining_level(device_turf.z) || istype(get_area(device_turf), /area/ruin/space/bubblegum_arena))
+		return "Ошибка! Требуется натуральная гравитация для размещения якоря."
+
 	return TRUE
 
 /obj/item/wormhole_jaunter/proc/get_destinations()


### PR DESCRIPTION

## Что этот ПР делает
Что-то я не подумал - запрет использования джаунтера лучше оставить
## Почему это хорошо для игры
С учетом новых особенностей джаунтера, на станции он полностью теряет свою прямую цель, превращаясь из защитной способности (эскейпа от сб) в атакующую. По итогу шахтоантаги с помощью джаунтеров будут ставить непроходимые стенки на пол минуты, заход в которые будет с приличным шансом удалять инвентарь СБ.
Как-то я всё время забываю, что любой предмет или гиммик извратят под боевку с целью побеждать соперника.
Лучше поправить это сразу, чем через время получать сотни пингов со словами, какая же это хуйня, что мы это разрешили
## Список изменений
:cl:
tweak: Джаунтером снова нельзя пользоваться на станции
/:cl:
