### PR TITLE
Отображение названия импланта в кейсе для имплантов

### DIFF
--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -68,3 +68,7 @@
 
 	return ..()
 
+/obj/item/implantcase/examine(mob/user)
+	. = ..()
+	if(imp)
+		. += span_notice("Внутри содержится [imp.declent_ru(NOMINATIVE)]")


### PR DESCRIPTION

## Что этот ПР делает
Добавляет в описание кейса для имплантов название импланта в нем
## Почему это хорошо для игры
Очень неудобно, когда единственный способ узнать, какой имплант вытащили из человека - заставить врача пролистать чат на наличие одной единственной строчки с названием.
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:

tweak: Добавлено отображение названия импланта в кейсе для имплантов.
/:cl:
