### PR TITLE
Фикс фантомного фейла прогресс баров

### DIFF
--- a/code/datums/timed_actions.dm
+++ b/code/datums/timed_actions.dm
@@ -157,12 +157,12 @@
 		cancel()
 		return
 
+	if(!QDELETED(progressbar))
+		progressbar.update(world.time - start_time)
+
 	if(world.time >= end_time)
 		status = ACTION_SUCCEEDED
 		return PROCESS_KILL
-
-	if(!QDELETED(progressbar))
-		progressbar.update(world.time - start_time)
 
 /datum/timed_action/proc/on_user_deleted(datum/source)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## Список изменений
:cl:
bugfix: Теперь прогресс бары при успешном действии не выглядят как зафейленые.
/:cl:
