### PR TITLE
Возможность на ходу снять огнетушитель с предохранителя

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -157,7 +157,7 @@
 		span_notice("Вы начинаете [safety ? "снимать" : "ставить"] предохранитель...")
 	)
 
-	if(!user || !do_after(user, 0.5 SECONDS, target = src) || QDELETED(src))
+	if(!user || !do_after(user, 0.5 SECONDS, target = src, timed_action_flags = DA_IGNORE_USER_LOC_CHANGE|DA_IGNORE_LYING) || QDELETED(src))
 		return
 
 	safety = !safety


### PR DESCRIPTION

## Что этот ПР делает
Мне было лень проставлять флаги для этого ду_афтера при его добавлении. Но сейчас чет надоело: обычно огнетушители нужны когда тебя сдувает ветром или толкают убегающие горящие люди
## Почему это хорошо для игры
Больше удобства при работе с огнетушителем
## Демонстрация изменений
<details><summary>Изображения и видео</summary>
<p>

</p>
</details>

## Список изменений
:cl:

tweak: Снятие огнетушителя с предохранителя на ходу.

/:cl:
