### PR TITLE
tweak: Хелп интент уменьшает кнокдаун

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -257,6 +257,7 @@
 		AdjustParalysis(-6 SECONDS)
 		AdjustStunned(-6 SECONDS)
 		AdjustWeakened(-6 SECONDS)
+		AdjustKnockdown(-6 SECONDS)
 		adjustStaminaLoss(-10)
 
 		if(body_position != STANDING_UP && !resting && !buckled)


### PR DESCRIPTION

## Что этот ПР делает
Если тыкать в хелпе карбона, то ты уменьшаешь его кнокдаун.
## Почему это хорошо для игры
На кнокдаун перешли, а в хелпе не добавили.
## Список изменений
:cl:
tweak: Хелп интент уменьшает кнокдаун у карбонов.
/:cl:
