### PR TITLE
дополнительная проверка на безопасные тайлы

### DIFF
--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -4,7 +4,7 @@
 	if(length(turfs))
 		return pick(turfs)
 
-/// Returns a random turf on the station, excludes dense turfs (like walls) and areas that have valid_territory set to FALSE
+/// Returns a random turf on the station, excludes dense turfs (like walls), areas with bad atmos and areas that have valid_territory set to FALSE
 /proc/get_safe_random_station_turf(list/areas_to_pick_from = SSmapping.existing_station_areas)
 	for(var/i in 1 to 5)
 		var/list/turf_list = get_area_turfs(pick(areas_to_pick_from))
@@ -13,7 +13,7 @@
 			var/I = rand(1, length(turf_list))
 			var/turf/checked_turf = turf_list[I]
 			var/area/turf_area = get_area(checked_turf)
-			if(!checked_turf.density && (turf_area.valid_territory) && !isgroundlessturf(checked_turf))
+			if(!checked_turf.density && (turf_area.valid_territory) && !isgroundlessturf(checked_turf) && is_safe_turf(checked_turf))
 				var/clear = TRUE
 				for(var/obj/checked_object in checked_turf)
 					if(checked_object.density)


### PR DESCRIPTION

## Что этот ПР делает
в прок get_safe_random_station_turf() добавляет проверку на нормальный атмос.
## Почему это хорошо для игры
Меньше спавнов в хранилище газов или внутри теслы (в """безопасных""" тайлах космоса).
## Список изменений
:cl:
bugfix: Станционный ивент "случайный спавн" имеет в разы меньше шансов бросить куклу в смертельную ситуацию.
/:cl:
