### PR TITLE
Увеличение цены Джаунтера.

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -371,7 +371,7 @@
 		EQUIPMENT("Industrial Mining Charge", /obj/item/grenade/plastic/miningcharge, 500),
 		EQUIPMENT("Whetstone", /obj/item/whetstone, 500),
 		EQUIPMENT("Fulton Pack", /obj/item/extraction_pack, 1500),
-		EQUIPMENT("Jaunter", /obj/item/wormhole_jaunter, 900),
+		EQUIPMENT("Jaunter", /obj/item/wormhole_jaunter, 2000),
 		EQUIPMENT("Chasm Jaunter Recovery Grenade", /obj/item/grenade/jaunter_grenade, 3000), // fishing rod supremacy
 		EQUIPMENT("Lazarus Injector", /obj/item/lazarus_injector, 600),
 		EQUIPMENT("Point Transfer Card (500)", /obj/item/card/mining_point_card, 500),


### PR DESCRIPTION
Увеличение цены Джаунтера, как плата за его высокую эффективность в спасении жизни шахтеров.

Что этот ПР делает
Повышает цену Джаунтера в автомате шахтеров с 900 до 2000 очков.

Почему это хорошо для игры
Высокая цена за быстрое спасение из опасной ситуации. Теперь шахтеры не смогут накупить пол сумки дешевых джаунтеров и использовать их без веского повода. Также это изменение повышает ценность фултона, так как в отличии от фултона у него всего 1 использование.

Список изменений
:cl:
tweak: Увеличена цена джаунтера в автомате выдачи оборудования шахтеров до 2000 очков 
/cl: