### PR TITLE
map: ССТ оружейка

### DIFF
--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -12255,8 +12255,6 @@
 /area/centcom/central_command_areas/evacuation)
 "fTC" = (
 /obj/structure/closet/syndicate/sst,
-/obj/item/ammo_box/magazine/l6saw/bleeding,
-/obj/item/ammo_box/magazine/l6saw,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -21099,8 +21097,6 @@
 /area/shuttle/administration)
 "kcz" = (
 /obj/structure/closet/syndicate/sst,
-/obj/item/ammo_box/magazine/l6saw/bleeding,
-/obj/item/ammo_box/magazine/l6saw,
 /obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/mineral/plastitanium,
 /area/centcom/syndicate_base/elite_squad)
@@ -44620,12 +44616,12 @@
 	},
 /area/centcom/central_command_areas/zone/three)
 "unV" = (
-/obj/item/gun/projectile/automatic/smg/c20r{
+/obj/item/gun/projectile/automatic/smg/c20r/auto{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/projectile/automatic/smg/c20r,
-/obj/item/gun/projectile/automatic/smg/c20r{
+/obj/item/gun/projectile/automatic/smg/c20r/auto,
+/obj/item/gun/projectile/automatic/smg/c20r/auto{
 	pixel_x = 3;
 	pixel_y = -3
 	},
@@ -44688,8 +44684,6 @@
 /area/shuttle/syndicate_sit)
 "upE" = (
 /obj/structure/closet/syndicate/sst,
-/obj/item/ammo_box/magazine/l6saw/bleeding,
-/obj/item/ammo_box/magazine/l6saw,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -44712,26 +44706,11 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
 /obj/effect/turf_decal/delivery/white/hollow,
 /obj/structure/rack/gunrack,
+/obj/item/storage/backpack/duffel/syndie/ammo/carbine,
+/obj/item/storage/backpack/duffel/syndie/ammo/carbine,
+/obj/item/storage/backpack/duffel/syndie/ammo/carbine,
 /turf/simulated/floor/mineral/plastitanium,
 /area/centcom/syndicate_base/elite_squad)
 "uqY" = (

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -46,6 +46,8 @@
 
 /obj/structure/closet/syndicate/sst/populate_contents()
 	new /obj/item/ammo_box/magazine/l6saw(src)
+	new /obj/item/ammo_box/magazine/l6saw(src)
+	new /obj/item/ammo_box/magazine/l6saw/bleeding(src)
 	new /obj/item/gun/projectile/automatic/l6_saw(src)
 	new /obj/item/tank/jetpack/oxygen/harness(src)
 	new /obj/item/storage/belt/military/sst(src)


### PR DESCRIPTION

## Что этот ПР делает
Заменяет базовую c20 на c20 с аплинка нюкеров - базовая используется для игрушки и гейтерской урезанки, а в аплинке нормальная версия, но в оружейке сст её не заменили.
Убирает с мапинга в код магазины от l6.
Заменяет кучу магазинов для m90gl на рюкзак с ними же.
## Почему это хорошо для игры
Актуализация и немного уборка.
## Список изменений
:cl:
map: Замена с20 на нюкеровскую версию в оружейке сст.
/:cl:
