### PR TITLE
Возможно чинит падение прикрученной линзы БФЛ в чазм

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -11,7 +11,6 @@
 		/mob/living/simple_animal/hostile/asteroid/elite,
 		/mob/living/simple_animal/hostile/megafauna,
 		/obj/bfl_crack,
-		/obj/machinery/bfl_lens,
 		/obj/docking_port,
 		/obj/effect/abstract,
 		/obj/effect/collapse,

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -11,6 +11,7 @@
 		/mob/living/simple_animal/hostile/asteroid/elite,
 		/mob/living/simple_animal/hostile/megafauna,
 		/obj/bfl_crack,
+		/obj/machinery/bfl_lens,
 		/obj/docking_port,
 		/obj/effect/abstract,
 		/obj/effect/collapse,

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -246,18 +246,22 @@
 	if(!anchored && !isfloorturf(loc))
 		user.visible_message(span_warning("A floor must be present to secure [src]!"))
 		return FALSE
+	if(obj_flags & NODECONSTRUCT)
+		return FALSE
+
 	if(I.tool_behaviour != TOOL_WRENCH)
 		return FALSE
 	if(!I.tool_use_check(user, 0))
 		return FALSE
-	if(!(obj_flags & NODECONSTRUCT))
-		CALCULATE_SKILL_MOD(user, CONSTRUCTING_SPEED_MOD, construction_mod)
-		to_chat(user, span_notice("Now [anchored ? "un" : ""]securing [name]."))
-		if(I.use_tool(src, user, time * construction_mod, volume = I.tool_volume))
-			to_chat(user, span_notice("You've [anchored ? "un" : ""]secured [name]."))
-			set_anchored(!anchored)
-		return TRUE
-	return FALSE
+
+	CALCULATE_SKILL_MOD(user, CONSTRUCTING_SPEED_MOD, construction_mod)
+	to_chat(user, span_notice("Now [anchored ? "un" : ""]securing [name]."))
+	if(!I.use_tool(src, user, time * construction_mod, volume = I.tool_volume))
+		return FALSE
+
+	to_chat(user, span_notice("You've [anchored ? "un" : ""]secured [name]."))
+	set_anchored(!anchored)
+	return TRUE
 
 /obj/water_act(volume, temperature, source, method = REAGENT_TOUCH)
 	. = ..()


### PR DESCRIPTION
## Что этот ПР делает

default_unfasten_wrench возвращал TRUE даже если не был пройден do_after, что могло поломать логику wrench_act БФЛа, где проверялось что возвращает default_unfasten_wrench

## Почему это хорошо для игры
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:
bugfix: возможно чинит падение прикрученной линзы БФЛ в чазм
/:cl:
