### PR TITLE
tweak: Пиро-когти открывашки

### DIFF
--- a/code/modules/anomalies/items/pyro_claws.dm
+++ b/code/modules/anomalies/items/pyro_claws.dm
@@ -81,7 +81,7 @@
 	user.visible_message(span_warning("[user] силой открыл[GEND_A_O_I(user)] шлюз при помощи [declent_ru(GENITIVE)]!"), \
 						span_warning("Вы силой открыли шлюз."), \
 						span_warning("Вы слышите металлический скрежет."))
-	airlock.open(2)
+	airlock.open(TRUE)
 
 /obj/item/twohanded/required/pyro_claws/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] начина[PLUR_ET_YUT(user)] пилить [declent_ru(NOMINATIVE)] друг об друга! \


### PR DESCRIPTION
## Что этот ПР делает
Пиро-когти научились открывать шлюзы без питания - с питанием умели, а без питания нет.

## Почему это хорошо для игры
Устраняем странности в коде когтей.

## Список изменений
:cl:
tweak: Пиро-когти могут открывать шлюзы без питания.
/:cl: