### PR TITLE
bugfix: Фикс смещения спрайта после update_transform

### DIFF
--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -37,8 +37,9 @@
 		var/is_vertical = !lying_angle || !rotate_on_lying
 		var/new_translation = get_transform_translation_size(resize * current_size)
 		///scaling also affects translation, so we've to undo the old translate beforehand.
-		if(translate && is_vertical)
-			ntransform.Translate(0, -translate)
+		if(is_vertical)
+			var/old_translation = get_transform_translation_size(current_size)
+			ntransform.Translate(0, -old_translation)
 		ntransform.Scale(resize)
 		current_size *= resize
 		//Update the height of the maptext according to the size of the mob so they don't overlap.


### PR DESCRIPTION
## Что этот ПР делает
Исправление ошибки, из-за которой после изменения размеров спрайта куклы - спрайт смещался от центра вверх/вниз,.

## Демонстрация изменений

<details><summary>Изображения и видео</summary>
<p>
<img width="1246" height="602" alt="image" src="https://github.com/user-attachments/assets/6408e889-47f4-4762-abe6-65b8086f79e7" />
</p>
</details>

## Список изменений
:cl:
bugfix: offset transform
/:cl: