### PR TITLE
Эмоут панель поменьше

### DIFF
--- a/tgui/packages/tgui/interfaces/EmotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/EmotePanel.tsx
@@ -265,36 +265,11 @@ const EmoteIcons = (props) => {
 
   return (
     <Box inline align="right">
-      <Icon
-        name="eye"
-        m={margin}
-        color={!visible ? 'red' : ''}
-        opacity={!visible ? 0.5 : 1}
-      />
-      <Icon
-        name="comment"
-        m={margin}
-        color={!audible ? 'red' : ''}
-        opacity={!audible ? 0.5 : 1}
-      />
-      <Icon
-        name="volume-up"
-        m={margin}
-        color={!sound ? 'red' : ''}
-        opacity={!sound ? 0.5 : 1}
-      />
-      <Icon
-        name="hand-paper"
-        m={margin}
-        color={!hands ? 'red' : ''}
-        opacity={!hands ? 0.5 : 1}
-      />
-      <Icon
-        name="crosshairs"
-        m={margin}
-        color={!use_params ? 'red' : ''}
-        opacity={!use_params ? 0.5 : 1}
-      />
+      {visible ? <Icon name="eye" m={margin} /> : null}
+      {audible ? <Icon name="comment" m={margin} /> : null}
+      {sound ? <Icon name="volume-up" m={margin} /> : null}
+      {hands ? <Icon name="hand-paper" m={margin} /> : null}
+      {use_params ? <Icon name="crosshairs" m={margin} /> : null}
     </Box>
   );
 };


### PR DESCRIPTION

## Что этот ПР делает

Меняет меню эмоутов, чтобы иконки не занимали пол окна

## Почему это хорошо для игры

Не болят глаза, игроки не путают что иконки делают.

## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

До

<img width="627" height="301" alt="До" src="https://github.com/user-attachments/assets/61783289-3e55-4ed3-86f6-e0faf24b1c3a" />

После

<img width="623" height="498" alt="После" src="https://github.com/user-attachments/assets/dc3b4b02-1bec-433f-9b27-57a088683283" />

</p>
</details>

## Список изменений
:cl:
tweak: Уменьшил количество иконок в эмоут панели
/:cl:
