### PR TITLE
Фикс некоторых проблем с навыками

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -209,7 +209,7 @@
 	current = new_character // link ourself to our new body
 	new_character.mind = src // and link our new body to ourself
 
-	if(!iscarbon(new_character))
+	if(!ishuman(new_character))
 		if(!temporaly_skills_holder && length(skills))
 			temporaly_skills_holder = skills
 			skills = list()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -126,15 +126,18 @@
 	var/list/job_objectives = list()
 
 	/// Flag for skills initialization
-	var/skills_initialized = FALSE
+	var/datum/weakref/skills_initialized
 	/// List of skill levels (associative map of type to level (number))
 	var/list/skills = list()
+	var/list/temporaly_skills_holder
 	/// Available free skill points
 	var/free_skill_points = BASIC_SKILL_POINTS_COUNT
 	/// Temp variable for skill leveling (for skill_select_win works)
 	var/list/selected_skills = null
 	/// Active skill bonuses from skill manuals
 	var/list/active_skill_bonuses = list()
+	/// Active skill bonuses from neurotrainer
+	var/list/active_neurotrainer_bonuses = list()
 	/// Active skill bonuses from skill manuals
 	var/list/read_manuals = list()
 
@@ -205,6 +208,15 @@
 
 	current = new_character // link ourself to our new body
 	new_character.mind = src // and link our new body to ourself
+
+	if(!iscarbon(new_character))
+		if(!temporaly_skills_holder && length(skills))
+			temporaly_skills_holder = skills
+			skills = list()
+	else if(temporaly_skills_holder && !length(skills))
+		skills = temporaly_skills_holder
+		temporaly_skills_holder = null
+
 
 	transfer_antag_huds(hud_to_transfer) // inherit the antag HUD
 	transfer_actions(new_character, old_current)
@@ -2646,7 +2658,7 @@
 	ASSERT(antag.owner && antag.owner.current)
 	antag.on_gain()
 
-	apply_antag_skills()
+	recalculate_skills()
 
 	return antag
 
@@ -2663,6 +2675,7 @@
 		return
 
 	qdel(antag)
+	recalculate_skills()
 
 /**
  * Removes all antag datums from the src mind.

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -65,12 +65,10 @@
 		return
 	if(!hasPower())
 		to_chat(user, span_notice("You start forcing [src] open..."))
-		CALCULATE_SKILL_MOD(user, BUILDING_SPEED_MOD, building_mod)
-		if(do_after(user, 5 SECONDS * I.toolspeed * building_mod, src, category = DA_CAT_TOOL))
-			if(!hasPower())
-				open()
-			else
-				to_chat(user, span_warning("[src] resists your efforts to force it!"))
+		if(!hasPower())
+			open()
+		else
+			to_chat(user, span_warning("[src] resists your efforts to force it!"))
 	else
 		to_chat(user, span_warning("[src] resists your efforts to force it!"))
 

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -330,6 +330,7 @@
 	if(. & ITEM_INTERACT_ANY_BLOCKER)
 		return .
 	rpd_interaction(interacting_with, user, mode)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/rpd/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	rpd_interaction(interacting_with, user, mode = RPD_DELETE_MODE)
@@ -338,7 +339,11 @@
 /obj/item/rpd/proc/rpd_interaction(atom/target, mob/user, mode, is_ranged = FALSE)
 	if(loc != user)
 		return
+
 	if(world.time < lastused + spawndelay)
+		return
+
+	if(astype(target, /obj/item).item_flags & IN_INVENTORY)
 		return
 
 	var/turf/location = get_turf(target)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -433,7 +433,7 @@ GLOBAL_VAR_INIT(off_mob_spawns, FALSE)
 			var/datum/job/current_job = SSjobs.GetJob(skills_ref_job)
 			current_job.apply_skills(H)
 		else
-			H.mind.apply_antag_skills(skills_ref_job)
+			H.mind.recalculate_skills(ref_job = skills_ref_job, force_antag = TRUE)
 
 	for(var/skill, level in skills)
 		H.mind.set_skill_level(skill, level)

--- a/code/modules/skills/_skill.dm
+++ b/code/modules/skills/_skill.dm
@@ -89,7 +89,7 @@ GLOBAL_LIST_EMPTY(skill_manual_types)
 	set name = "Навыки персонажа"
 	set category = VERB_CATEGORY_IC
 	if(mind)
-		if(mind.free_skill_points > 0)
+		if(mind.free_skill_points > 0 && iscarbon(usr))
 			var/datum/ui_module/skills_select_win/tgui = new(usr)
 			tgui.show(usr, src)
 		else

--- a/code/modules/skills/manual.dm
+++ b/code/modules/skills/manual.dm
@@ -66,7 +66,7 @@
 	if(applyed_bonus_points <= 0)
 		return
 	user.mind.skills[skill_type] = current_skill_level + applyed_bonus_points
-	user.mind.active_skill_bonuses += skill_type
+	user.mind.active_skill_bonuses[skill_type] = applyed_bonus_points
 
 /obj/item/book/skill_manual/proc/try_remove_skill_bonus(mob/user)
 	if(applyed_bonus_points <= 0)

--- a/code/modules/skills/mind_skill.dm
+++ b/code/modules/skills/mind_skill.dm
@@ -56,7 +56,8 @@
 	var/datum/job/current_job
 	if(ref_job)
 		current_job = SSjobs.GetJob(ref_job)
-	var/is_antag = iscarbon(current) && length(antag_datums) || force_antag
+	var/is_human = ishuman(current)
+	var/is_antag = is_human && length(antag_datums) || force_antag
 	var/basic_skill = is_antag? SKILL_LEVEL_BASIC : SKILL_LEVEL_NONE
 	var/list/cached_manual_bonuses = active_skill_bonuses
 	var/list/cached_neurotrainer_bonuses = active_neurotrainer_bonuses
@@ -72,7 +73,7 @@
 		if(current_job)
 			job_skill = current_job.get_skill_level(skill.type, role_alt_title)
 		var/level = max(job_skill, antag_skill_level)
-		var/bonus = cached_manual_bonuses[skill.type] || 0 + cached_neurotrainer_bonuses[skill.type] || 0
+		var/bonus = is_human? cached_manual_bonuses[skill.type] || 0 + cached_neurotrainer_bonuses[skill.type] || 0 : 0
 		level = min(level + bonus, SKILL_LEVEL_LEGEND)
 		set_skill_level(skill.type, level)
 

--- a/code/modules/skills/mind_skill.dm
+++ b/code/modules/skills/mind_skill.dm
@@ -5,7 +5,7 @@
 		var/datum/skill/skill = skill_datum
 		set_skill_level(skill.type, SKILL_LEVEL_BASIC)
 
-	skills_initialized = user
+	skills_initialized = WEAKREF(user)
 
 /datum/mind/proc/get_skill_level(skill_type)
 	var/level = skills[skill_type]
@@ -19,10 +19,13 @@
 /datum/mind/proc/register_skill_signals_for_user(mob/user)
 	if(!user)
 		return
-	if(skills_initialized && skills_initialized != user)
-		unregister_skill_signals_for_user(skills_initialized)
+	if(skills_initialized && skills_initialized != WEAKREF(user))
+		unregister_skill_signals_for_user(skills_initialized.resolve())
 	if(user != skills_initialized)
-		init_skills(user)
+		if(!length(skills))
+			init_skills(user)
+		else
+			skills_initialized = WEAKREF(user)
 		RegisterSignal(user, COMSIG_GET_SKILL_LEVEL, PROC_REF(get_skill_level_from_signal))
 		RegisterSignal(user, COMSIG_SKILL_AVAILABLE, PROC_REF(get_skill_available_from_signal))
 		for(var/skill_name, skill_datum in GLOB.skills)
@@ -48,19 +51,30 @@
 		return SKILL_NOT_AVAILABLE_RESULT
 	return SKILL_AVAILABLE_RESULT
 
-/datum/mind/proc/apply_antag_skills(ref_job = current.job)
+/datum/mind/proc/recalculate_skills(ref_job = current.job, force_antag = FALSE)
 	var/list/antag_skills = GLOB.antag_skills
 	var/datum/job/current_job
 	if(ref_job)
 		current_job = SSjobs.GetJob(ref_job)
+	var/is_antag = iscarbon(current) && length(antag_datums) || force_antag
+	var/basic_skill = is_antag? SKILL_LEVEL_BASIC : SKILL_LEVEL_NONE
+	var/list/cached_manual_bonuses = active_skill_bonuses
+	var/list/cached_neurotrainer_bonuses = active_neurotrainer_bonuses
+	for(var/obj/item/book/skill_manual/manual in current.get_equipped_items(INCLUDE_HELD))
+		current.drop_item_ground(manual, TRUE)
+	selected_skills = null
 	for(var/skill_name, skill_datum in GLOB.skills)
 		var/datum/skill/skill = skill_datum
-		var/antag_skill_level = antag_skills[skill.type]
-		if(!antag_skill_level)
-			antag_skill_level = SKILL_LEVEL_BASIC
-		var/job_skill = SKILL_LEVEL_BASIC
+		var/antag_skill_level = basic_skill
+		if(is_antag)
+			antag_skill_level = antag_skills[skill.type] || basic_skill
+		var/job_skill = basic_skill
 		if(current_job)
 			job_skill = current_job.get_skill_level(skill.type, role_alt_title)
 		var/level = max(job_skill, antag_skill_level)
+		var/bonus = cached_manual_bonuses[skill.type] || 0 + cached_neurotrainer_bonuses[skill.type] || 0
+		level = min(level + bonus, SKILL_LEVEL_LEGEND)
 		set_skill_level(skill.type, level)
-		free_skill_points = BASIC_ANTAG_SKILL_POINTS_COUNT
+
+	free_skill_points = is_antag? BASIC_ANTAG_SKILL_POINTS_COUNT : BASIC_SKILL_POINTS_COUNT
+

--- a/code/modules/skills/neurotrainer.dm
+++ b/code/modules/skills/neurotrainer.dm
@@ -81,6 +81,7 @@
 		applyed_bonus_points = SKILL_LEVEL_LEGEND - current_skill_level
 	if(applyed_bonus_points > 0)
 		target.mind.skills[skill_types] = current_skill_level + applyed_bonus_points
+		target.mind.active_neurotrainer_bonuses[skill_types] += applyed_bonus_points
 		. = TRUE
 		used = TRUE
 


### PR DESCRIPTION
## Список изменений
:cl:
bugfix: Исправлена возможная причина потери навыков при клонировании.
bugfix: Теперь при перемещении майнда в не хумана навыки сохраняются, но не передаются не хуману. Они сохранятся и будут возвращены, когда майнд вернется в хумана.
bugfix: Теперь при получении потери датумизированного антага происходит сброс и перерасчет навыков. Эффекты нейротрейнеров и прочитанных мануалов сохраняются(если моб - хуман)
bugfix: Исправлено некорректное поведение рцд при клике по рюказаку в инвентаре.
/:cl:
