### PR TITLE
Мультитул больше не бьёт реактор

### DIFF
--- a/code/modules/power/fission/gas_node.dm
+++ b/code/modules/power/fission/gas_node.dm
@@ -136,17 +136,28 @@
 		audible_message(span_notice("The gas node pings as it connects to the reactor."))
 
 /obj/machinery/atmospherics/unary/reactor_gas_node/multitool_act(mob/living/user, obj/item/I)
+	. = TRUE
 	to_chat(user, span_notice("You begin to reverse the gas flow direction..."))
-	if(do_after(user, 1 SECONDS, TRUE, src))
+	if(do_after(user, 1 SECONDS, src))
 		intake_vent = !intake_vent
 		if(intake_vent)
 			name = "Reactor Gas Intake"
 		else
 			name = "Reactor Gas Extractor"
-	return ..()
 
 /obj/machinery/atmospherics/unary/reactor_gas_node/moderator
 	name = "Reactor Gas Moderator"
+
+
+/obj/machinery/atmospherics/unary/reactor_gas_node/moderator/Initialize(mapload)
+	. = ..()
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/machine/reactor_moderator_gas_node(src)
+	component_parts += new /obj/item/stack/sheet/metal(src, 2)
+	component_parts += new /obj/item/stack/cable_coil(src, 2)
+	initialize_directions = dir
+	RefreshParts()
+	update_icon()
 
 /obj/machinery/atmospherics/unary/reactor_gas_node/moderator/get_reactor_gas()
 	return linked_reactor.moderator_gas

--- a/code/modules/power/fission/nuclear_misc.dm
+++ b/code/modules/power/fission/nuclear_misc.dm
@@ -90,6 +90,7 @@
 	return TRUE
 
 /obj/machinery/computer/fission_monitor/multitool_act(mob/living/user, obj/item/I)
+	. = TRUE
 	if(!I.multitool_check_buffer(user))
 		return
 	var/obj/item/multitool/multitool = I

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -250,6 +250,7 @@
 	return TRUE
 
 /obj/machinery/power/compressor/multitool_act(mob/living/user, obj/item/I)
+	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 
@@ -667,7 +668,9 @@
 	ui_interact(user)
 
 /obj/machinery/computer/turbine_computer/multitool_act(mob/living/user, obj/item/I)
-	. = ..()
+	. = TRUE
+	if(!I.multitool_check_buffer(user))
+		return
 	var/obj/item/multitool/tool = I
 	compressor = tool.buffer
 	to_chat(user, span_notice("You link [src] to the turbine compressor in [I]'s buffer."))


### PR DESCRIPTION

## Что этот ПР делает

Чинит пару взаимодействий мультитулом.
Чинит плату, что выпадает при разборе входе раундстартовой Reactor Gas Moderator.

## Почему это хорошо для игры

Когда игрок бьёт мультитулом по предмету - он думает что мультитул не может работать на него.

## Список изменений
:cl:
bugfix: Персонаж больше не бьёт мультитулом по турбине, его монитору или монитору ядерного реактора
bugfix: Мультитул теперь правильно меняет направление газов в ядерном реакторе
/:cl:
