### PR TITLE
tweak: Нормальная С20

### DIFF
--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(summoned_guns, list(
 	/obj/item/gun/energy/kinetic_accelerator/crossbow/large,
 	/obj/item/gun/energy/gun/nuclear,
 	/obj/item/gun/projectile/automatic/smg/saber,
-	/obj/item/gun/projectile/automatic/smg/c20r,
+	/obj/item/gun/projectile/automatic/smg/c20r/auto,
 	/obj/item/gun/projectile/automatic/l6_saw,
 	/obj/item/gun/projectile/automatic/m90,
 	/obj/item/gun/energy/alien,

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -706,7 +706,7 @@
 	new /obj/item/ammo_box/magazine/smgm45(src)
 	new /obj/item/ammo_box/magazine/smgm45(src)
 	new /obj/item/ammo_box/magazine/smgm45(src)
-	new /obj/item/gun/projectile/automatic/smg/c20r(src)
+	new /obj/item/gun/projectile/automatic/smg/c20r/auto(src)
 	new /obj/item/gun_module/muzzle/suppressor(src)
 
 /obj/item/storage/backpack/duffel/syndie/bulldogbundle

--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_INIT(mystery_box_guns, list(
 	/obj/item/gun/energy/sniperrifle/pod_pilot,
 	/obj/item/gun/projectile/automatic/aks74u,
 	/obj/item/gun/projectile/automatic/shotgun/bulldog,
-	/obj/item/gun/projectile/automatic/smg/c20r,
+	/obj/item/gun/projectile/automatic/smg/c20r/auto,
 	/obj/item/gun/projectile/automatic/smg/wt550,
 	/obj/item/gun/projectile/automatic/smg/sfg,
 	/obj/item/gun/projectile/shotgun/automatic/combat,

--- a/code/modules/awaymissions/mission_code/spacebattle.dm
+++ b/code/modules/awaymissions/mission_code/spacebattle.dm
@@ -368,7 +368,7 @@
 		if(47 to 50) // 3%
 			SynRange = /obj/item/ammo_box/magazine/smgm45
 		if(50 to 51) // 1%
-			SynRange = /obj/item/gun/projectile/automatic/smg/c20r
+			SynRange = /obj/item/gun/projectile/automatic/smg/c20r/rusted
 		else
 			SynRange = /obj/item/ammo_casing/c10mm
 	. = ..()


### PR DESCRIPTION

## Что этот ПР делает
Заменяет базовую версию с20 на нормальную с20 из аплинка, где её забыли.
Заменил в луте из синдикат симплмобов с20 на ржавую.
## Почему это хорошо для игры
Поиграл я на лонг опсе, купил набор, а там с20, которую даже ппшки станции перестреливают. Спасибо, не надо такого другим.
Ржавую и делали, чтобы гейтеры не выходили с синдилутом из гейта, так что она как раз к месту.
## Список изменений
:cl:
tweak: Возвращение нюкеровской с20 для ритуала мага, набора с20 нюкеров, мистических коробок.
tweak: Замена базовой с20 на ржавую с20 с симпл мобов гейта спейсбаттла.
/:cl:
