### PR TITLE
Убраны 4 лишние трубы в техах под библиотекой

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -43158,11 +43158,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/maintenance/detectives_office)
-"iFg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "iFk" = (
 /obj/item/flag/species,
 /obj/effect/turf_decal/delivery/red,
@@ -47750,9 +47745,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -159041,7 +159040,7 @@ wyc
 fqW
 prt
 oMI
-iFg
+hxP
 jAL
 fhD
 xBO


### PR DESCRIPTION

## Что этот ПР делает
Убраны 2 трубы ведущие в никуда (и еще 2 заменены)
## Почему это хорошо для игры
Шизофрения маппинг
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
<img width="190" height="273" alt="изображение" src="https://github.com/user-attachments/assets/302f2bf5-a4d9-4e6c-9bd5-4c25ab43f775" />

<img width="507" height="394" alt="изображение" src="https://github.com/user-attachments/assets/7933bfa2-cefc-478b-a1e6-bda4220417bf" />

</p>
</details>

## Список изменений
:cl:

map: Убраны лишние трубы под библиотекой.

/:cl:
