### PR TITLE
Пачка фиксов для reagent_containers

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -237,16 +237,15 @@ LIGHTERS ARE IN LIGHTERS.DM
 	if(!lit)
 		return
 
-	if(!ru_names)
-		ru_names = get_ru_names_cached()
+	var/alist/real_ru_names = get_ru_names_cached()
 
 	ru_names = alist(
-		NOMINATIVE = "[lit ? "прикуренная " : ""]" + ru_names[NOMINATIVE],
-		GENITIVE = "[lit ? "прикуренной " : ""]" + ru_names[GENITIVE],
-		DATIVE = "[lit ? "прикуренной " : ""]" + ru_names[DATIVE],
-		ACCUSATIVE = "[lit ? "прикуренную " : ""]" + ru_names[ACCUSATIVE],
-		INSTRUMENTAL = "[lit ? "прикуренной " : ""]" + ru_names[INSTRUMENTAL],
-		PREPOSITIONAL = "[lit ? "прикуренной " : ""]" + ru_names[PREPOSITIONAL],
+		NOMINATIVE = "[lit ? "прикуренная " : ""]" + real_ru_names[NOMINATIVE],
+		GENITIVE = "[lit ? "прикуренной " : ""]" + real_ru_names[GENITIVE],
+		DATIVE = "[lit ? "прикуренной " : ""]" + real_ru_names[DATIVE],
+		ACCUSATIVE = "[lit ? "прикуренную " : ""]" + real_ru_names[ACCUSATIVE],
+		INSTRUMENTAL = "[lit ? "прикуренной " : ""]" + real_ru_names[INSTRUMENTAL],
+		PREPOSITIONAL = "[lit ? "прикуренной " : ""]" + real_ru_names[PREPOSITIONAL],
 	)
 
 /obj/item/clothing/mask/cigarette/get_temperature()

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -152,7 +152,6 @@
 	icon_state = "misterjani"
 	item_state = "misterjani"
 	amount_per_transfer_from_this = 5
-	has_variable_transfer_amount = FALSE
 
 /obj/item/watertank/janitor/make_noz()
 	return new /obj/item/reagent_containers/spray/mister/janitor(src)

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -152,7 +152,7 @@
 	icon_state = "misterjani"
 	item_state = "misterjani"
 	amount_per_transfer_from_this = 5
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 
 /obj/item/watertank/janitor/make_noz()
 	return new /obj/item/reagent_containers/spray/mister/janitor(src)

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -1,5 +1,5 @@
 /obj/item/reagent_containers/food
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	volume = 50 //Sets the default container amount for all food items.
 	visible_transfer_rate = FALSE
 	righthand_file = 'icons/mob/inhands/foods_righthand.dmi'

--- a/code/modules/hydroponics/beekeeping/honeycomb.dm
+++ b/code/modules/hydroponics/beekeeping/honeycomb.dm
@@ -4,7 +4,7 @@
 	desc = "A hexagonal mesh of honeycomb."
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "honeycomb"
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	visible_transfer_rate = FALSE
 	disease_amount = 0
 	volume = 10

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -7,6 +7,8 @@
 	w_class = WEIGHT_CLASS_TINY
 	var/amount_per_transfer_from_this = 5
 	var/visible_transfer_rate = TRUE
+	/// Does this container allow changing transfer amounts at all, the container can still have only one possible transfer value in `possible_transfer_amounts` at some point even if this is true
+	var/has_variable_transfer_amount = TRUE
 	/// The different possible amounts of reagent to transfer out of the container
 	var/list/possible_transfer_amounts = list(5,10,15,20,25,30)
 	/// The maximum amount of reagents this container can hold
@@ -72,8 +74,11 @@
 
 /obj/item/reagent_containers/examine()
 	. = ..()
-	if(possible_transfer_amounts.len)
-		. += span_notice("Объём перемещения содержимого — [amount_per_transfer_from_this] единиц[declension_ru(amount_per_transfer_from_this, "а", "ы", "")]. Используйте [EXAMINE_HINT("ЛКМ")] или [EXAMINE_HINT("ПКМ")] для изменения.")
+	if(has_variable_transfer_amount)
+		if(possible_transfer_amounts.len)
+			. += span_notice("Объём перемещения содержимого — [amount_per_transfer_from_this] единиц[declension_ru(amount_per_transfer_from_this, "а", "ы", "")]. Используйте [EXAMINE_HINT("ЛКМ")] или [EXAMINE_HINT("ПКМ")] для изменения.")
+		else if(possible_transfer_amounts.len)
+			. += span_notice("Объём перемещения содержимого — [amount_per_transfer_from_this] единиц[declension_ru(amount_per_transfer_from_this, "а", "ы", "")].")
 
 /obj/item/reagent_containers/attack(mob/living/target, mob/living/user, params, def_zone, skip_attack_anim = FALSE)
 	if(user.a_intent != INTENT_HARM)
@@ -85,10 +90,13 @@
 		reagents.add_reagent_list(list_reagents)
 
 /obj/item/reagent_containers/attack_self(mob/user)
-	change_transfer_amount(user, FORWARD)
+	if(has_variable_transfer_amount)
+		change_transfer_amount(user, FORWARD)
+		return TRUE
 
 /obj/item/reagent_containers/attack_self_secondary(mob/user)
-	change_transfer_amount(user, BACKWARD)
+	if(has_variable_transfer_amount)
+		change_transfer_amount(user, BACKWARD)
 
 /obj/item/reagent_containers/proc/mode_change_message(mob/user)
 	return

--- a/code/modules/reagents/reagent_containers/applicator.dm
+++ b/code/modules/reagents/reagent_containers/applicator.dm
@@ -16,7 +16,7 @@
 	item_state = "mender"
 	belt_icon = "mender"
 	volume = 200
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	visible_transfer_rate = FALSE
 	resistance_flags = ACID_PROOF
 	container_type = REFILLABLE | AMOUNT_VISIBLE

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/hypo.dmi'
 	item_state = "hypo"
 	icon_state = "borghypo"
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	can_empty = FALSE
 	var/mode = 1
 	var/charge_cost = 50

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -35,9 +35,11 @@
 	if(isnull(held_item) || held_item == src)
 		if(can_lid)
 			context[SCREENTIP_CONTEXT_ALT_LMB] = "[has_lid ? "Снять" : "Надеть"] крышку"
-		context[SCREENTIP_CONTEXT_LMB] = "Перемещать больше"
-		context[SCREENTIP_CONTEXT_RMB] = "Перемещать меньше"
-		return CONTEXTUAL_SCREENTIP_SET
+			. = CONTEXTUAL_SCREENTIP_SET
+		if(has_variable_transfer_amount)
+			context[SCREENTIP_CONTEXT_LMB] = "Перемещать больше"
+			context[SCREENTIP_CONTEXT_RMB] = "Перемещать меньше"
+			. = CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/reagent_containers/cup/examine(mob/user)
 	. = ..()
@@ -120,6 +122,7 @@
 
 	SEND_SIGNAL(src, COMSIG_GLASS_DRANK, target, user)
 	var/fraction = min(gulp_size/reagents.total_volume, 1)
+	reagents.reaction(target, REAGENT_INGEST, fraction)
 	reagents.trans_to(target, gulp_size)
 	checkLiked(fraction, target)
 	playsound(target.loc,'sound/items/drink.ogg', rand(10,50), TRUE)
@@ -376,7 +379,7 @@ GAME_VERB_SRC(/obj/item/reagent_containers/cup/beaker, remove_assembly, usr, "О
 	name = "baggie"
 	desc = "Небольшой пластиковый пакет, часто используемый фармацевтическими \"предпринимателями\"."
 	amount_per_transfer_from_this = 2
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 
 /obj/item/reagent_containers/cup/beaker/plastic_baggie/drugs/get_ru_names()
 	return alist(
@@ -392,7 +395,7 @@ GAME_VERB_SRC(/obj/item/reagent_containers/cup/beaker, remove_assembly, usr, "О
 	name = "Thermite load"
 	desc = "Пластиковый пакетик, надпись на этикетке – \"Термит\"."
 	amount_per_transfer_from_this = 25
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	list_reagents = list("thermite" = 25)
 
 /obj/item/reagent_containers/cup/beaker/plastic_baggie/thermite/get_ru_names()
@@ -649,7 +652,7 @@ GAME_VERB_SRC(/obj/item/reagent_containers/cup/beaker, remove_assembly, usr, "О
 	materials = list(MAT_METAL = 100, MAT_GLASS = 100)
 	w_class = WEIGHT_CLASS_NORMAL
 	amount_per_transfer_from_this = 15
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	volume = 15
 	resistance_flags = FLAMMABLE
 	color = "#0085E5"

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -52,14 +52,14 @@
 	extinguish()
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/update_icon_state()
-	if(reagents.reagent_list.len)
+	if(length(reagents.reagent_list))
 		var/datum/reagent/check = reagents.get_master_reagent()
 		if(check.drink_icon)
 			icon_state = check.drink_icon
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/update_overlays()
 	. = ..()
-	if(reagents.reagent_list.len)
+	if(length(reagents.reagent_list))
 		var/datum/reagent/check = reagents.get_master_reagent()
 		if(!check.drink_icon)
 			var/mutable_appearance/glass_overlay = mutable_appearance(icon, "glassoverlay")
@@ -70,7 +70,7 @@
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/update_name(updates)
 	. = ..()
-	if(reagents.reagent_list.len)
+	if(length(reagents.reagent_list))
 		var/datum/reagent/check = reagents.get_master_reagent()
 		name = check.drink_name
 	else
@@ -78,7 +78,7 @@
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/update_desc(updates)
 	. = ..()
-	if(reagents.reagent_list.len)
+	if(length(reagents.reagent_list))
 		var/datum/reagent/check = reagents.get_master_reagent()
 		desc = check.drink_desc
 	else

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -1,5 +1,3 @@
-
-
 /obj/item/reagent_containers/cup/glass/drinkingglass
 	name = "glass"
 	desc = "Стеклянный стакан, из таких обычно пьют. Постарайтесь не разбить его."
@@ -54,14 +52,14 @@
 	extinguish()
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/update_icon_state()
-	if(length(reagents.reagent_list))
+	if(reagents.reagent_list.len)
 		var/datum/reagent/check = reagents.get_master_reagent()
 		if(check.drink_icon)
 			icon_state = check.drink_icon
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/update_overlays()
 	. = ..()
-	if(length(reagents.reagent_list))
+	if(reagents.reagent_list.len)
 		var/datum/reagent/check = reagents.get_master_reagent()
 		if(!check.drink_icon)
 			var/mutable_appearance/glass_overlay = mutable_appearance(icon, "glassoverlay")
@@ -72,7 +70,7 @@
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/update_name(updates)
 	. = ..()
-	if(length(reagents.reagent_list))
+	if(reagents.reagent_list.len)
 		var/datum/reagent/check = reagents.get_master_reagent()
 		name = check.drink_name
 	else
@@ -80,14 +78,11 @@
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/update_desc(updates)
 	. = ..()
-	if(length(reagents.reagent_list))
+	if(reagents.reagent_list.len)
 		var/datum/reagent/check = reagents.get_master_reagent()
 		desc = check.drink_desc
 	else
 		desc = initial(desc)
-
-/obj/item/reagent_containers/cup/glass/drinkingglass/on_reagent_change()
-	update_appearance()
 
 // for /obj/machinery/vending/sovietsoda
 /obj/item/reagent_containers/cup/glass/drinkingglass/soda

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -37,7 +37,7 @@
 	force = 1
 	throwforce = 1
 	materials = list(MAT_METAL=100)
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	volume = 5
 	flags = CONDUCT
 	resistance_flags = FIRE_PROOF
@@ -166,7 +166,7 @@
 	desc = "A paper water cup."
 	icon_state = "water_cup_e"
 	item_state = "coffee"
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	volume = 10
 	isGlass = FALSE
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -203,7 +203,7 @@
 	name = "combat stimulant injector"
 	desc = "Модифицированный автоинъектор с воздушной иглой, используемый оперативниками поддержки для быстрого заживления ран в бою."
 	amount_per_transfer_from_this = 15
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	icon_state = "combat_hypo"
 	volume = 90
 	ignore_flags = 1 // So they can heal their comrades.
@@ -363,7 +363,7 @@
 	item_state = "autoinjector"
 	belt_icon = "autoinjector"
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	volume = 10
 	ignore_flags = TRUE //so you can medipen through hardsuits
 	container_type = DRAWABLE

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -3,7 +3,7 @@
 	desc = "Химический пластырь, предназначенный для медленного ввода веществ в кровоток пациента через контакт с кожей."
 	icon_state = "bandaid"
 	item_state = "bandaid"
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	volume = 20
 	container_type = 0 //nooo my insta-kill patch!!!
 	apply_type = REAGENT_TOUCH

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -3,7 +3,6 @@
 	desc = "Химический пластырь, предназначенный для медленного ввода веществ в кровоток пациента через контакт с кожей."
 	icon_state = "bandaid"
 	item_state = "bandaid"
-	has_variable_transfer_amount = FALSE
 	volume = 20
 	container_type = 0 //nooo my insta-kill patch!!!
 	apply_type = REAGENT_TOUCH

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -7,7 +7,6 @@
 	gender = FEMALE
 	icon_state = "pill"
 	item_state = "pill"
-	has_variable_transfer_amount = FALSE
 	volume = 100
 	consume_sound = null
 	can_taste = FALSE

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -7,7 +7,7 @@
 	gender = FEMALE
 	icon_state = "pill"
 	item_state = "pill"
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	volume = 100
 	consume_sound = null
 	can_taste = FALSE

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -16,7 +16,7 @@
 	/// max spray distance mod
 	var/spray_maxrange_mod = 1
 	volume = 250
-	possible_transfer_amounts = null
+	has_variable_transfer_amount = FALSE
 	var/delay = CLICK_CD_RANGE * 2
 	var/spray_maxrange = 3 //what the sprayer will set spray_currentrange to in the attack_self.
 	var/spray_currentrange = 3 //the range of tiles the sprayer will reach when in fixed mode.


### PR DESCRIPTION

## Что этот ПР делает
<img width="569" height="55" alt="изображение" src="https://github.com/user-attachments/assets/1cfc7d50-f922-40cf-9d59-530bd848595b" />
<img width="604" height="77" alt="изображение" src="https://github.com/user-attachments/assets/2742725a-e608-4ad0-a5c8-c06a96a490fb" />
<img width="565" height="76" alt="изображение" src="https://github.com/user-attachments/assets/7cbe3e54-3875-4ecc-b87d-0f3c06e83aeb" />



## Список изменений
:cl:
bugfix: Починена передача вирусов через питьё из ёмкости.
bugfix: Починен осмотр ёмкостей с неизменяемым объёмом перемещения содержимого.
bugfix: Исправлены рантаймы стаканов (вроде бы?).
/:cl:
