### PR TITLE
Изменение механики джаунтера

### DIFF
--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -26,12 +26,16 @@
 	activate(user, TRUE)
 
 /obj/item/wormhole_jaunter/proc/turf_check()
+
 	var/turf/device_turf = get_turf(src)
 
 	if(!device_turf || !is_teleport_allowed(device_turf.z))
 		return "Ошибка! Телепортация невозможна."
 
-	if(!is_mining_level(device_turf.z) || istype(get_area(device_turf), /area/ruin/space/bubblegum_arena))
+	if(istype(get_area(device_turf), /area/ruin/space/bubblegum_arena))
+		return "Ошибка! Требуется натуральная гравитация для размещения якоря."
+
+	if(!is_mining_level(device_turf.z) && !(emagged && is_station_level(device_turf.z)))
 		return "Ошибка! Требуется натуральная гравитация для размещения якоря."
 
 	return TRUE
@@ -60,7 +64,8 @@
 
 	var/chosen_beacon = pick(destinations)
 
-	var/obj/effect/portal/jaunt_tunnel/tunnel = new(get_turf(src), get_turf(chosen_beacon), src, 100, user)
+	var/tunnel_lifespan = emagged ? 50 : 100
+	var/obj/effect/portal/jaunt_tunnel/tunnel = new(get_turf(src), get_turf(chosen_beacon), src, tunnel_lifespan, user)
 	tunnel.emagged = emagged
 	if(teleport)
 		tunnel.teleport(user)
@@ -123,7 +128,7 @@
 		return
 
 	var/mob/living/carbon/living_target = movable
-	if(ishuman(living_target)) //we need to check this first, because after weaken all held items will be dropped
+	if(emagged && ishuman(living_target)) //we need to check this first, because after weaken all held items will be dropped
 		handle_clothing_destruction(living_target)
 	living_target.Weaken(12 SECONDS)
 
@@ -231,4 +236,5 @@
 		new /obj/effect/portal/jaunt_tunnel(drunken_opening, drunk_dial, src, 10 SECONDS, thrower)
 		new /obj/effect/temp_visual/thunderbolt(drunken_opening)
 	qdel(src)
+
 

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -32,10 +32,7 @@
 	if(!device_turf || !is_teleport_allowed(device_turf.z))
 		return "Ошибка! Телепортация невозможна."
 
-	if(istype(get_area(device_turf), /area/ruin/space/bubblegum_arena))
-		return "Ошибка! Требуется натуральная гравитация для размещения якоря."
-
-	if(!is_mining_level(device_turf.z) && !(emagged && is_station_level(device_turf.z)))
+	if(istype(get_area(device_turf), /area/ruin/space/bubblegum_arena) || !is_mining_level(device_turf.z) && !(emagged && is_station_level(device_turf.z)))
 		return "Ошибка! Требуется натуральная гравитация для размещения якоря."
 
 	return TRUE
@@ -64,7 +61,7 @@
 
 	var/chosen_beacon = pick(destinations)
 
-	var/tunnel_lifespan = emagged ? 50 : 100
+	var/tunnel_lifespan = emagged ? 5 SECONDS : 10 SECONDS
 	var/obj/effect/portal/jaunt_tunnel/tunnel = new(get_turf(src), get_turf(chosen_beacon), src, tunnel_lifespan, user)
 	tunnel.emagged = emagged
 	if(teleport)
@@ -236,5 +233,4 @@
 		new /obj/effect/portal/jaunt_tunnel(drunken_opening, drunk_dial, src, 10 SECONDS, thrower)
 		new /obj/effect/temp_visual/thunderbolt(drunken_opening)
 	qdel(src)
-
 


### PR DESCRIPTION
#Для чего этот ПР нужен?
Изначально джаунтер создавался как средство спасения шахтеров от смертельной опасности с поверхности планетоида и не работал в секторе станции. После доработки стал работать в секторе станции, но сжигать случайный предмет сотрудника. Среди таких предметов могли быть как ценные вещи, так и медикаменты которые могли спасти сотруднику жизнь, в свою очередь. Изменения которые я предлагаю: 
#Вернуть обычному джаунтеру старый метод работы, при котором он телепортировал с планетоида, не сжигая предметы бедных шахтеров.  #Перенести механику сжигания предметов на емагнутую версию джаунтера. # возврат емагнутой версии джаунтера возможности применения на территории станции, но время исчезновения воронки снижено в двое, только у емагнутой версии.
## Что этот ПР делает

Изменяет механику работы генератора червоточин (`/obj/item/wormhole_jaunter`) и создаваемого им портала (`/obj/effect/portal/jaunt_tunnel`):

* **Обычная версия:** больше не сжигает одежду и предметы в инвентаре/руках при прохождении через червоточину (оглушение, тряска экрана и рвота остаются).
* **Взломанная (emagged) версия:**
  * Теперь может быть активирована на уровне станции (проверка `turf_check` разрешает активацию при `emagged && is_station_level()`).
  * Время существования создаваемого портала сокращено  вдвое.
  * Эффект уничтожения (сжигания) одежды/предметов теперь срабатывает **только** при прохождении через взломанный портал.

## Почему это хорошо для игры

* **Улучшение QoL для шахтёров и сотрудников:** обычный джаунтер больше не наказывает игроков уничтожением ценного снаряжения при штатном использовании или спасении от пропастей.
* **Новые возможности для предателей:** взлом джаунтера теперь даёт полезный тактический инструмент для экстренного побега на станции, но балансируется риском сжигания вещей и укороченным временем работы портала.


## Список изменений

:cl:
balance: Обычный генератор червоточин больше не сжигает вещи при телепортации.
tweak: Взломанный генератор червоточин теперь можно использовать на уровне станции, однако время жизни портала снижено, а телепортация через него сжигает вещи.
/:cl:
