### PR TITLE
Увеличение времени таймаута тестов

### DIFF
--- a/.github/workflows/run_station_test.yml
+++ b/.github/workflows/run_station_test.yml
@@ -11,11 +11,11 @@ jobs:
   run_station_test:
     name: Station Test (${{ inputs.station }}; ${{ matrix.byondtype }})
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        byondtype: ["STABLE"]
+        byondtype: ['STABLE']
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -7,11 +7,11 @@ jobs:
   unit_tests:
     name: Run SQL Validation + Unit Tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
-        byondtype: ["STABLE"]
+        byondtype: ['STABLE']
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/setup_build_artifact_station_tests.yml
+++ b/.github/workflows/setup_build_artifact_station_tests.yml
@@ -5,18 +5,18 @@ jobs:
   setup_build_artifact_station_tests:
     name: Setup build artifact # MAP_TESTS
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        byondtype: ["STABLE"]
+        byondtype: ['STABLE']
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v7
         with:
           node-version: 22.11.0
-          cache: "yarn"
+          cache: 'yarn'
           cache-dependency-path: ./tgui/yarn.lock
 
       - name: Restore BYOND from Cache

--- a/.github/workflows/setup_build_artifact_unit_tests.yml
+++ b/.github/workflows/setup_build_artifact_unit_tests.yml
@@ -5,18 +5,18 @@ jobs:
   setup_build_artifact_unit_tests:
     name: Setup build artifact # UNIT_TESTS
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
-        byondtype: ["STABLE"]
+        byondtype: ['STABLE']
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v7
         with:
           node-version: 22.11.0
-          cache: "yarn"
+          cache: 'yarn'
           cache-dependency-path: ./tgui/yarn.lock
 
       - name: Restore BYOND from Cache


### PR DESCRIPTION

## Что этот ПР делает
Юнит тесты уходят в таймаут по какой-то причине, возможно им просто нужно больше времени для обработки уникального билда парадайз
<img width="581" height="230" alt="image" src="https://github.com/user-attachments/assets/1da234eb-8fe8-4508-b8fe-0f6cc9d8e3d1" />
## Список изменений
:cl:
server: Увеличено время таймаута тестов.
/:cl:
