### PR TITLE
tweak: Фаерлоки

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -316,8 +316,7 @@
 	. = TRUE
 	if(operating)
 		return
-	CALCULATE_SKILL_MOD(user, LOCKPICK_SPEED_MOD, lockpick_mod)
-	if(!I.use_tool(src, user, 1 SECONDS * lockpick_mod, volume = 0))
+	if(!I.use_tool(src, user, 0, volume = 0))
 		return
 	try_to_crowbar(user, I)
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -126,12 +126,17 @@
 
 	user.changeNext_move(CLICK_CD_MELEE)
 
+	var/open_time = manual_open_time
+	if(ishuman(user))
+		var/datum/strength_level/level = user.get_strength_level()
+		if(level)
+			open_time = manual_open_time / max(0.1, level.door_open_speed_modifier)
+
 	user.visible_message(
 		span_notice("[user] tries to open [src] manually."),
 		span_notice("You operate the manual lever on [src]."))
 
-	CALCULATE_SKILL_MOD(user, LOCKPICK_SPEED_MOD, lockpick_mod)
-	if(do_after(user, manual_open_time * lockpick_mod, src))
+	if(do_after(user, open_time, src))
 		add_fingerprint(user)
 		user.visible_message(
 			span_notice("[user] opens [src]."),


### PR DESCRIPTION

## Что этот ПР делает
Возвращает зависимость скорости открытия фаерлока руками от силы (сейчас влияет навык взлома).
Убирает прогресс бар для открытия фаерлоков ломом.
## Почему это хорошо для игры
Почему силовой способ открытия фаерлока зависит от взлома? Ответа нет, убираем.
Фаерлоки в условиях пожаров с их ветрами стали очень неприятным препятствием.
## Список изменений
:cl:
tweak: Открытие фаерлоков руками зависит от силы.
tweak: Открытие фаерлоков ломом моментальное.
/:cl:
