### PR TITLE
bugfix: Thunderdome timer 

### DIFF
--- a/code/modules/mini_games/thunderdome/brawlers/mob_spawns.dm
+++ b/code/modules/mini_games/thunderdome/brawlers/mob_spawns.dm
@@ -40,10 +40,13 @@
 
 /obj/effect/mob_spawn/human/thunderdome/create(mob/dead/observer/plr, flavour, name, prefs, _mob_name, _mob_gender, _mob_species)
 	var/death_time_before = plr.persistent_client.time_of_death
+	var/datum/mini_game/thunderdome_battle/battle = thunderdome
 	var/mob/living/created = ..()
-	thunderdome.fighters += created
+	if(!created || !battle)
+		return
+	battle.fighters += created
 	created.ignore_slowdown(THUNDERDOME_TRAIT)
-	created.AddComponent(/datum/component/thunderdome_death_signaler, thunderdome)
+	created.AddComponent(/datum/component/thunderdome_death_signaler, battle)
 	created.AddComponent(/datum/component/death_timer_reset, death_time_before)
 
 /obj/effect/mob_spawn/human/thunderdome/cqc

--- a/code/modules/mini_games/thunderdome/thunderdome_battle.dm
+++ b/code/modules/mini_games/thunderdome/thunderdome_battle.dm
@@ -201,9 +201,6 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/centcom/tdome/new_arena/cqc))
 	if(dead_fighter in fighters)
 		fighters -= dead_fighter
 
-	if(dead_fighter.ckey)
-		addtimer(CALLBACK(src, PROC_REF(restore_ghost_state), dead_fighter.ckey), 5 SECONDS)
-
 	if(length(fighters) <= 1 && !is_cleansing_going)
 		for(var/datum/timedevent/timer in _active_timers)
 			qdel(timer)
@@ -212,6 +209,9 @@ GLOBAL_VAR_INIT(tdome_arena_melee, locate(/area/centcom/tdome/new_arena/cqc))
 		//Also avoiding all issues with death handling of thunderdome participants by letting fighters' components do their stuff.
 		if(last_poller)
 			last_poller.visible_message(span_danger("Thunderdome has ended with death of all participants! Cleansing in 5 seconds..."))
+
+	if(dead_fighter.ckey)
+		addtimer(CALLBACK(src, PROC_REF(restore_ghost_state), dead_fighter.ckey), 5 SECONDS)
 	return
 
 /**


### PR DESCRIPTION
## Что этот ПР делает
Фикс тандердома. Теперь он корректно очищается после смерти последнего гладиатора. ~~Наверное.~~

## Почему это хорошо для игры
Я устал ждать по 5 минут, пока тандер очистится.

## Список изменений

:cl:
bugfix: Фикс очистки тандердома
/:cl:
