### PR TITLE
Удаляет вормхол джаунтер везде кроме стартового гира шахтера и шахтемедика

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -371,7 +371,6 @@
 		EQUIPMENT("Industrial Mining Charge", /obj/item/grenade/plastic/miningcharge, 500),
 		EQUIPMENT("Whetstone", /obj/item/whetstone, 500),
 		EQUIPMENT("Fulton Pack", /obj/item/extraction_pack, 1500),
-		EQUIPMENT("Jaunter", /obj/item/wormhole_jaunter, 900),
 		EQUIPMENT("Chasm Jaunter Recovery Grenade", /obj/item/grenade/jaunter_grenade, 3000), // fishing rod supremacy
 		EQUIPMENT("Lazarus Injector", /obj/item/lazarus_injector, 600),
 		EQUIPMENT("Point Transfer Card (500)", /obj/item/card/mining_point_card, 500),

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -658,7 +658,6 @@
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/clothing/suit/hooded/explorer(src)
 	new /obj/item/storage/bag/gem(src)
-	new /obj/item/wormhole_jaunter(src)
 
 /obj/item/storage/backpack/duffel/minebot_kit
 	name = "minebot Kit"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -1267,7 +1267,6 @@
 	new /obj/item/survivalcapsule(src)
 	new /obj/item/grenade/plastic/miningcharge/lesser(src)
 	new /obj/item/grenade/plastic/miningcharge/lesser(src)
-	new /obj/item/wormhole_jaunter(src)
 
 /obj/item/storage/belt/mining/alt
 	icon_state = "explorer2"


### PR DESCRIPTION

## Что этот ПР делает
Название
## Почему это хорошо для игры
«Джаунтер - слишком чизовая хуйня которая не должна существа в любом её виде более одной штуки. Для спасения от бури у шахтера есть капсулы, для эвакуации с Лазиса существуют фултоны. Для спасения от иных опасностей Лазиса у шахтера должны быть только его прямые руки или другие шахтеры. Джаунтер остаётся только как один единственный предмет второго шанса который может быть использован лишь раз за раунд», — astolfofan.
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
balance: Вормхол джаунтер теперь нельзя купить.
/:cl:
