### PR TITLE
Исправление работы микрофона рации независимо от включенности динамика рации.dm

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -203,9 +203,7 @@ GLOBAL_LIST_INIT(default_pirate_channels, list(
 
 	if(listening)
 		recalculate_channels()
-		return
 
-	reset_channels()
 
 /**
  * setter for broadcasting that makes us not hearing sensitive if not broadcasting and hearing sensitive if broadcasting
@@ -250,8 +248,7 @@ GLOBAL_LIST_INIT(default_pirate_channels, list(
 	if(new_frequency)
 		frequency = new_frequency
 
-	if(listening && on)
-		radio_connection = SSradio.add_object(src, frequency, RADIO_CHAT)
+	radio_connection = SSradio.add_object(src, frequency, RADIO_CHAT)
 
 /obj/item/radio/emag_act(mob/user)
 	if(!user.mind.special_role && !is_admin(user) || !hidden_uplink)


### PR DESCRIPTION
Исправлен баг, при котором при выключенном динамике в рации переставал работать и микрофон


<!-- Пишите **ПОД** Заголовками и **НАД** комментариями, иначе Вашего текста будет не видно. -->
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название Вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

## Что этот ПР делает
- Исправлен баг, при котором при выключенном динамике в рации (listening = FALSE) переставал работать и микрофон — сообщения не отправлялись.
- Причина: `set_listening()` вызывал `reset_channels()`, который удалял все радио соединения (`radio_connection`, `secure_radio_connections`), необходимые для передачи звука.
- Исправление: убран вызов `reset_channels()` из `set_listening()` — соединения теперь не сбрасываются при выключении динамика.
- Дополнительно: убрано условие `if(listening && on)` в `set_frequency()`, чтобы при смене частоты с выключенным динамиком соединение всё равно создавалось.
- Баг затрагивал портативные рации, гарнитуры и рации боргов. Интеркомы не были затронуты багом.

## Почему это хорошо для игры
Ранее игроки, выключив динамик (чтобы не слышать радио), не могли говорить в гарнитуру, что было нелогично и вызывало путаницу. Отключение динамика должно влиять только на приём, но не на передачу.


## Список изменений

:cl:
bugfix: Выключенный динамик больше не блокирует микрофон раций/гарнитур.
/:cl:

