### PR TITLE
Фикс модуля встроенного сидения для киборгов 2

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -292,8 +292,8 @@
 	ADD_TRAIT(rider, TRAIT_FORCED_STANDING, UNIQUE_TRAIT_SOURCE(src))
 
 /datum/component/riding/creature/cyborg/handle_unbuckle(mob/living/rider)
-	. = ..()
 	REMOVE_TRAIT(rider, TRAIT_FORCED_STANDING, UNIQUE_TRAIT_SOURCE(src))
+	..()
 	// For some reason, after unbuckling, game is substracting atom's 'pixel_y' var by 9.
 	rider.pixel_y += 9
 


### PR DESCRIPTION


## Что этот ПР делает

Мне один зюзя нашептал, что оказывается модуль встроенного сидения ломает своих бывших пассажиров, из-за чего они больше не могли лежать. Теперь такого не происходит

## Почему это хорошо для игры

Меньше багов. Больше добра

## Демонстрация изменений

<details><summary>Изображения и видео</summary>
<p>
все, что здесь было - все пропало
</p>
</details>

## Список изменений

:cl:
bugfix: Модуль встроенного сидения киборгов больше не ломает своих бывших пассажиров и они могут свободно лежать.
/:cl: