### PR TITLE
balance: Дирслеш для cqc

### DIFF
--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -3,7 +3,6 @@
 	weight = 7
 	block_chance = 75
 	has_explaination_verb = TRUE
-	has_dirslash = FALSE
 	grab_speed = 2 SECONDS
 	grab_resist_chances = list(
 		MARTIAL_GRAB_AGGRESSIVE = 40,


### PR DESCRIPTION

## Что этот ПР делает
Возвращает cqc атаку по направлению без необходимости тыкать прямо по мобу.
## Почему это хорошо для игры
Балансеры талк.
<img width="1241" height="822" alt="image" src="https://github.com/user-attachments/assets/1dad0389-b72a-4cfa-96d8-bc5549822e12" />
## Список изменений
:cl:
balance: CQC получил дирслеш.
/:cl:
