### PR TITLE
tweak: wet_stacks slip

### DIFF
--- a/code/datums/status_effects/wet_stacks.dm
+++ b/code/datums/status_effects/wet_stacks.dm
@@ -26,7 +26,6 @@
 
 /datum/status_effect/stacking/wet/proc/WetMob()
 	if(!HAS_TRAIT(owner, TRAIT_WET_IMMUNITY) && stacks > 0)
-		owner.AddComponent(/datum/component/slippery, SLIPPERY_TIME_WATER)
 		update_wet()
 		SEND_SIGNAL(owner, COMSIG_LIVING_WET)
 		return TRUE


### PR DESCRIPTION
## Что этот ПР делает
Убирает поскальные об мокрых мобов.

## Почему это хорошо для игры

<details><summary>Жаль мало кто поймет, почему это так смешно и необычно</summary>
<p>

https://github.com/user-attachments/assets/285b6cda-356f-487d-9a42-f12ea9fd2c39

</p>
</details>

## Список изменений
:cl:
tweak: Убрано поскальзывание об мокрых мобов
/:cl:
