### PR TITLE
Временное отключение дезматча

### DIFF
--- a/code/modules/tgui/modules/minigames_explorer.dm
+++ b/code/modules/tgui/modules/minigames_explorer.dm
@@ -55,9 +55,8 @@
 
 	switch(action)
 		if("deathmatch")
-			ui.close()
-			deathmatch()
-			return TRUE
+			to_chat(owner, span_warning("Дезматч временно отключён до дальнейшего оповещения."))
+			return
 
 	var/list/possible_spawners = params["ID"]
 	var/obj/MS = locateUID(pick(possible_spawners))


### PR DESCRIPTION

## Что этот ПР делает
Выключает дезматчи в виду неизвестной ошибки, от которой он ломается и высирает сотни тысяч рантаймов. Пока так, потом разберемся, в чем причина
:cl:
del: Дезматч убран из ротации до дальнейшего оповещения
/:cl:
