### PR TITLE
QoL для огнестрела

### DIFF
--- a/code/__DEFINES/gun.dm
+++ b/code/__DEFINES/gun.dm
@@ -7,7 +7,7 @@
 #define ATTACHMENT_SLOT_UNDER "under"
 /// Sibyl slot identifier
 #define ATTACHMENT_SLOT_SIBYL "sibyl"
-/// Muzzle slot identifier
+/// Stock slot identifier
 #define ATTACHMENT_SLOT_STOCK "stock"
 
 // Keys for attachment X/Y offset values

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -57,6 +57,39 @@
 	initial_mats = materials.Copy()
 	update_mat_value()
 
+	register_context()
+	register_item_context()
+
+/obj/item/ammo_box/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	if(held_item == src && length(stored_ammo))
+		context[SCREENTIP_CONTEXT_LMB] = "Разрядить"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(isammocasing(held_item))
+		var/obj/item/ammo_casing/casing = held_item
+		if(!ammo_suitability(casing))
+			return
+		context[SCREENTIP_CONTEXT_LMB] = "Зарядить"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(isammobox(held_item) && held_item != src)
+		var/obj/item/ammo_box/box = held_item
+		if(!ammo_suitability(box.get_round(TRUE))) // no hint if there's no ammo to get
+			return
+		context[SCREENTIP_CONTEXT_LMB] = "Зарядить"
+		return CONTEXTUAL_SCREENTIP_SET
+
+/obj/item/ammo_box/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
+	. = ..()
+
+	if(isammocasing(target) && !user.is_in_hands(target))
+		if(!ammo_suitability(target))
+			return
+		context[SCREENTIP_CONTEXT_LMB] = "Зарядить"
+		return CONTEXTUAL_SCREENTIP_SET
+
 /obj/item/ammo_box/Destroy()
 	QDEL_LIST(stored_ammo)
 	stored_ammo = null
@@ -84,7 +117,7 @@
 	if(!istype(mag_ammo))
 		return ""
 
-	if(caliber && max_ammo) // Text references a 'магазин' as only magazines generally have the caliber variable initialized
+	if(caliber && max_ammo)
 		readout += "<b><u>ВМЕСТИМОСТЬ</u></b>"
 		readout += "- Вмещает в себя вплоть до <b>[max_ammo]</b> боеприпас[declension_ru(max_ammo, "а", "ов", "ов")] калибра <b>[caliber]</b>."
 
@@ -243,9 +276,6 @@
 		balloon_alert(user, "патрон извлечён")
 		update_appearance(UPDATE_ICON)
 		user.put_in_hands(casing)
-
-/obj/item/ammo_box/click_alt(mob/user)
-	attack_self(user)
 
 /obj/item/ammo_box/update_icon_state()
 	var/icon_base = icon_prefix ? icon_prefix : initial(icon_state)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -63,23 +63,29 @@
 /obj/item/ammo_box/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 
+	if(length(stored_ammo))
+		context[SCREENTIP_CONTEXT_RMB] = "Разрядить"
+		. = CONTEXTUAL_SCREENTIP_SET
+
 	if(held_item == src && length(stored_ammo))
 		context[SCREENTIP_CONTEXT_LMB] = "Разрядить"
-		return CONTEXTUAL_SCREENTIP_SET
+		. = CONTEXTUAL_SCREENTIP_SET
 
 	if(isammocasing(held_item))
 		var/obj/item/ammo_casing/casing = held_item
 		if(!ammo_suitability(casing))
 			return
 		context[SCREENTIP_CONTEXT_LMB] = "Зарядить"
-		return CONTEXTUAL_SCREENTIP_SET
+		. = CONTEXTUAL_SCREENTIP_SET
 
 	if(isammobox(held_item) && held_item != src)
 		var/obj/item/ammo_box/box = held_item
 		if(!ammo_suitability(box.get_round(TRUE))) // no hint if there's no ammo to get
 			return
 		context[SCREENTIP_CONTEXT_LMB] = "Зарядить"
-		return CONTEXTUAL_SCREENTIP_SET
+		. = CONTEXTUAL_SCREENTIP_SET
+
+	return .
 
 /obj/item/ammo_box/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
 	. = ..()
@@ -276,6 +282,21 @@
 		balloon_alert(user, "патрон извлечён")
 		update_appearance(UPDATE_ICON)
 		user.put_in_hands(casing)
+
+/obj/item/ammo_box/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+
+	attack_self(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/ammo_box/attack_self_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(.)
+		return
+
+	attack_self(user)
 
 /obj/item/ammo_box/update_icon_state()
 	var/icon_base = icon_prefix ? icon_prefix : initial(icon_state)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -189,6 +189,36 @@
 	else if(!istype(accuracy, /datum/gun_accuracy))
 		stack_trace("Invalid type [accuracy.type] found in .accuracy during /obj/item/gun Initialize()")
 
+	register_context()
+
+/obj/item/gun/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	if((isnull(held_item) || held_item == src) && user.is_in_hands(held_item))
+		for(var/slot in attachments_by_slot)
+			var/obj/item/gun_module/module = attachments_by_slot[slot]
+			if(!module?.can_detach)
+				continue
+			context[SCREENTIP_CONTEXT_ALT_LMB] = "Снять модуль"
+			. = CONTEXTUAL_SCREENTIP_SET
+			break
+
+	if(held_item == src)
+		var/obj/item/gun_module/stock/stock = attachments_by_slot[ATTACHMENT_SLOT_STOCK]
+		if(!stock)
+			return
+		context[SCREENTIP_CONTEXT_RMB] = "[stock.unfolded ? "С" : "Раз"]ложить приклад"
+		. = CONTEXTUAL_SCREENTIP_SET
+
+	if(istype(held_item, /obj/item/gun_module))
+		var/obj/item/gun_module/incoming_module = held_item
+		if(attachments_by_slot[incoming_module.slot])
+			return
+		context[SCREENTIP_CONTEXT_LMB] = "Установить модуль"
+		. = CONTEXTUAL_SCREENTIP_SET
+
+	return .
+
 /obj/item/gun/Destroy()
 	QDEL_NULL(gun_light)
 	for(var/attachment in attachments_by_slot)
@@ -212,31 +242,42 @@
 		set_gun_light(null)
 	return ..()
 
+/obj/item/gun/proc/get_attachment_module_examine_text(mob/user, slot, missing_text = "модуль отсутствует")
+	var/obj/item/gun_module/module = attachments_by_slot[slot]
+	if(!module)
+		return "[missing_text]"
+	return "[module.get_examine_icon(user)] [module.declent_ru(NOMINATIVE)]"
+
 /obj/item/gun/examine(mob/user)
 	. = ..()
-	if(attachments_by_slot[ATTACHMENT_SLOT_RAIL])
-		. += span_notice("На прицельную планку прикреплен [attachments_by_slot[ATTACHMENT_SLOT_RAIL].declent_ru(NOMINATIVE)].")
-	else if(attachable_allowed & GUN_MODULE_CLASS_RIFLE_RAIL)
-		. += span_notice("Имеет большое крепление для прицелов. Можно установить все виды прицелов.")
-	if(attachable_allowed & GUN_MODULE_CLASS_SHOTGUN_RAIL)
-		. += span_notice("Имеет среднее крепление для прицелов. Подойдут большинство прицелов и коллиматоров.")
-	else if(attachable_allowed & GUN_MODULE_CLASS_PISTOL_RAIL)
-		. += span_notice("Имеет малое крепление для прицелов. Подойдут только маленькие коллиматоры.")
 
-	if(attachments_by_slot[ATTACHMENT_SLOT_MUZZLE])
-		. += span_notice("На ствол прикручен [attachments_by_slot[ATTACHMENT_SLOT_MUZZLE].declent_ru(NOMINATIVE)].")
-	else if(attachable_allowed & GUN_MODULE_CLASS_ANY_MUZZLE)
-		. += span_notice("Имеет нарезы для крепления наствольных модулей.")
+	var/static/list/attachment_examine_data = list(
+		// Scope
+		list(GUN_MODULE_CLASS_PISTOL_RAIL, "Совместимо с малогабаритными прицелами.", "Малая прицельная планка", ATTACHMENT_SLOT_RAIL),
+		list(GUN_MODULE_CLASS_SHOTGUN_RAIL, "Совместимо со среднегабаритными прицелами.", "Средняя прицельная планка", ATTACHMENT_SLOT_RAIL),
+		list(GUN_MODULE_CLASS_RIFLE_RAIL | GUN_MODULE_CLASS_SNIPER_RAIL, "Совместимо с крупногабаритными прицелами.", "Большая прицельная планка", ATTACHMENT_SLOT_RAIL),
+		// Muzzle
+		list(GUN_MODULE_CLASS_ANY_MUZZLE, "Совместимо с дульными модулями.", "Нарезы на стволе", ATTACHMENT_SLOT_MUZZLE),
+		// Underbarrel
+		list(GUN_MODULE_CLASS_PISTOL_UNDER, "Совместимо с малогабаритными подствольными модулями.", "Малая планка на цевье", ATTACHMENT_SLOT_UNDER),
+		list(GUN_MODULE_CLASS_SHOTGUN_UNDER, "Совместимо со среднегабаритными подствольными модулями.", "Средняя планка на цевье", ATTACHMENT_SLOT_UNDER),
+		list(GUN_MODULE_CLASS_RIFLE_UNDER, "Совместимо с крупногабаритными подствольными модулями.", "Большая планка на цевье", ATTACHMENT_SLOT_UNDER),
+		list(GUN_MODULE_CLASS_SNIPER_UNDER, "Совместимо с лазерными прицелами.", "Малое крепление на цевье", ATTACHMENT_SLOT_UNDER),
+		// Stock
+		list(GUN_MODULE_CLASS_SMG_STOCK, "Совместимо со специализированными прикладами.", "Замок приклада", ATTACHMENT_SLOT_STOCK)
+	)
 
-	if(attachments_by_slot[ATTACHMENT_SLOT_UNDER])
-		. += span_notice("К цевью прикреплен [attachments_by_slot[ATTACHMENT_SLOT_UNDER].declent_ru(NOMINATIVE)].")
-	else if(attachable_allowed & GUN_MODULE_CLASS_PISTOL_UNDER)
-		. += span_notice("Имеет маленькую планку на цевье для крепление пистолетного фонаря.")
-	else if(attachable_allowed & (GUN_MODULE_CLASS_RIFLE_UNDER|GUN_MODULE_CLASS_SHOTGUN_UNDER))
-		. += span_notice("Имеет большую планку на цевье для крепление большого фонаря или рукоятки.")
+	for(var/list/entry in attachment_examine_data)
+		var/flag_mask = entry[1]
+		if(!(attachable_allowed & flag_mask))
+			continue
+		var/tooltip_text = entry[2]
+		var/tooltip_label = entry[3]
+		var/slot = entry[4]
+		. += span_notice("[span_tooltip(tooltip_text, tooltip_label)]: [get_attachment_module_examine_text(user, slot)]")
 
 	if(unique_rename)
-		. += span_notice("Используйте ручку чтобы переименовать его.")
+		. += span_notice("Используйте ручку для переименования.")
 
 
 /obj/item/gun/update_overlays()
@@ -393,11 +434,11 @@
 		return
 
 	if(!HAS_TRAIT(user, TRAIT_BADASS) && weapon_weight == WEAPON_HEAVY && (user.get_inactive_hand() || !user.has_inactive_hand() || (user.pulling && user.pull_hand != PULL_WITHOUT_HANDS)))
-		to_chat(user, span_userdanger("Для стрельбы из [declent_ru(GENITIVE)] нужны две свободные руки!"))
+		balloon_alert(user, "нужны обе руки!")
 		return
 
 	if(!HAS_TRAIT(user, TRAIT_BADASS) && weapon_weight == WEAPON_MEDIUM && isgun(user.get_inactive_hand()))
-		to_chat(user, span_userdanger("Стрелять с двух рук используя [declent_ru(ACCUSATIVE)] не получится!"))
+		balloon_alert(user, "не для двуручной стрельбы!")
 		return
 
 	if(gun_on_cooldown(user))
@@ -434,8 +475,6 @@
 	if(world.time >= delay && (!user || SEND_SIGNAL(user, COMSIG_MOB_GUN_COOLDOWN, src)))
 		return FALSE
 
-	if(world.time % 3)
-		to_chat(user, span_warning("[src] is not ready to fire again!"))
 	return TRUE
 
 ///Update the target if you draged your mouse
@@ -577,7 +616,6 @@
 	return TRUE
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user)
-	to_chat(user, span_danger("*клик*"))
 	playsound(user, 'sound/weapons/empty.ogg', 100, TRUE)
 
 /obj/item/gun/proc/shoot_live_shot(mob/living/user, atom/target, pointblank = FALSE)
@@ -615,7 +653,11 @@
 	shots_fired++
 
 /obj/item/gun/proc/do_pointblank_shot(mob/living/user, atom/target)
-	user.visible_message(span_danger("[user] стреля[PLUR_ET_YUT(user)] из [declent_ru(GENITIVE)] в упор в [target]!"), span_danger("Вы стреляете из [declent_ru(GENITIVE)] в упор в [target]!"), span_italics("Вы слышите [fire_sound_text]!"))
+	user.visible_message(
+		span_danger("[user] стреля[PLUR_ET_YUT(user)] из [declent_ru(GENITIVE)] в упор в [target]!"),
+		span_danger("Вы стреляете из [declent_ru(GENITIVE)] в упор в [target]!"),
+		span_italics("Вы слышите [fire_sound_text]!"),
+	)
 	if(pb_knockback > 0 && isliving(target))
 		do_pb_knockback(user, target)
 
@@ -810,14 +852,14 @@
 
 	if(user && !isturf(user.loc))
 		if(!silent)
-			to_chat(user, span_warning("Вы не можете переключить фонарь, находясь в [user.loc]!"))
+			balloon_alert(user, "невозможно в текущем положении!")
 		return
 
 	gun_light.on = !gun_light.on
 	if(!silent)
 		playsound(loc, 'sound/weapons/empty.ogg', 100, TRUE)
 		if(user)
-			to_chat(user, span_notice("Вы переключаете фонарь: [gun_light.on ? "вкл": "выкл"]."))
+			balloon_alert(user, "фонарь [gun_light.on ? "включён" : "выключен"]")
 	gun_light.set_light_on(gun_light.on)
 	SEND_SIGNAL(src, COMSIG_GUN_LIGHT_TOGGLE, user)
 	update_icon(UPDATE_OVERLAYS)
@@ -873,8 +915,14 @@
 	if(loc != user)
 		return NONE
 	if(user.incapacitated() || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-		to_chat(user, span_warning("Вы не можете сделать это сейчас!"))
+		balloon_alert(user, "невозможно сейчас!")
 		return CLICK_ACTION_BLOCKING
+
+	var/obj/item/held_item = user.get_active_hand()
+	if(held_item && held_item != src)
+		balloon_alert(user, "рука занята!")
+		return CLICK_ACTION_BLOCKING
+
 	try_detach_gun_module(user)
 	return CLICK_ACTION_SUCCESS
 
@@ -889,9 +937,7 @@
 			choices[module.declent_ru(NOMINATIVE)] = image(icon = module.icon, icon_state = module.icon_state)
 	if(length(choices) == 0)
 		return
-	var/choice = choices[1]
-	if(length(choices) > 1)
-		choice = show_radial_menu(user, src, choices, require_near = TRUE)
+	var/choice = show_radial_menu(user, src, choices, require_near = TRUE, autopick_single_option = FALSE)
 	if(!choice)
 		return FALSE
 	for(var/slot in attachments_by_slot)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -246,7 +246,7 @@
 	var/obj/item/gun_module/module = attachments_by_slot[slot]
 	if(!module)
 		return "[missing_text]"
-	return "[module.get_examine_icon(user)] [module.declent_ru(NOMINATIVE)]"
+	return "[module.get_examine_icon(user)] [DECLENT_RU_CAP(module, NOMINATIVE)]"
 
 /obj/item/gun/examine(mob/user)
 	. = ..()
@@ -934,7 +934,7 @@
 			continue
 		var/obj/item/gun_module/module = attachments_by_slot[slot]
 		if(module.can_detach)
-			choices[module.declent_ru(NOMINATIVE)] = image(icon = module.icon, icon_state = module.icon_state)
+			choices[DECLENT_RU_CAP(module, NOMINATIVE)] = image(icon = module.icon, icon_state = module.icon_state)
 	if(length(choices) == 0)
 		return
 	var/choice = show_radial_menu(user, src, choices, require_near = TRUE, autopick_single_option = FALSE)
@@ -944,7 +944,7 @@
 		if(!attachments_by_slot[slot])
 			continue
 		var/obj/item/gun_module/module = attachments_by_slot[slot]
-		if(module.declent_ru(NOMINATIVE) == choice)
+		if(DECLENT_RU_CAP(module, NOMINATIVE) == choice)
 			return module.detach_without_check(src, user)
 
 

--- a/code/modules/projectiles/gun_modules/_gun_module.dm
+++ b/code/modules/projectiles/gun_modules/_gun_module.dm
@@ -1,3 +1,6 @@
+/// Time to attach/detach module.
+#define GUN_MODULE_ATTACHMENT_TIME 3 SECONDS
+
 /**
  * MARK: Basic module
  */
@@ -15,9 +18,9 @@
 	var/overlay_state = "comp"
 	var/overlay_offset
 	var/buffered_overlay = null
-	//attached state variables
+	/// Attached state variables.
 	var/obj/item/gun/gun = null
-	/// Is module can detached
+	/// Can module be detached.
 	var/can_detach = TRUE
 
 /obj/item/gun_module/Destroy()
@@ -43,7 +46,8 @@
 
 /// Attaching module to gun without check, use try_attach(/obj/item/gun/target, mob/user) for checks
 /obj/item/gun_module/proc/attach_without_check(obj/item/gun/target_gun, mob/user)
-	if(!do_after(user, 1 SECONDS, target_gun))
+	balloon_alert(user, "установка модуля...")
+	if(!do_after(user, GUN_MODULE_ATTACHMENT_TIME, target_gun))
 		return FALSE
 	target_gun.attachments_by_slot[slot] = src
 	target_gun.add_attachment_overlay(src)
@@ -51,12 +55,12 @@
 	gun = target_gun
 	src.on_attach(target_gun, user)
 	SEND_SIGNAL(target_gun, COMSIG_GUN_MODULE_ATTACH, user, target_gun, src)
-	user.balloon_alert(user, "модуль установлен")
 	return TRUE
 
 /// Detaching module from gun without check, use try_detach(/obj/item/gun/target, mob/user) for checks
-/obj/item/gun_module/proc/detach_without_check(obj/item/gun/target_gun, mob/user, force = FALSE, put_in_hands = TRUE, silence = FALSE)
-	if(!force && !do_after(user, 1 SECONDS, target_gun))
+/obj/item/gun_module/proc/detach_without_check(obj/item/gun/target_gun, mob/user, force = FALSE, put_in_hands = TRUE)
+	balloon_alert(user, "снятие модуля...")
+	if(!force && !do_after(user, GUN_MODULE_ATTACHMENT_TIME, target_gun))
 		return FALSE
 	src.on_detach(target_gun, user)
 	target_gun.attachments_by_slot[slot] = null
@@ -67,8 +71,6 @@
 	else
 		src.forceMove(target_gun.drop_location())
 	gun = null
-	if(!silence)
-		user.balloon_alert(user, "модуль снят")
 	return TRUE
 
 /obj/item/gun_module/proc/create_overlay()
@@ -83,3 +85,5 @@
 
 /obj/item/gun_module/proc/on_detach(obj/item/gun/target_gun, mob/user)
 	return
+
+#undef GUN_MODULE_ATTACHMENT_TIME

--- a/code/modules/projectiles/gun_modules/_gun_module.dm
+++ b/code/modules/projectiles/gun_modules/_gun_module.dm
@@ -46,8 +46,7 @@
 
 /// Attaching module to gun without check, use try_attach(/obj/item/gun/target, mob/user) for checks
 /obj/item/gun_module/proc/attach_without_check(obj/item/gun/target_gun, mob/user)
-	balloon_alert(user, "установка модуля...")
-	if(!do_after(user, GUN_MODULE_ATTACHMENT_TIME, target_gun))
+	if(!do_after(user, GUN_MODULE_ATTACHMENT_TIME, target_gun, max_interact_count = 1))
 		return FALSE
 	target_gun.attachments_by_slot[slot] = src
 	target_gun.add_attachment_overlay(src)
@@ -59,8 +58,7 @@
 
 /// Detaching module from gun without check, use try_detach(/obj/item/gun/target, mob/user) for checks
 /obj/item/gun_module/proc/detach_without_check(obj/item/gun/target_gun, mob/user, force = FALSE, put_in_hands = TRUE)
-	balloon_alert(user, "снятие модуля...")
-	if(!force && !do_after(user, GUN_MODULE_ATTACHMENT_TIME, target_gun))
+	if(!force && !do_after(user, GUN_MODULE_ATTACHMENT_TIME, target_gun, max_interact_count = 1))
 		return FALSE
 	src.on_detach(target_gun, user)
 	target_gun.attachments_by_slot[slot] = null

--- a/code/modules/projectiles/gun_modules/stock.dm
+++ b/code/modules/projectiles/gun_modules/stock.dm
@@ -22,6 +22,16 @@
 	/// Default gun weight class buffer variable
 	var/gun_w_class
 
+/obj/item/gun_module/stock/get_ru_names()
+	return alist(
+		NOMINATIVE = "телескопический приклад",
+		GENITIVE = "телескопического приклада",
+		DATIVE = "телескопическому прикладу",
+		ACCUSATIVE = "телескопический приклад",
+		INSTRUMENTAL = "телескопическим прикладом",
+		PREPOSITIONAL = "телескопическом прикладе",
+	)
+
 /obj/item/gun_module/stock/Destroy()
 	QDEL_NULL(buffered_overlay_unfold)
 	return ..()

--- a/code/modules/projectiles/guns/ballistic/__projectile.dm
+++ b/code/modules/projectiles/guns/ballistic/__projectile.dm
@@ -6,7 +6,9 @@
 	origin_tech = "combat=2;materials=2"
 	materials = list(MAT_METAL=1000)
 	recoil = GUN_RECOIL_LOW
-	var/mag_type = /obj/item/ammo_box/magazine/m10mm //Removes the need for max_ammo and caliber info
+	/// Type of magazine compatible with this gun.
+	var/mag_type = /obj/item/ammo_box/magazine/m10mm
+	/// Currently inserted magazine.
 	var/obj/item/ammo_box/magazine/magazine
 	var/can_tactical = FALSE //check to see if the gun can tactically reload
 	/// Register fireshoot component
@@ -25,6 +27,16 @@
 	if(!base_icon_state)
 		base_icon_state = initial(icon_state)
 	update_appearance(UPDATE_ICON_STATE|UPDATE_OVERLAYS)
+
+/obj/item/gun/projectile/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(held_item == src && get_ammo())
+		context[SCREENTIP_CONTEXT_LMB] = "Разрядить"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(istype(held_item, mag_type))
+		context[SCREENTIP_CONTEXT_LMB] = "Зарядить"
+		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/gun/projectile/examine(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/_automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/_automatic.dm
@@ -8,6 +8,12 @@
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_BURSTFIRE)
 	weapon_weight = WEAPON_MEDIUM
 
+/obj/item/gun/projectile/automatic/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(held_item == src && chambered)
+		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Передёрнуть затвор"
+		return CONTEXTUAL_SCREENTIP_SET
+
 /obj/item/gun/projectile/automatic/update_icon_state()
 	icon_state = "[initial(icon_state)][magazine ? "-[magazine.max_ammo]" : ""][chambered ? "" : "-e"]"
 
@@ -25,7 +31,7 @@
 /obj/item/gun/projectile/automatic/CtrlClick(mob/user)
 	if(user.is_in_hands(src) && chambered)
 		process_chamber(TRUE, TRUE)
-		balloon_alert(user, "патрон извлечён")
+		balloon_alert(user, "затвор передёрнут")
 		playsound(loc, 'sound/weapons/gun_interactions/remove_bullet.ogg', 50, TRUE)
 		update_appearance(UPDATE_ICON_STATE|UPDATE_OVERLAYS)
 		return

--- a/code/modules/projectiles/guns/ballistic/_revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/_revolver.dm
@@ -37,6 +37,24 @@
 	if(!istype(magazine, /obj/item/ammo_box/magazine/internal/cylinder))
 		can_spin_cylinder = FALSE
 
+/obj/item/gun/projectile/revolver/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	var/obj/item/ammo_casing/incoming_ammo
+	if(isammocasing(held_item))
+		incoming_ammo = held_item
+	else if(isspeedloader(held_item))
+		var/obj/item/ammo_box/speedloader/speedloader = held_item
+		incoming_ammo = speedloader.get_round(TRUE)
+	else
+		return
+
+	if(!incoming_ammo || !magazine.ammo_suitability(incoming_ammo))
+		return
+
+	context[SCREENTIP_CONTEXT_LMB] = "Зарядить"
+	return CONTEXTUAL_SCREENTIP_SET
+
 /obj/item/gun/projectile/revolver/set_gun_user(mob/user)
 	verbs -= /obj/item/gun/projectile/revolver/proc/spin
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/_shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/_shotgun.dm
@@ -36,6 +36,27 @@
 		PREPOSITIONAL = "дробовике 12g",
 	)
 
+/obj/item/gun/projectile/shotgun/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(held_item == src && get_ammo())
+		context[SCREENTIP_CONTEXT_LMB] = "Передёрнуть затвор"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	var/obj/item/ammo_casing/incoming_ammo
+	if(isammocasing(held_item))
+		incoming_ammo = held_item
+	else if(isspeedloader(held_item))
+		var/obj/item/ammo_box/speedloader/speedloader = held_item
+		incoming_ammo = speedloader.get_round(TRUE)
+	else
+		return
+
+	if(!incoming_ammo || !magazine.ammo_suitability(incoming_ammo))
+		return
+
+	context[SCREENTIP_CONTEXT_LMB] = "Зарядить"
+	return CONTEXTUAL_SCREENTIP_SET
+
 /obj/item/gun/projectile/shotgun/attackby(obj/item/item, mob/user, params)
 	if(speedloader_reload(item, user))
 		return ATTACK_CHAIN_PROCEED

--- a/code/modules/projectiles/guns/ballistic/bolt_action_rifles.dm
+++ b/code/modules/projectiles/guns/ballistic/bolt_action_rifles.dm
@@ -29,6 +29,12 @@
 		PREPOSITIONAL = "винтовке Мосина",
 	)
 
+/obj/item/gun/projectile/shotgun/boltaction/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(held_item == src)
+		context[SCREENTIP_CONTEXT_LMB] = "[bolt_open ? "За" : "От"]крыть затвор"
+		return CONTEXTUAL_SCREENTIP_SET
+
 /obj/item/gun/projectile/shotgun/boltaction/pump(mob/M)
 	playsound(M, 'sound/weapons/gun_interactions/rifle_load.ogg', 60, TRUE)
 	if(bolt_open)

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -35,6 +35,27 @@
 		PREPOSITIONAL = "деревянном луке",
 	)
 
+/obj/item/gun/projectile/bow/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(held_item == src && chambered)
+		context[SCREENTIP_CONTEXT_LMB] = "[ready_to_fire ? "Натянуть" : "Ослабить"] тетиву"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(!magazine)
+		return
+
+	var/obj/item/ammo_casing/incoming_ammo
+	if(isammocasing(held_item))
+		incoming_ammo = held_item
+	else
+		return
+
+	if(!magazine.ammo_suitability(incoming_ammo))
+		return
+
+	context[SCREENTIP_CONTEXT_LMB] = "Установить стрелу"
+	return CONTEXTUAL_SCREENTIP_SET
+
 /obj/item/gun/projectile/bow/proc/update_state()
 	update_slowdown()
 	update_icon(UPDATE_ICON_STATE)

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -38,7 +38,7 @@
 /obj/item/gun/projectile/bow/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	if(held_item == src && chambered)
-		context[SCREENTIP_CONTEXT_LMB] = "[ready_to_fire ? "Натянуть" : "Ослабить"] тетиву"
+		context[SCREENTIP_CONTEXT_LMB] = "[ready_to_fire ? "Ослабить" : "Натянуть"] тетиву"
 		return CONTEXTUAL_SCREENTIP_SET
 
 	if(!magazine)

--- a/code/modules/projectiles/guns/ballistic/grenade_launchers_1.dm
+++ b/code/modules/projectiles/guns/ballistic/grenade_launchers_1.dm
@@ -17,7 +17,7 @@
 	recoil = GUN_RECOIL_MEGA
 	var/opened = FALSE
 
-/obj/item/gun/projectile/bombarda/bombplet/get_ru_names()
+/obj/item/gun/projectile/bombarda/get_ru_names()
 	return alist(
 		NOMINATIVE = "кустарный гранатомет",
 		GENITIVE = "кустарного гранатомета",
@@ -26,6 +26,27 @@
 		INSTRUMENTAL = "кустарным гранатометом",
 		PREPOSITIONAL = "кустарном гранатомете",
 	)
+
+/obj/item/gun/projectile/bombarda/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(held_item == src)
+		context[SCREENTIP_CONTEXT_LMB] = "[opened ? "За" : "От"]крыть"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(!magazine)
+		return
+
+	var/obj/item/ammo_casing/incoming_ammo
+	if(isammocasing(held_item))
+		incoming_ammo = held_item
+	else
+		return
+
+	if(!magazine.ammo_suitability(incoming_ammo))
+		return
+
+	context[SCREENTIP_CONTEXT_LMB] = "Зарядить"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/gun/projectile/bombarda/attackby(obj/item/item, mob/user, params)
 	if(isammocasing(item))

--- a/code/modules/projectiles/guns/ballistic/grenade_launchers_2.dm
+++ b/code/modules/projectiles/guns/ballistic/grenade_launchers_2.dm
@@ -31,7 +31,7 @@
 /obj/item/gun/projectile/revolver/grenadelauncher/multi/cyborg/attack_self()
 	return
 
-// MARK: PML-8 rocket launcher
+// MARK: PML-8
 /obj/item/gun/projectile/revolver/rocketlauncher //nice revolver you got here
 	name = "PML-8"
 	desc = "A reusable rocket propelled grenade launcher. The words \"NT this way\" and an arrow have been written near the barrel."
@@ -139,7 +139,7 @@
 		sleep(2 SECONDS)
 		return OXYLOSS
 
-// MARK: RPG-232 rocket launcher
+// MARK: RPG-232
 /obj/item/gun/projectile/revolver/rocketlauncher/rpg232
 	name = "RPG-232"
 	desc = "Разработанный в ТСФ многоразовый гранатомет, так и не поступивший на вооружение Федерации. Модель стала популярна среди тяжеловооруженных отрядов ОЗА \"Нанотрейзен\"."

--- a/code/modules/projectiles/guns/ballistic/lmg.dm
+++ b/code/modules/projectiles/guns/ballistic/lmg.dm
@@ -24,7 +24,13 @@
 		ATTACHMENT_SLOT_UNDER = list(ATTACHMENT_OFFSET_X = 7, ATTACHMENT_OFFSET_Y = -11),
 	)
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOMATIC)
-	var/cover_open = 0
+	var/cover_open = FALSE
+
+/obj/item/gun/projectile/automatic/l6_saw/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(held_item == src)
+		context[SCREENTIP_CONTEXT_LMB] = "[cover_open ? "За" : "От"]крыть крышку"
+		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/gun/projectile/automatic/l6_saw/get_ru_names()
 	return alist(


### PR DESCRIPTION
## Что этот ПР делает

1. Добавлено множество скринтипов для стволов, магазинов, пачек с патронами и самих патронов
2. Инфа об оружейных модулях в поле осмотра оружия переписана с целью улучшения читаемости
3. Балуны, ру неймы, переводы
4. Доставание патронов из коробок альт-кликом заменено на ПКМ

## Почему это хорошо для игры

Будь ты проклят, Вова Конс.

## Демонстрация изменений

https://github.com/user-attachments/assets/e8d339b1-15d4-4af9-9f25-ad4bf8689c9f

## Список изменений

:cl:
qol: Новые контекстные подсказки для огнестрела
qol: Улучшена опись об оружейных модулях при осмотре оружия
qol: Патроны из коробок и магазинов достаются ПКМом вместо альт-клика
/:cl:
