### PR TITLE
map: Зарядник борга для додзё

### DIFF
--- a/_maps/map_files/generic/CentComm.dmm
+++ b/_maps/map_files/generic/CentComm.dmm
@@ -4557,17 +4557,15 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/administration)
 "cqi" = (
-/obj/structure/table/abductor{
-	color = "#99ff99";
-	name = "table"
-	},
-/obj/item/storage/box/manacles{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/storage/box/manacles{
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/double/ninja{
 	pixel_x = -3;
-	pixel_y = 2
+	pixel_y = 3
+	},
+/obj/item/tank/internals/emergency_oxygen/double/ninja,
+/obj/item/tank/internals/emergency_oxygen/double/ninja{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/simulated/floor/indestructible{
 	icon_state = "floorgrime"
@@ -6832,27 +6830,24 @@
 	},
 /area/centcom/ninja/holding)
 "duk" = (
-/obj/structure/sign/poster/official/air2{
-	pixel_y = -32
+/obj/structure/table/abductor{
+	color = "#99ff99";
+	name = "table"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen{
-	maximum_pressure = 50000
+/obj/item/storage/box/manacles{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/storage/box/manacles{
+	pixel_x = -3;
+	pixel_y = 2
 	},
 /turf/simulated/floor/indestructible{
 	icon_state = "floorgrime"
 	},
 /area/centcom/ninja/holding)
 "dum" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen/double/ninja{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/tank/internals/emergency_oxygen/double/ninja,
-/obj/item/tank/internals/emergency_oxygen/double/ninja{
-	pixel_x = 3;
-	pixel_y = -3
-	},
+/obj/machinery/recharge_station/upgraded,
 /turf/simulated/floor/indestructible{
 	icon_state = "floorgrime"
 	},
@@ -45373,6 +45368,17 @@
 	icon_state = "neutralfull"
 	},
 /area/shuttle/escape)
+"uFl" = (
+/obj/structure/sign/poster/official/air2{
+	pixel_y = -32
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen{
+	maximum_pressure = 50000
+	},
+/turf/simulated/floor/indestructible{
+	icon_state = "floorgrime"
+	},
+/area/centcom/ninja/holding)
 "uFn" = (
 /obj/structure/table/abductor{
 	color = "#99ff99";
@@ -88651,7 +88657,7 @@ bhg
 nWf
 bDR
 qDI
-dMb
+uFl
 dMb
 jSw
 dVZ
@@ -89421,7 +89427,7 @@ bRM
 cjy
 nEN
 bGP
-bRx
+bRM
 duk
 dMb
 jSw

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -35,6 +35,7 @@
 /obj/structure/shuttle/engine/platform
 	name = "platform"
 	icon_state = "platform"
+	layer = TABLE_LAYER
 
 /obj/structure/shuttle/engine/propulsion
 	name = "propulsion"


### PR DESCRIPTION

## Что этот ПР делает
Добавляет зарядник борга в додзё ниндзи.
Понижает леер платформы, чтобы она не перекрывала сами движки.
## Почему это хорошо для игры
[Обсуждение зарядника](https://discord.com/channels/617003227182792704/1539904149704019999/1539904149704019999).
Красиво.
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>
Было
<img width="1627" height="625" alt="image" src="https://github.com/user-attachments/assets/2ddfd216-0efc-433c-abc2-5f587cc1dbda" />

Стало
<img width="1554" height="565" alt="image" src="https://github.com/user-attachments/assets/cd8955ee-2259-4ffc-999a-5c8c633a616a" />

</p>
</details>

## Список изменений
:cl:
map: Добавил в додзё зарядник борга.
/:cl:
