### PR TITLE
do_after без cancel_on_max больше не прерываются при макс числе интеракций

### DIFF
--- a/code/datums/timed_actions.dm
+++ b/code/datums/timed_actions.dm
@@ -174,6 +174,8 @@
 	if(interaction_key == src.interaction_key)
 		var/reduced_interaction_count = LAZYACCESS(source.do_afters, interaction_key)
 		if(reduced_interaction_count >= max_interact_count)
+			if(cancel_message)
+					to_chat(user, "[cancel_message]")
 			cancel()
 
 /datum/timed_action/proc/on_target_deleted(datum/source)

--- a/code/datums/timed_actions.dm
+++ b/code/datums/timed_actions.dm
@@ -87,7 +87,7 @@
 
 /datum/timed_action/proc/register_signals()
 	RegisterSignal(user, COMSIG_QDELETING, PROC_REF(on_user_deleted))
-	if(interaction_key)
+	if(cancel_on_max && interaction_key)
 		RegisterSignal(user, COMSIG_DO_AFTER_PRE_BEGAN, PROC_REF(on_do_after_pre_began))
 
 	if(!(timed_action_flags & DA_IGNORE_USER_LOC_CHANGE))
@@ -275,7 +275,7 @@
  * - cancel_message - Message shown to the user if cancel_on_max is set to `TRUE` and they exceeds max interaction count. Use empty string ("") to skip default cancel message.
  * - category - Used to apply proper action speed modifier to passed delay.
  */
-/proc/do_after(atom/movable/user, delay, atom/target, timed_action_flags = NONE, show_progress = TRUE, datum/callback/extra_checks, interaction_key, max_interact_count = 1, cog_icon = 'icons/effects/progressbar.dmi', cog_iconstate = "cog", mob/bar_override = null, cancel_on_max = FALSE, cancel_message = span_warning("Attempt cancelled."), category = DA_CAT_ALL)
+/proc/do_after(atom/movable/user, delay, atom/target, timed_action_flags = NONE, show_progress = TRUE, datum/callback/extra_checks, interaction_key, max_interact_count = INFINITY, cog_icon = 'icons/effects/progressbar.dmi', cog_iconstate = "cog", mob/bar_override = null, cancel_on_max = FALSE, cancel_message = span_warning("Attempt cancelled."), category = DA_CAT_ALL)
 	if(!user)
 		return FALSE
 	var/mob/as_mob = astype(user, /mob)


### PR DESCRIPTION
## Список изменений
:cl:
bugfix: do_after без cancel_on_max больше не прерываются при макс числе интеракций.
/:cl:
