### PR TITLE
Исправляет математику с get_grab_upgrade_time

### DIFF
--- a/code/datums/components/muscles.dm
+++ b/code/datums/components/muscles.dm
@@ -315,7 +315,7 @@
 /datum/strength_level/weak
 	next_level = /datum/strength_level/normal
 	level_num = 1
-	grab_speed_modifier = 0.8
+	grab_speed_modifier = 1.2
 	pull_slowdown_modifier = 1.2
 	melee_damage_delta = -2
 	break_ties_speed_modifier = 0.8
@@ -349,7 +349,7 @@
 	next_level = /datum/strength_level/ideal
 	prev_level = /datum/strength_level/normal
 	level_num = 3
-	grab_speed_modifier = 1.15
+	grab_speed_modifier = 0.85
 	pull_slowdown_modifier = 0.75
 	melee_damage_delta = 2
 	break_ties_speed_modifier = 1.3
@@ -366,7 +366,7 @@
 	next_level = /datum/strength_level/superhuman
 	prev_level = /datum/strength_level/strong
 	level_num = 4
-	grab_speed_modifier = 1.3
+	grab_speed_modifier = 0.7
 	pull_slowdown_modifier = 0.5
 	melee_damage_delta = 4
 	break_ties_speed_modifier = 1.5
@@ -382,7 +382,7 @@
 /datum/strength_level/superhuman
 	prev_level = /datum/strength_level/ideal
 	level_num = 5
-	grab_speed_modifier = 1.5
+	grab_speed_modifier = 0.5
 	pull_slowdown_modifier = 0
 	melee_damage_delta = 6
 	break_ties_speed_modifier = 2

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -461,7 +461,7 @@
 		mod *= modifier
 
 	var/normal_grab_update_time = GRAB_UPGRADE_TIME * mod
-	return isnull(grabber.mind?.martial_art?.grab_speed) ? normal_grab_update_time / mod : grabber.mind.martial_art.grab_speed
+	return isnull(grabber.mind?.martial_art?.grab_speed) ? normal_grab_update_time : grabber.mind.martial_art.grab_speed
 
 /mob/living/attack_slime(mob/living/simple_animal/slime/M)
 	if(!SSticker)


### PR DESCRIPTION

## Что этот ПР делает

Убирает деление после умножения на то же число в грабе.
Переделал граб моды в силах под новую математику, думая что раньше оно делилось (и под мыслями, что слабая сила должна быть слабей).

## Почему это хорошо для игры

Было багом. В оригинальной [предложке](https://discord.com/channels/617003227182792704/755125334097133628/1386100365992263770) скорость захвата менялась от силы.
Выглядело как баг. Умножать на X и делить на X выглядело неправильно.


## Список изменений
:cl:
bugfix: Починил скорость граба от силы
/:cl:
