### PR TITLE
Ремонт руны призыва культа крови

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -206,13 +206,14 @@ structure_check() searches for nearby cultist structures required for the invoca
  * * target - Location to teleport to
  */
 /obj/effect/rune/proc/teleport_effect(mob/living/user, turf/location, target)
+	var/trait_source = UNIQUE_TRAIT_SOURCE(src) // Перехватываем до возможного qdel, который сотрет руну.
 	new /obj/effect/temp_visual/dir_setting/cult/phase/out(location, user.dir)
 	new /obj/effect/temp_visual/dir_setting/cult/phase(target, user.dir)
 	// So that the mob only appears after the effect is finished
-	ADD_TRAIT(user, TRAIT_NO_TRANSFORM, UNIQUE_TRAIT_SOURCE(src))
+	ADD_TRAIT(user, TRAIT_NO_TRANSFORM, trait_source)
 	user.invisibility = INVISIBILITY_MAXIMUM
 	sleep(1.2 SECONDS)
-	REMOVE_TRAIT(user, TRAIT_NO_TRANSFORM, UNIQUE_TRAIT_SOURCE(src))
+	REMOVE_TRAIT(user, TRAIT_NO_TRANSFORM, trait_source)
 	user.invisibility = 0
 
 /obj/effect/rune/proc/do_invoke_glow()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -206,7 +206,7 @@ structure_check() searches for nearby cultist structures required for the invoca
  * * target - Location to teleport to
  */
 /obj/effect/rune/proc/teleport_effect(mob/living/user, turf/location, target)
-	var/trait_source = UNIQUE_TRAIT_SOURCE(src) // Перехватываем до возможного qdel, который сотрет руну.
+	var/trait_source = UNIQUE_TRAIT_SOURCE(src)
 	new /obj/effect/temp_visual/dir_setting/cult/phase/out(location, user.dir)
 	new /obj/effect/temp_visual/dir_setting/cult/phase(target, user.dir)
 	// So that the mob only appears after the effect is finished


### PR DESCRIPTION
 Исправлен баг, при котором руна призыва культиста (Summon Cultist) оставляла игрока без возможности двигаться после телепортации.
## Что этот ПР делает

- Исправлен баг, при котором руна призыва культиста (Summon Cultist) оставляла игрока без возможности двигаться после телепортации.
- Причина: UNIQUE_TRAIT_SOURCE(src) генерировал разную строку для ADD_TRAIT и REMOVE_TRAIT` так как к моменту снятия трейта руна уже была удалена (`qdel(src)`).
- Исправление: значение UNIQUE_TRAIT_SOURCE(src) сохраняется в локальную переменную в начале teleport_effect(), пока src ещё валиден. Теперь оба вызова гарантированно используют один и тот же источник.

## Почему это хорошо для игры
При использовании руны Summon Cultist игрок после телепортации не мог двигаться самостоятельно. Его можно было тащить за собой, но он не мог ни идти, ни ползти. 



## Список изменений

:cl:
bugfix: Руна призыва культиста больше не блокирует движение после телепортации.
/:cl: