### PR TITLE
Бармен теперь различает вино от льда

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -468,6 +468,7 @@
 	is_drink = TRUE
 	base_skill = /datum/skill/service/drink_mixing
 	dispence_skill_name = DRINKS_DISPENSE_RAND_SIZE
+	dispence_random_prob_name = DRINKS_DISPENSE_RAND_REAGENT_PROB
 
 /obj/machinery/chem_dispenser/beer/get_ru_names()
 	return alist(

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -344,7 +344,7 @@
 		return
 
 	hackedcheck = !hackedcheck
-	balloon_alert(user, "защитные протоколы [hackedcheck ? "активированы" : "дезактивированы"]")
+	balloon_alert(user, "защитные протоколы [hackedcheck ? "дезактивированы" : "активированы"]")
 	update_reagents(UPDATE_TYPE_HACK)
 	SStgui.update_uis(src)
 


### PR DESCRIPTION

## Что этот ПР делает

Меняет какой сигнал отправляется, при заливании реагентов.
Текст при взломе делает нормальней.

## Почему это хорошо для игры

Выглядело как баг.

## Список изменений
:cl:
bugfix: Раздатчик бармена не требует навыка химии.
bugfix: Раздатчики теперь правильно говорят, есть ли защита или нет.
/:cl:
