### PR TITLE
bugfix: crate mimic nerf(bug)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -62,7 +62,7 @@
 /mob/living/simple_animal/hostile/mimic/crate/DestroyPathToTarget()
 	..()
 	if(prob(90))
-		icon_state = "[initial(icon_state)]open"
+		icon_state = "[initial(icon_state)]_open"
 	else
 		icon_state = initial(icon_state)
 


### PR DESCRIPTION

## Что этот ПР делает
чиним древний баг с невидимым мимиком
https://discord.com/channels/617003227182792704/1470338773610008748
## Почему это хорошо для игры
меньше багов
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
отсутствуют
</p>
</details>

## Список изменений
:cl:
bugfix: мимики ящиков больше не могут быть невидимыми
/:cl:
