### PR TITLE
Игрушечный меч игрушечный

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -218,6 +218,10 @@ GLOBAL_LIST_INIT(body_zones, list(
 #define REFLECTABILITY_PHYSICAL 1
 #define REFLECTABILITY_ENERGY 2
 
+#define REFLECT_NOTHING 0
+#define REFLECT_NORMAL 1
+#define REFLECT_TOY 2
+
 //Autofire component
 /// Compatible firemode is in the gun. Wait until it's held in the user hands.
 #define AUTOFIRE_STAT_IDLE (1<<0)

--- a/code/game/gamemodes/clockwork/clockwork_items.dm
+++ b/code/game/gamemodes/clockwork/clockwork_items.dm
@@ -865,10 +865,10 @@
 
 /obj/item/clothing/suit/armor/clockwork/IsReflect(def_zone)
 	if(!ishuman(loc))
-		return FALSE
+		return REFLECT_NOTHING
 	var/mob/living/carbon/human/owner = loc
 	if(owner.wear_suit != src)
-		return FALSE
+		return REFLECT_NOTHING
 	if(enchant_type == REFLECT_SPELL && isclocker(owner))
 		playsound(loc, "sparks", 100, TRUE)
 		new /obj/effect/temp_visual/ratvar/sparks(get_turf(owner))
@@ -877,8 +877,8 @@
 			deplete_spell()
 		else
 			reflect_uses--
-		return TRUE
-	return FALSE
+		return REFLECT_NORMAL
+	return REFLECT_NOTHING
 
 /obj/item/clothing/suit/armor/clockwork/attack_self(mob/user)
 	. = ..()

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -681,7 +681,7 @@
 	if(isliving(loc))
 		var/mob/living/holder = loc
 		return prob(reflect_chance) && iscultist(holder) //so non-cultist can not reflect using this shield
-	return FALSE
+	return REFLECT_NOTHING
 
 /obj/item/twohanded/cult_spear
 	name = "blood halberd"

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -92,7 +92,7 @@
 
 /obj/item/clothing/suit/armor/abductor/vest/IsReflect()
 	DeactivateStealth()
-	return 0
+	return REFLECT_NOTHING
 
 /obj/item/clothing/suit/armor/abductor/vest/ui_action_click(mob/user, datum/action/action, leftclick)
 	switch(mode)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -980,7 +980,7 @@ GAME_VERB_SRC(/obj/item, verb_pickup, oview(1), "Pick up", VERB_CATEGORY_HIDDEN)
  * This proc determines if and at what% an object will reflect energy projectiles if it's in l_hand,r_hand or wear_suit
  */
 /obj/item/proc/IsReflect(def_zone)
-	return FALSE
+	return REFLECT_NOTHING
 
 /obj/item/proc/get_loc_turf()
 	var/atom/L = loc

--- a/code/game/objects/items/toys/weapons.dm
+++ b/code/game/objects/items/toys/weapons.dm
@@ -115,7 +115,7 @@
 
 /obj/item/twohanded/dualsaber/toy/IsReflect()
 	if(HAS_TRAIT(src, TRAIT_WIELDED))
-		return REFLECT_NORMAL
+		return REFLECT_TOY
 
 /obj/item/twohanded/dualsaber/toy/add_parry_component()
 	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.25, _parryable_attack_types = UNARMED_ATTACK, _parry_cooldown = (1 / 3) SECONDS, _requires_two_hands = TRUE) // 0.3333 seconds of cooldown for 75% uptime

--- a/code/game/objects/items/toys/weapons.dm
+++ b/code/game/objects/items/toys/weapons.dm
@@ -113,6 +113,13 @@
 /obj/item/twohanded/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = ITEM_ATTACK)
 	return HIT_RESULT_FAILED
 
+/obj/item/twohanded/dualsaber/toy/IsReflect()
+	if(HAS_TRAIT(src, TRAIT_WIELDED))
+		return REFLECT_NORMAL
+
+/obj/item/twohanded/dualsaber/toy/add_parry_component()
+	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.25, _parryable_attack_types = UNARMED_ATTACK, _parry_cooldown = (1 / 3) SECONDS, _requires_two_hands = TRUE) // 0.3333 seconds of cooldown for 75% uptime
+
 /obj/item/toy/katana
 	name = "replica katana"
 	desc = "Неоправданно слабая в настольных играх."

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -342,7 +342,7 @@
 
 /obj/item/twohanded/dualsaber/IsReflect()
 	if(HAS_TRAIT(src, TRAIT_WIELDED))
-		return TRUE
+		return REFLECT_NORMAL
 
 /obj/item/twohanded/dualsaber/update_icon_state()
 	if(HAS_TRAIT(src, TRAIT_WIELDED))

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -384,7 +384,7 @@
 		playsound(turf, 'sound/weapons/effects/batreflect1.ogg', 50, TRUE)
 	if(picksound == 2)
 		playsound(turf, 'sound/weapons/effects/batreflect2.ogg', 50, TRUE)
-	return 1
+	return REFLECT_NORMAL
 
 /obj/item/melee/baseball_bat/homerun/central_command
 	name = "тактическая бита Флота \"Нанотрейзен\""

--- a/code/modules/clothing/reflector.dm
+++ b/code/modules/clothing/reflector.dm
@@ -32,9 +32,9 @@
 
 /obj/item/clothing/gloves/reflector/IsReflect(def_zone)
 	if(!(def_zone in reflect_zones))
-		return FALSE
-	if(prob(hit_reflect_chance))
-		return TRUE
+		return REFLECT_NOTHING
+
+	return prob(hit_reflect_chance)
 
 /obj/item/clothing/head/helmet/reflector
 	name = "reflector hat"
@@ -77,9 +77,9 @@
 
 /obj/item/clothing/head/helmet/reflector/IsReflect(def_zone)
 	if(!(def_zone in reflect_zones))
-		return FALSE
-	if(prob(hit_reflect_chance))
-		return TRUE
+		return REFLECT_NOTHING
+
+	return prob(hit_reflect_chance)
 
 /obj/item/clothing/shoes/reflector
 	name = "reflector boots"
@@ -116,9 +116,9 @@
 
 /obj/item/clothing/shoes/reflector/IsReflect(def_zone)
 	if(!(def_zone in reflect_zones))
-		return FALSE
-	if(prob(hit_reflect_chance))
-		return TRUE
+		return REFLECT_NOTHING
+
+	return prob(hit_reflect_chance)
 
 /obj/item/clothing/suit/armor/reflector
 	name = "reflector coat"
@@ -158,9 +158,6 @@
 
 /obj/item/clothing/suit/armor/reflector/IsReflect(def_zone)
 	if(!(def_zone in reflect_zones))
-		return FALSE
+		return REFLECT_NOTHING
 
-	if(prob(hit_reflect_chance))
-		return TRUE
-
-	return FALSE
+	return prob(hit_reflect_chance)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -353,8 +353,7 @@
 	AddElement(/datum/element/high_value_item)
 
 /obj/item/clothing/suit/armor/laserproof/IsReflect()
-	if(prob(hit_reflect_chance))
-		return 1
+	return prob(hit_reflect_chance)
 
 /obj/item/clothing/suit/armor/vest/det_suit
 	desc = "An armored vest with a detective's badge on it."

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -17,9 +17,9 @@ emp_act
 		var/reflected = FALSE
 
 		switch(can_reflect)
-			if(1) // proper reflection
+			if(REFLECT_NORMAL)
 				reflected = TRUE
-			if(2) //If target is holding a toy sword
+			if(REFLECT_TOY) //If target is holding a toy sword
 				var/static/list/safe_list = list(/obj/projectile/beam/lasertag, /obj/projectile/beam/practice)
 				reflected = is_type_in_list(P, safe_list) //And it's safe
 


### PR DESCRIPTION

## Что этот ПР делает

Переписывает код IsReflect(), чтобы читался нормально.
Меняет парирование и отражение игрушечной даблы на игрушечные действия.

## Почему это хорошо для игры

~~Вопрос хороший.~~ У игроков не будет бюджетной даблы.

## Список изменений
:cl:
tweak: Поменял парирования у игрушечного меча, теперь отражает только безоружные удары.
bugfix: Игрушечная дабла работает только на игрушках.
refactor: Переписал код отражения, чтобы он выглядел важней и имел меньше шанс быть удалёным.
/:cl:
