### PR TITLE
Чинит верб у пачки бумаги

### DIFF
--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -286,11 +286,12 @@
 	set src in usr
 
 	to_chat(usr, span_notice("You loosen the bundle."))
-	for(var/obj/O in src)
-		O.loc = usr.loc
-		O.layer = initial(O.layer)
-		O.plane = initial(O.plane)
-		O.add_fingerprint(usr)
+	for(var/obj/item/page in papers)
+		page.forceMove_turf(usr.loc)
+		page.layer = initial(page.layer)
+		page.plane = initial(page.plane)
+		page.add_fingerprint(usr)
+		LAZYREMOVE(papers, page)
 	usr.temporarily_remove_item_from_inventory(src)
 	qdel(src)
 	return

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -291,7 +291,7 @@
 		page.layer = initial(page.layer)
 		page.plane = initial(page.plane)
 		page.add_fingerprint(usr)
-		LAZYREMOVE(papers, page)
+	LAZYCLEARLIST(papers)
 	usr.temporarily_remove_item_from_inventory(src)
 	qdel(src)
 	return


### PR DESCRIPTION

## Что этот ПР делает

Добавил строчку, чтоб пачка бумаги забывала про бумагу, когда её достают.

## Почему это хорошо для игры

Важные бумаги не пропадают.

## Список изменений
:cl:
bugfix: Теперь распускание пачки бумаг не удаляет эту пачку
/:cl:
