### PR TITLE
Автошаттл вызывается независимо от всего

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -127,7 +127,7 @@ SUBSYSTEM_DEF(ticker)
 			mode.process_job_tasks()
 
 			if(world.time > next_autotransfer)
-				SSvote.initiate_vote(/datum/vote/crew_transfer, "Autotransfer")
+				SSvote.initiate_vote(/datum/vote/crew_transfer, "Autotransfer", forced = TRUE)
 				next_autotransfer = world.time + CONFIG_GET(number/vote_autotransfer_interval)
 
 			var/game_finished = SSshuttle.emergency?.mode == SHUTTLE_ENDGAME || mode.station_was_nuked

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -117,7 +117,7 @@
 				SSsecurity_level.set_level(SEC_LEVEL_RED)
 		if(BLOB_DEATH_REPORT_FOURTH)
 			blob_stage = BLOB_STAGE_ZERO
-			SSvote.initiate_vote(/datum/vote/crew_transfer, "Autotransfer")
+			SSvote.initiate_vote(/datum/vote/crew_transfer, "Autotransfer", forced = TRUE)
 			return
 		else
 			return


### PR DESCRIPTION
<!-- Пишите **ПОД** Заголовками и **НАД** комментариями, иначе Вашего текста будет не видно. -->
<!-- Если вам необходимо отключить IconDiffBot2 или MapDiffBot2, тогда добавьте в название Вашего пр-а тэги [IDB IGNORE] или [MDB IGNORE] соответственно. -->

## Что этот ПР делает

Добавляет параметр "forced" автошаттлам.

## Почему?

Воут на шаттл возвращал `"Only admins can create crew transfer vote."`, вместо `VOTE_AVAILABLE`, от чего автоматический воут не запускался.
Форс воута решает эту проблему.

## Проблемы

Возможно, пропадёт воуты админов/игроков, что будет идти вместе с шаттлом

## Список изменений

<!-- Если Ваш PR изменяет аспекты игры, которые могут быть конкретно замечены игроками, Вы должны добавить это в список изменений. Если Ваши изменения НЕ соответствует этому списку изменений, удалите этот раздел. -->

:cl:
bugfix: Любой ценой запускается голосование за автошаттл
/:cl:

<!-- Оба тега :cl: обязательны для работы списка изменений! Вы можете указать своё имя справа от первого :cl:, если хотите переопределить username пользователя GitHub, как автора в игре. -->
<!-- Вы можете использовать несколько одинаковых префиксов (они используются только для иконки в игре) и удалять ненужные. Несмотря на некоторые теги, списки изменений должны в целом отражать то, как изменения могут повлиять на игрока, а не быть кратким содержанием PR. -->
