### PR TITLE
Универсальный берет и универсальная куртка

### DIFF
--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -252,6 +252,8 @@
 
 	var/tmp/list/gear_leftovers = list()
 	var/obj/item/organ/internal/cyberimp/eyes/hud/implant_variant = null
+	var/obj/item/clothing/head/beret/beret_variant = null
+	var/obj/item/clothing/suit/hooded/wintercoat/coat_variant = null
 
 /datum/outfit/job/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(allow_backbag_choice)

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -306,7 +306,7 @@
 			gear_leftovers += gear_datum
 			continue
 
-		var/obj/item/placed_in = gear_datum.spawn_item(H, H.client.prefs.get_gear_metadata(gear_datum))
+		var/obj/item/placed_in = gear_datum.spawn_item(H, H.client.prefs.get_gear_metadata(gear_datum), src)
 		if(H.equip_to_slot_or_del(placed_in, gear_datum.slot, TRUE))
 			to_chat(H, span_notice("Вы получили [placed_in.declent_ru(ACCUSATIVE)]!"))
 		else
@@ -326,7 +326,7 @@
 
 	if(length(gear_leftovers))
 		for(var/datum/gear/G in gear_leftovers)
-			var/obj/item/placed_in = G.spawn_item(null, H.client.prefs.get_gear_metadata(G))
+			var/obj/item/placed_in = G.spawn_item(null, H.client.prefs.get_gear_metadata(G), src)
 			if(!placed_in)
 				continue
 			if(placed_in.equip_to_best_slot(H))

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -55,6 +55,8 @@
 	dufflebag = /obj/item/storage/backpack/duffel/engineering
 	box = /obj/item/storage/box/survival/engineer
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/meson
+	beret_variant = /obj/item/clothing/head/beret/ce
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/engineering/ce
 
 /datum/job/engineering
 	abstract_type = /datum/job/engineering
@@ -114,6 +116,8 @@
 	dufflebag = /obj/item/storage/backpack/duffel/engineering
 	box = /obj/item/storage/box/survival/engineer
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/meson
+	beret_variant = /obj/item/clothing/head/beret/eng
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/engineering
 
 /datum/job/engineering/atmos
 	title = JOB_TITLE_ATMOSTECH
@@ -154,6 +158,8 @@
 	satchel = /obj/item/storage/backpack/satchel_eng
 	dufflebag = /obj/item/storage/backpack/duffel/atmos
 	box = /obj/item/storage/box/survival/engineer
+	beret_variant = /obj/item/clothing/head/beret/atmos
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos
 
 /datum/job/engineering/engineer/trainee
 	title = JOB_TITLE_ENGINEER_TRAINEE

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -46,6 +46,8 @@
 	satchel = /obj/item/storage/backpack/satchel_med
 	dufflebag = /obj/item/storage/backpack/duffel/medical
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/medical
+	beret_variant = /obj/item/clothing/head/beret/elo
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/medical/cmo
 
 /datum/job/medical
 	abstract_type = /datum/job/medical
@@ -123,6 +125,8 @@
 	satchel = /obj/item/storage/backpack/satchel_med
 	dufflebag = /obj/item/storage/backpack/duffel/medical
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/medical
+	beret_variant = /obj/item/clothing/head/beret/med
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/medical
 
 /datum/outfit/job/doctor/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
@@ -223,6 +227,8 @@
 		/obj/item/storage/box/bodybags = 1,
 	)
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/medical
+	beret_variant = /obj/item/clothing/head/beret/med
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/medical
 
 /datum/job/medical/chemist
 	title = JOB_TITLE_CHEMIST
@@ -263,6 +269,8 @@
 	satchel = /obj/item/storage/backpack/satchel_chem
 	dufflebag = /obj/item/storage/backpack/duffel/chemistry
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/medical
+	beret_variant = /obj/item/clothing/head/beret/med
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/medical
 
 /datum/job/medical/geneticist
 	title = JOB_TITLE_GENETICIST
@@ -307,6 +315,8 @@
 	satchel = /obj/item/storage/backpack/satchel_gen
 	dufflebag = /obj/item/storage/backpack/duffel/genetics
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/medical
+	beret_variant = /obj/item/clothing/head/beret/med
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/medical
 
 /datum/job/medical/virologist
 	title = JOB_TITLE_VIROLOGIST
@@ -350,6 +360,8 @@
 	satchel = /obj/item/storage/backpack/satchel_vir
 	dufflebag = /obj/item/storage/backpack/duffel/virology
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/medical
+	beret_variant = /obj/item/clothing/head/beret/med
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/medical
 
 /datum/job/medical/psychiatrist
 	title = JOB_TITLE_PSYCHIATRIST
@@ -386,6 +398,8 @@
 	suit_store = /obj/item/flashlight/pen
 	pda = /obj/item/pda/medical
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/medical
+	beret_variant = /obj/item/clothing/head/beret/med
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/medical
 
 /datum/outfit/job/psychiatrist/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
@@ -441,6 +455,8 @@
 	dufflebag = /obj/item/storage/backpack/duffel/medical
 	box = /obj/item/storage/box/survival/engineer
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/medical
+	beret_variant = /obj/item/clothing/head/beret/med
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/medical
 
 /datum/outfit/job/paramedic/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -56,6 +56,8 @@
 	satchel = /obj/item/storage/backpack/satchel_tox
 	dufflebag = /obj/item/storage/backpack/duffel/science
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/science
+	beret_variant = /obj/item/clothing/head/beret/purple/rd
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/medical/science/rd
 
 /datum/job/science
 	abstract_type = /datum/job/science
@@ -151,6 +153,8 @@
 	satchel = /obj/item/storage/backpack/satchel_tox
 	dufflebag = /obj/item/storage/backpack/duffel/science
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/science
+	beret_variant = /obj/item/clothing/head/beret/sci
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/medical/science
 
 /datum/job/science/scientist/student
 	title = JOB_TITLE_SCIENCE_STUDENT
@@ -232,6 +236,8 @@
 	id = /obj/item/card/id/research
 	pda = /obj/item/pda/roboticist
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/diagnostic
+	beret_variant = /obj/item/clothing/head/beret/sci
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/medical/science
 
 /datum/job/science/mechanic
 	title = JOB_TITLE_SPACEPOD_TECHNICIAN
@@ -273,3 +279,5 @@
 	dufflebag = /obj/item/storage/backpack/duffel/engineering
 	box = /obj/item/storage/box/survival/engineer
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/meson
+	beret_variant = /obj/item/clothing/head/beret/sci
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/medical/science

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -64,6 +64,8 @@
 	dufflebag = /obj/item/storage/backpack/duffel/security
 	box = /obj/item/storage/box/survival/survival_security/hos
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/security
+	beret_variant = /obj/item/clothing/head/HoS/beret
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/security/hos
 
 /datum/job/security
 	abstract_type = /datum/job/security
@@ -139,6 +141,8 @@
 	dufflebag = /obj/item/storage/backpack/duffel/security
 	box = /obj/item/storage/box/survival/survival_security/warden
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/security
+	beret_variant = /obj/item/clothing/head/beret/sec/warden
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/security
 
 /datum/job/security/detective
 	title = JOB_TITLE_DETECTIVE
@@ -191,6 +195,8 @@
 
 	implants = list(/obj/item/implant/mindshield)
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/security
+	beret_variant = /obj/item/clothing/head/beret/sec
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/security
 
 /datum/outfit/job/detective/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
@@ -265,6 +271,8 @@
 	dufflebag = /obj/item/storage/backpack/duffel/security
 	box = /obj/item/storage/box/survival/survival_security
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/security
+	beret_variant = /obj/item/clothing/head/beret/sec
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/security
 
 /datum/outfit/job/officer/cadet
 	name = "Кадет"
@@ -318,6 +326,8 @@
 	dufflebag = /obj/item/storage/backpack/duffel/medical
 	box = /obj/item/storage/box/survival/brigphys
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/medical
+	beret_variant = /obj/item/clothing/head/beret/brigphys
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/security
 
 /datum/job/security/pilot
 	title = JOB_TITLE_PILOT
@@ -367,3 +377,5 @@
 	dufflebag = /obj/item/storage/backpack/duffel/security
 	box = /obj/item/storage/box/survival/survival_security/pilot
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/security
+	beret_variant = /obj/item/clothing/head/beret/sec/black
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/security

--- a/code/game/jobs/job/service.dm
+++ b/code/game/jobs/job/service.dm
@@ -57,6 +57,7 @@
 		/obj/item/melee/baton/telescopic = 1,
 	)
 	implants = list()
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/hop
 
 /datum/job/service
 	abstract_type = /datum/job/service

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -79,6 +79,8 @@
 	satchel = /obj/item/storage/backpack/satchel_cap
 	dufflebag = /obj/item/storage/backpack/duffel/captain
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/security
+	beret_variant = /obj/item/clothing/head/caphat/beret
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/captain
 
 /datum/outfit/job/captain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()

--- a/code/game/jobs/job/supply.dm
+++ b/code/game/jobs/job/supply.dm
@@ -50,6 +50,7 @@
 	)
 	head = /obj/item/clothing/head/cowboyhat/tan
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/meson
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/cargo/qm
 
 /datum/job/supply
 	abstract_type = /datum/job/supply
@@ -92,6 +93,7 @@
 	id = /obj/item/card/id/supply
 	pda = /obj/item/pda/cargo
 	backpack = /obj/item/storage/backpack/cargo
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/cargo
 
 /datum/job/supply/mining
 	title = JOB_TITLE_MINER
@@ -141,6 +143,7 @@
 	satchel = /obj/item/storage/backpack/satchel_explorer
 	box = /obj/item/storage/box/survival/survival_mining
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/meson
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/miner
 
 /datum/outfit/job/mining/equipped
 	toggle_helmet = TRUE
@@ -209,3 +212,5 @@
 		/obj/item/wormhole_jaunter = 1,
 	)
 	implant_variant = /obj/item/organ/internal/cyberimp/eyes/hud/medical
+	beret_variant = /obj/item/clothing/head/beret/mining_medic
+	coat_variant = /obj/item/clothing/suit/hooded/wintercoat/cargo

--- a/code/modules/client/preference/loadout/loadout.dm
+++ b/code/modules/client/preference/loadout/loadout.dm
@@ -59,11 +59,14 @@ GLOBAL_LIST_EMPTY(gear_datums)
 	path = npath
 	location = nlocation
 
+/datum/gear_data/proc/get_path()
+	return path
+
 /datum/gear/proc/spawn_item(location, metadata)
 	var/datum/gear_data/gear_data = new(path, location)
 	for(var/datum/gear_tweak/tweak in gear_tweaks)
 		tweak.tweak_gear_data(metadata["[tweak]"], gear_data)
-	var/gear_path = gear_data.path || path
+	var/gear_path = gear_data.get_path() || get_spawn_path()
 	var/item = new gear_path(gear_data.location)
 	if(!item)
 		return

--- a/code/modules/client/preference/loadout/loadout.dm
+++ b/code/modules/client/preference/loadout/loadout.dm
@@ -62,11 +62,11 @@ GLOBAL_LIST_EMPTY(gear_datums)
 /datum/gear_data/proc/get_path()
 	return path
 
-/datum/gear/proc/spawn_item(location, metadata)
+/datum/gear/proc/spawn_item(location, metadata, datum/outfit/job/job)
 	var/datum/gear_data/gear_data = new(path, location)
 	for(var/datum/gear_tweak/tweak in gear_tweaks)
 		tweak.tweak_gear_data(metadata["[tweak]"], gear_data)
-	var/gear_path = gear_data.get_path() || get_spawn_path()
+	var/gear_path = get_spawn_path(job) || gear_data.get_path()
 	var/item = new gear_path(gear_data.location)
 	if(!item)
 		return
@@ -89,5 +89,5 @@ GLOBAL_LIST_EMPTY(gear_datums)
 /datum/gear/proc/get_header_tips()
 	return
 
-/datum/gear/proc/get_spawn_path(job_name, metadata)
+/datum/gear/proc/get_spawn_path(datum/outfit/job/job)
 	return path

--- a/code/modules/client/preference/loadout/loadout_hat.dm
+++ b/code/modules/client/preference/loadout/loadout_hat.dm
@@ -231,8 +231,9 @@
 /datum/gear/hat/universal_beret
 	index_name = "universal beret"
 	display_name = "берет, универсальный"
+	path = /obj/item/clothing/head/beret
 
-/datum/gear/hat/beret/resovle_path()
+/datum/gear/hat/universal_beret/get_spawn_path(datum/outfit/job/job)
 	if(!istype(job) || !job.beret_variant)
 		return null
 	return job.beret_variant

--- a/code/modules/client/preference/loadout/loadout_hat.dm
+++ b/code/modules/client/preference/loadout/loadout_hat.dm
@@ -227,3 +227,12 @@
 /datum/gear/hat/headband/New()
 	..()
 	gear_tweaks += new /datum/gear_tweak/color(parent = src)
+
+/datum/gear/hat/universal_beret
+	index_name = "universal beret"
+	display_name = "берет, универсальный"
+
+/datum/gear/hat/beret/resovle_path()
+	if(!istype(job) || !job.beret_variant)
+		return null
+	return job.beret_variant

--- a/code/modules/client/preference/loadout/loadout_suit.dm
+++ b/code/modules/client/preference/loadout/loadout_suit.dm
@@ -93,8 +93,9 @@
 /datum/gear/suit/coat/universal
 	index_name = "universal winter coat"
 	display_name = "универсальная зимняя куртка"
+	path = /obj/item/clothing/suit/hooded/wintercoat
 
-/datum/gear/suit/coat/universal/resovle_path()
+/datum/gear/suit/coat/universal/get_spawn_path(datum/outfit/job/job)
 	if(!istype(job) || !job.coat_variant)
 		return null
 	return job.coat_variant

--- a/code/modules/client/preference/loadout/loadout_suit.dm
+++ b/code/modules/client/preference/loadout/loadout_suit.dm
@@ -90,6 +90,15 @@
 	path = /obj/item/clothing/suit/hooded/wintercoat/hop
 	allowed_roles = list(JOB_TITLE_HOP)
 
+/datum/gear/suit/coat/universal
+	index_name = "universal winter coat"
+	display_name = "универсальная зимняя куртка"
+
+/datum/gear/suit/coat/universal/resovle_path()
+	if(!istype(job) || !job.coat_variant)
+		return null
+	return job.coat_variant
+
 //LABCOATS
 /datum/gear/suit/labcoat
 	index_name = "labcoat"


### PR DESCRIPTION

## Что этот ПР делает
Добавляет в лоудаут два новых предмета - универсальный берет и универсальную куртку.
По взятии данных предметов, на кукле появляется берет или курта, подходящие для выбранной профессии. В случае, если у нужной профессии нет нужного типа одежды, кукла появляется со стандартным беретом/курткой.
## Демонстрация изменений

https://github.com/user-attachments/assets/bea27fcd-bb0e-4639-b1c4-e29b8dad9e9b
## Список изменений
:cl:
tweak: Добавлено два новых типа одежды в лоудаут
/:cl:
